### PR TITLE
Add parseIterator method to Json::Reader

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -99,6 +99,12 @@ public:
   /// \see Json::operator>>(std::istream&, Json::Value&).
   bool parse(std::istream& is, Value& root, bool collectComments = true);
 
+  /// \brief Parse from iterator
+  template<typename Iterator>
+  bool parseIterator(Iterator begin, Iterator end, Value& root, bool collectComments = true) {
+    return parse(&(*begin), &(*end), root, collectComments);
+  }
+
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
    * \return Formatted error message with the list of errors with their location

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1601,6 +1601,18 @@ JSONTEST_FIXTURE(ReaderTest, parseWithDetailError) {
   JSONTEST_ASSERT(errors.at(0).message == "Bad escape sequence in string");
 }
 
+JSONTEST_FIXTURE(ReaderTest, parseIterator) {
+  Json::Reader reader;
+  Json::Value root;
+
+  std::string str = "{ \"property\": \"value\" }";
+  std::vector<char> vec(str.begin(), str.end());
+
+  bool ok = reader.parseIterator(vec.begin(), vec.end(), root);
+
+  JSONTEST_ASSERT(ok);
+}
+
 int main(int argc, const char* argv[]) {
   JsonTest::Runner runner;
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, checkNormalizeFloatingPointStr);
@@ -1630,6 +1642,7 @@ int main(int argc, const char* argv[]) {
   JSONTEST_REGISTER_FIXTURE(runner, ReaderTest, parseWithOneError);
   JSONTEST_REGISTER_FIXTURE(runner, ReaderTest, parseChineseWithOneError);
   JSONTEST_REGISTER_FIXTURE(runner, ReaderTest, parseWithDetailError);
+  JSONTEST_REGISTER_FIXTURE(runner, ReaderTest, parseIterator);
 
   JSONTEST_REGISTER_FIXTURE(runner, WriterTest, dropNullPlaceholders);
 


### PR DESCRIPTION
Because this:

    reader.parseIterator(vec.begin(), vec.end(), root);

is way more intuitive than:

    reader.parse(&(*vec.begin()), &(*vec.end()), root);