### PR TITLE
Switch to copy-and-swap idiom for operator=.

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -171,7 +171,7 @@ private:
     CZString(const char *cstr, DuplicationPolicy allocate);
     CZString(const CZString &other);
     ~CZString();
-    CZString &operator=(const CZString &other);
+    CZString &operator=(CZString other);
     bool operator<(const CZString &other) const;
     bool operator==(const CZString &other) const;
     ArrayIndex index() const;
@@ -238,7 +238,7 @@ Json::Value obj_value(Json::objectValue); // {}
   Value(const Value &other);
   ~Value();
 
-  Value &operator=(const Value &other);
+  Value &operator=(Value other);
   /// Swap values.
   /// \note Currently, comments are intentionally not swapped, for
   /// both logic and efficiency.
@@ -681,7 +681,7 @@ public:
 
   ValueInternalMap();
   ValueInternalMap(const ValueInternalMap &other);
-  ValueInternalMap &operator=(const ValueInternalMap &other);
+  ValueInternalMap &operator=(ValueInternalMap other);
   ~ValueInternalMap();
 
   void swap(ValueInternalMap &other);
@@ -775,7 +775,7 @@ public:
 
   ValueInternalArray();
   ValueInternalArray(const ValueInternalArray &other);
-  ValueInternalArray &operator=(const ValueInternalArray &other);
+  ValueInternalArray &operator=(ValueInternalArray other);
   ~ValueInternalArray();
   void swap(ValueInternalArray &other);
 

--- a/src/lib_json/json_internalarray.inl
+++ b/src/lib_json/json_internalarray.inl
@@ -280,10 +280,9 @@ ValueInternalArray::ValueInternalArray( const ValueInternalArray &other )
 
 
 ValueInternalArray &
-ValueInternalArray::operator =( const ValueInternalArray &other )
+ValueInternalArray::operator=(ValueInternalArray other)
 {
-   ValueInternalArray temp( other );
-   swap( temp );
+   swap(other);
    return *this;
 }
 

--- a/src/lib_json/json_internalmap.inl
+++ b/src/lib_json/json_internalmap.inl
@@ -196,10 +196,9 @@ ValueInternalMap::ValueInternalMap( const ValueInternalMap &other )
 
 
 ValueInternalMap &
-ValueInternalMap::operator =( const ValueInternalMap &other )
+ValueInternalMap::operator=(ValueInternalMap other)
 {
-   ValueInternalMap dummy( other );
-   swap( dummy );
+   swap(other);
    return *this;
 }
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -191,9 +191,8 @@ void Value::CZString::swap(CZString &other) {
   std::swap(index_, other.index_);
 }
 
-Value::CZString &Value::CZString::operator=(const CZString &other) {
-  CZString temp(other);
-  swap(temp);
+Value::CZString &Value::CZString::operator=(CZString other) {
+  swap(other);
   return *this;
 }
 
@@ -482,9 +481,8 @@ Value::~Value() {
     delete[] comments_;
 }
 
-Value &Value::operator=(const Value &other) {
-  Value temp(other);
-  swap(temp);
+Value &Value::operator=(Value other) {
+  swap(other);
   return *this;
 }
 


### PR DESCRIPTION
This allows the compiler to elide a copy when rhs is a temporary.
