### PR TITLE
cast override suggestion

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -273,6 +273,16 @@ Json::Value obj_value(Json::objectValue); // {}
   double asDouble() const;
   bool asBool() const;
 
+  operator const char*() const;
+  operator std::string() const;
+  operator Int() const;
+  operator UInt() const;
+  operator Int64() const;
+  operator UInt64() const;
+  operator float() const;
+  operator double() const;
+  operator bool() const;
+
   bool isNull() const;
   bool isBool() const;
   bool isInt() const;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -795,6 +795,42 @@ bool Value::asBool() const {
   JSON_FAIL_MESSAGE("Value is not convertible to bool.");
 }
 
+Value::operator const char*() const {
+  return Value::asCString();
+}
+
+Value::operator std::string() const {
+  return Value::asString();
+}
+
+Value::operator Int() const {
+  return Value::asInt();
+}
+
+Value::operator UInt() const {
+  return Value::asUInt();
+}
+
+Value::operator Int64() const {
+  return Value::asInt64();
+}
+
+Value::operator UInt64() const {
+  return Value::asUInt64();
+}
+
+Value::operator float() const {
+  return Value::asFloat();
+}
+
+Value::operator double() const {
+  return Value::asDouble();
+}
+
+Value::operator bool() const {
+  return Value::asBool();
+}
+
 bool Value::isConvertibleTo(ValueType other) const {
   switch (other) {
   case nullValue:


### PR DESCRIPTION
Hi, guys!

Nice project!

I'm just curious, can't we override the type casts so that we don't have to specify `Json::Value::as*()`?

For example, with your current version, we have to specify the type of the values like:

``` cpp
Json::Value json;
int var1 = json["IntParam"].asInt();
std::string var2 = json["StrParam"].asString();
```

However, by applying this pull request, we can do something like:

``` cpp
Json::Value json;
int var1 = json["IntParam"];
std::string var2 = json["StrParam"];
```

_without_ specifying the type, and leave it to the compiler to figure it out from the context.

You may have discussed this prior to transferring to GitHub, but I'd really like to know why you're adapting explicit type specifications without using the features of C++.

Thanks in advance :)
