### PR TITLE
Patch for bug #53 on version 0.5.0

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <sstream>
 #include <iomanip>
+#include <math.h>
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0
 // Disable warning about strdup being deprecated.
@@ -79,7 +80,29 @@ std::string valueToString(double value) {
   sprintf_s(buffer, sizeof(buffer), "%.16g", value);
   #endif
 #else
-  snprintf(buffer, sizeof(buffer), "%.16g", value);
+  if ( isfinite( value ))
+  {
+     snprintf(buffer, sizeof(buffer), "%.16g", value);
+  }
+  else
+  {
+     // IEEE standard states that NaN values will not compare to themselves
+     if ( value != value)
+     {
+        snprintf(buffer, sizeof(buffer), "null"); 
+     }
+     else if ( value < 0)
+     {
+        snprintf(buffer, sizeof(buffer), "-1e+9999"); 
+     }
+     else
+     {
+        snprintf(buffer, sizeof(buffer), "1e+9999"); 
+     }
+     // nothing more to do, return.
+     return buffer;
+  }
+
 #endif
   fixNumericLocale(buffer, buffer + strlen(buffer));
   return buffer;


### PR DESCRIPTION
This is a patch that we have utilized at IDEXX Labs for the the bug described above.
We have tested and verified this on x86 32 and 64 bit linux and 32 bit arm.

also a c++ program to verify the fix:
# include "json/value.h"
# include "json/reader.h"
# include "json/writer.h"
# include <stdio.h>
# include <fstream>
# include <string.h>
# include <cstdlib>
# include <limits>

using namespace std;
const char\* FILENAME =  "test.json";

int main()
{
    Json::Value root;
    Json::Value data;

```
data["myval1"] = 0.0/0.0;
data["myval2"] = 0.1/0.0;
data["myval3"] = -0.1/0.0;
root["TEST_INF_NAN"] = data;

ofstream outstream(FILENAME, ofstream::binary );
outstream.write(root.toStyledString().c_str(), root.toStyledString().size());
outstream.close();
Json::StyledWriter writer;

Json::Value valueFromFile;
Json::Reader reader;

ifstream instream( FILENAME , ifstream::binary );
if (!reader.parse( instream, valueFromFile, false ))
{
    printf("FAIL.\n");
    return 1;
}

Json::Value child = valueFromFile.get( "TEST_INF_NAN", Json::Value() ); 


if ( !child["myval1"].isNull() )    
{
printf("FAIL.\n");
    return 1;
}

if ( !child["myval2"].asDouble() == std::numeric_limits<double>::infinity() )
{
    printf("FAIL.\n");
    return 1;
}

if ( !child["myval3"].asDouble() == ( std::numeric_limits<double>::infinity() * -1 ) )
{
    printf("FAIL.\n");
    return 1;
}

char buff[24];
sprintf(buff, "rm %s", FILENAME); 
system(buff);
printf("PASS.\n");
return 0;
```

}
