### PR TITLE
fix gcc warning when CXXFLAGS contains '-Wextra'

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -175,7 +175,8 @@ Value::CZString::CZString(const CZString& other)
                 ? duplicateStringValue(other.cstr_)
                 : other.cstr_),
       index_(other.cstr_
-                 ? (other.index_ == noDuplication ? noDuplication : duplicate)
+                 ? static_cast<ArrayIndex>(other.index_ == noDuplication 
+                     ? noDuplication : duplicate)
                  : other.index_) {}
 
 Value::CZString::~CZString() {


### PR DESCRIPTION
When CXXFLAGS contains '-Wextra', as I set 
SET(CMAKE_CXX_FLAGS_RELEASE ‘-Wall -Wextra’)
in root CMakeLists.txt.
I got the following error:
json_value.cpp:179:26: warning: enumeral and non-enumeral type in conditional expression [enabled by default]

I have describe it in the closed pull as follows:
https://github.com/open-source-parsers/jsoncpp/pull/80

Thanks the help of Christopher Dunn 
"
Yours will be slightly less efficient. I know this CZString stuff is kind of hacky, but why not use static_cast<ArrayIndex>(other.index_ == noDuplication ? noDuplication : duplicate) after the question mark?
"
I test the modification and it works fine.
