### PR TITLE
Added arrow operator to ValueIterator and ValueConstIterator

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -1017,6 +1017,8 @@ public:
   }
 
   reference operator*() const { return deref(); }
+  
+  pointer operator->() const { return &deref(); }
 };
 
 /** \brief Iterator for object and array value.
@@ -1071,6 +1073,8 @@ public:
   }
 
   reference operator*() const { return deref(); }
+  
+  pointer operator->() const { return &deref(); }
 };
 
 } // namespace Json


### PR DESCRIPTION
When using ValueIterator or ValueConstIterator, it is necessary to dereference and use the dot operator to access the underlying value. [STL Iterators](http://www.cplusplus.com/reference/iterator/), however, also override the arrow operator to provide shorthand for this.

For example, `(*it).a` is equivalent to `it->a`.

This pull request overrides the arrow operator to provide this functionality.
