### PR TITLE
Workaround for missing C99 functions in older versions of Visual Studio

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -15,6 +15,10 @@
 #include <cstring>
 #include <istream>
 
+#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
+#define snprintf _snprintf
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0
 // Disable warning about strdup being deprecated.
 #pragma warning(disable : 4996)

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -15,6 +15,12 @@
 #include <iomanip>
 #include <math.h>
 
+#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
+#include <float.h>
+#define isfinite _finite
+#define snprintf _snprintf
+#endif
+
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0
 // Disable warning about strdup being deprecated.
 #pragma warning(disable : 4996)


### PR DESCRIPTION
MSVC 7 and 8 ar emissing the isfinite and snprintf functions but have equivalent non-standard version available as _foo
