### PR TITLE
added option to FastWriter which omits the trailing new line character

### DIFF
--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -54,6 +54,8 @@ public:
    */
   void dropNullPlaceholders();
 
+  void omitEndingLineFeed();
+
 public: // overridden from Writer
   virtual std::string write(const Value &root);
 
@@ -63,6 +65,7 @@ private:
   std::string document_;
   bool yamlCompatiblityEnabled_;
   bool dropNullPlaceholders_;
+  bool omitEndingLineFeed_;
 };
 
 /** \brief Writes a Value in <a HREF="http://www.json.org">JSON</a> format in a

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -180,16 +180,19 @@ Writer::~Writer() {}
 // //////////////////////////////////////////////////////////////////
 
 FastWriter::FastWriter()
-    : yamlCompatiblityEnabled_(false), dropNullPlaceholders_(false) {}
+    : yamlCompatiblityEnabled_(false), dropNullPlaceholders_(false), omitEndingLineFeed_(false) {}
 
 void FastWriter::enableYAMLCompatibility() { yamlCompatiblityEnabled_ = true; }
 
 void FastWriter::dropNullPlaceholders() { dropNullPlaceholders_ = true; }
 
+void FastWriter::omitEndingLineFeed() { omitEndingLineFeed_ = true; }
+
 std::string FastWriter::write(const Value &root) {
   document_ = "";
   writeValue(root);
-  document_ += "\n";
+  if (!omitEndingLineFeed_)
+    document_ += "\n";
   return document_;
 }
 


### PR DESCRIPTION
I want the FastWriter to optionally write a json string without the final new line. This update adds this functionality.
