### PR TITLE
Fix CMake subproject behaviour.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ macro(UseCompilationWarningAsError)
 endmacro() 
 
 # Include our configuration header
-INCLUDE_DIRECTORIES( ${CMAKE_SOURCE_DIR}/include )
+INCLUDE_DIRECTORIES( ${jsoncpp_SOURCE_DIR}/include )
 
 if ( MSVC )
     # Only enabled in debug because some old versions of VS STL generate


### PR DESCRIPTION
If you add jsoncpp to another project with CMake, as a subproject, than ${CMAKE_SOURCE_DIR}/include will be a root project include directory:

```
project_a/
  CMakeLists.txt  # Contains: add_subdirectory(jsoncpp)
  include/  # <- ${CMAKE_SOURCE_DIR}/include
  jsoncpp/
    CMakeLists.txt
    include/  # <- ${jsoncpp_SOURCE_DIR}/include
```
