### PR TITLE
Fix compiler warning:

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -170,13 +170,17 @@ Value::CZString::CZString(const char* cstr, DuplicationPolicy allocate)
     : cstr_(allocate == duplicate ? duplicateStringValue(cstr) : cstr),
       index_(allocate) {}
 
-Value::CZString::CZString(const CZString& other)
-    : cstr_(other.index_ != noDuplication && other.cstr_ != 0
-                ? duplicateStringValue(other.cstr_)
-                : other.cstr_),
-      index_(other.cstr_
-                 ? (other.index_ == noDuplication ? noDuplication : duplicate)
-                 : other.index_) {}
+Value::CZString::CZString(const CZString& other) {
+  DuplicationPolicy policy = static_cast<DuplicationPolicy>(other.index_);
+  if (policy != noDuplication && other.cstr_ != 0)
+    cstr_ = duplicateStringValue(other.cstr_);
+  else
+      cstr_ = other.cstr_;
+  if (other.cstr_)
+    index_ = (policy == noDuplication ? noDuplication : duplicate);
+  else
+    index_ = other.index_;
+}
 
 Value::CZString::~CZString() {
   if (cstr_ && index_ == duplicate)


### PR DESCRIPTION
json_value.cpp: In copy constructor ‘Json::Value::CZString::CZString(const Json::Value::CZString&)’:
json_value.cpp:179:26: warning: enumeral and non-enumeral type in conditional expression [enabled by default]

I tested, and the patch should fix the warning.
But the following modifies have no effects.

Value::CZString::CZString(const CZString& other)
    : cstr_(static_cast<DuplicationPolicy>(other.index_) != noDuplication && other.cstr_ != 0
                ? duplicateStringValue(other.cstr_)
                : other.cstr_),
      index_(other.cstr_
                 ? (static_cast<DuplicationPolicy>(other.index_) == noDuplication ? noDuplication : duplicate)
                 : other.index_) {}
