### PR TITLE
locale for floating point numbers

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -63,22 +63,15 @@ std::string valueToString(UInt value) {
 #endif // # if defined(JSON_HAS_INT64)
 
 std::string valueToString(double value) {
-  // Allocate a buffer that is more than large enough to store the 16 digits of
-  // precision requested below.
-  char buffer[32];
-
-// Print into the buffer. We need not request the alternative representation
-// that always has a decimal point because JSON doesn't distingish the
-// concepts of reals and integers.
-#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__) // Use secure version with
-                                                      // visual studio 2005 to
-                                                      // avoid warning.
-  sprintf_s(buffer, sizeof(buffer), "%.16g", value);
-#else
-  snprintf(buffer, sizeof(buffer), "%.16g", value);
-#endif
-
-  return buffer;
+  // We need not request the alternative representation
+  // that always has a decimal point because JSON doesn't distingish the
+  // concepts of reals and integers.
+  std::stringstream str;
+  // Set locale to "C" to always get a '.' instead of a ','
+  str.imbue(std::locale::classic());
+  str.precision(16);
+  str << value;
+  return str.str();
 }
 
 std::string valueToString(bool value) { return value ? "true" : "false"; }


### PR DESCRIPTION
(Continuation of https://github.com/jacobsa/jsoncpp/pull/2, rebased against current master)

> Hmm. I'm not sure this was a good change. snprintf is more efficient. You can set the locale for snprintf too:
> 
> ```
> http://stackoverflow.com/questions/3457968/snprintf-simple-way-to-force-as-radix
> ```
> 
> Was this a problem only on Windows?

It think the problem will be there both under Linux and Windows (I was using Linux).

The problem is that setlocale() will replace the locale globally (which means it is a bad idea to call it from a library) and uselocale() is POSIX-specific.

> I think you had 2 problems. First, you might have had issues with your tool-chain. If you set LC_ALL in your makefile and export it, then it becomes the default. From your code, I am not sure how you were injecting it. I would need to see your makefile.

I wasn't setting the locale during compilation but when executing the binary.

> Second, and more important, you need to run set locale(LC_NUMERIC, val) after you set the global locale.
> 
> Here is my makefile and example, which works as expected:
> 
> ```
> https://gist.github.com/cdunn2001/61bc4a05ce906492defd
> ```
> 
> So I would like to revert your change. Is that ok?

Resetting the LC_NUMERIC locale to "C" will work, but that means that either the library has to do it (which IMHO is a bad idea when doing it globally) or the program has to do it. I think that requiring the program to change the locale is not a good idea either; many developers will never notice the problem when they are using a US locale for development.

Another possibility to fix the problem would be to replace the ',' by a '.' after calling snprintf(), AFAIK there are no locales which use something other than '.' or ','. Doing this feels weird, but probably will work and has almost the same performance as just calling snprintf().
