### PR TITLE
Specialize std::swap() for Json::Value

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -1082,6 +1082,10 @@ public:
 
 } // namespace Json
 
+/// Specialize std::swap() for Json::Value.
+namespace std { void swap(Json::Value&, Json::Value&); }
+inline void std::swap(Json::Value& a, Json::Value& b) { a.swap(b); }
+
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 #pragma warning(pop)
 #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -1083,7 +1083,7 @@ public:
 } // namespace Json
 
 /// Specialize std::swap() for Json::Value.
-namespace std { void swap(Json::Value&, Json::Value&); }
+template<>
 inline void std::swap(Json::Value& a, Json::Value& b) { a.swap(b); }
 
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)


### PR DESCRIPTION
This addresses [BilliyGoto](https://github.com/BillyGoto)'s comment on https://github.com/open-source-parsers/jsoncpp/issues/47