### PR TITLE
Json::Value: Refactor common code in all constructors to an initBasic() function.

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -440,6 +440,8 @@ Json::Value obj_value(Json::objectValue); // {}
   size_t getOffsetLimit() const;
 
 private:
+  void initBasic(ValueType type, bool allocated = false);
+
   Value& resolveReference(const char* key, bool isStatic);
 
 #ifdef JSON_VALUE_USE_INTERNAL_MAP


### PR DESCRIPTION
This reduces 8 lines to 2 lines in 12 places.
There shouldn't be a performance hit, as Value fields are POD.
