### PR TITLE
Fixed deprecated target file path location

### DIFF
--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -12,11 +12,10 @@ SET_TARGET_PROPERTIES(jsontestrunner_exe PROPERTIES OUTPUT_NAME jsontestrunner_e
 
 IF(PYTHONINTERP_FOUND)
     # Run end to end parser/writer tests
-    GET_PROPERTY(JSONTESTRUNNER_EXE_PATH TARGET jsontestrunner_exe PROPERTY LOCATION)
     SET(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../test)
     SET(RUNJSONTESTS_PATH ${TEST_DIR}/runjsontests.py)
     ADD_CUSTOM_TARGET(jsoncpp_readerwriter_tests ALL
-                      "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" "${JSONTESTRUNNER_EXE_PATH}" "${TEST_DIR}/data"
+                      "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" $<TARGET_FILE:jsontestrunner_exe> "${TEST_DIR}/data"
                       DEPENDS jsontestrunner_exe jsoncpp_test
                       )
     ADD_CUSTOM_TARGET(jsoncpp_check DEPENDS jsoncpp_readerwriter_tests)

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -15,8 +15,8 @@ TARGET_LINK_LIBRARIES(jsoncpp_test jsoncpp_lib)
 # (default cmake workflow hides away the test result into a file, resulting in poor dev workflow?!?)
 IF(JSONCPP_WITH_POST_BUILD_UNITTEST)
     ADD_CUSTOM_COMMAND( TARGET jsoncpp_test
-				        POST_BUILD
-				        COMMAND jsoncpp_test)
+                        POST_BUILD
+                        COMMAND $<TARGET_FILE:jsoncpp_test>)
 ENDIF(JSONCPP_WITH_POST_BUILD_UNITTEST)
 
 SET_TARGET_PROPERTIES(jsoncpp_test PROPERTIES OUTPUT_NAME jsoncpp_test) 


### PR DESCRIPTION
- Fixed jsoncpp_test invocation path, because it doesn't work the original way on Cygwin as well as on any other Linux I believe (fails to find the jsoncpp_test utility from the source directory).
- FIxed jsoncpprunner_exe invocaton path just to get rid of the warning and make it a bit more clear.
