### PR TITLE
Add public semantic error reporting

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -130,6 +130,29 @@ public:
    */
   std::vector<StructuredError> getStructuredErrors() const;
 
+  /** \brief Add a semantic error message.
+   * \param value JSON Value location associated with the error
+   * \param message The error message.
+   * \return \c true if the error was successfully added, \c false if the
+   * Value offset exceeds the document size.
+   */
+  bool pushError(const Value& value, const std::string& message);
+
+  /** \brief Add a semantic error message with extra context.
+   * \param value JSON Value location associated with the error
+   * \param message The error message.
+   * \param extra Additional JSON Value location to contextualize the error
+   * \return \c true if the error was successfully added, \c false if either
+   * Value offset exceeds the document size.
+   */
+  bool pushError(const Value& value, const std::string& message, const Value& extra);
+
+  /** \brief Return whether there are any errors.
+   * \return \c true if there are no errors to report \c false if
+   * errors have occurred.
+   */
+  bool good() const;
+
 private:
   enum TokenType {
     tokenEndOfStream = 0,

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -830,6 +830,43 @@ std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   return allErrors;
 }
 
+bool Reader::pushError(const Value& value, const std::string& message) {
+  if(value.getOffsetStart() > end_ - begin_
+    || value.getOffsetLimit() > end_ - begin_)
+    return false;
+  Token token;
+  token.type_ = tokenError;
+  token.start_ = begin_ + value.getOffsetStart();
+  token.end_ = end_ + value.getOffsetLimit();
+  ErrorInfo info;
+  info.token_ = token;
+  info.message_ = message;
+  info.extra_ = 0;
+  errors_.push_back(info);
+  return true;
+}
+
+bool Reader::pushError(const Value& value, const std::string& message, const Value& extra) {
+  if(value.getOffsetStart() > end_ - begin_
+    || value.getOffsetLimit() > end_ - begin_
+    || extra.getOffsetLimit() > end_ - begin_)
+    return false;
+  Token token;
+  token.type_ = tokenError;
+  token.start_ = begin_ + value.getOffsetStart();
+  token.end_ = begin_ + value.getOffsetLimit();
+  ErrorInfo info;
+  info.token_ = token;
+  info.message_ = message;
+  info.extra_ = begin_ + extra.getOffsetStart();
+  errors_.push_back(info);
+  return true;
+}
+
+bool Reader::good() const {
+  return !errors_.size();
+}
+
 std::istream& operator>>(std::istream& sin, Value& root) {
   Json::Reader reader;
   bool ok = reader.parse(sin, root, true);


### PR DESCRIPTION
Adds the following public member functions to allow reporting semantic errors with location information.

> bool Reader::pushError(const Value& value, std::string msg);
> bool Reader::pushError(const Value& value, std::string msg, const Value& extra);
> bool Reader::good() const;

Closes issue #57. Note that the `pushError` functions return boolean values indicating whether the error was added successfully.
