### PR TITLE
Doxybuild: Error message if doxygen not found

### DIFF
--- a/doxybuild.py
+++ b/doxybuild.py
@@ -49,6 +49,12 @@ def do_subst_in_file(targetfile, sourcefile, dict):
 def run_doxygen(doxygen_path, config_file, working_dir, is_silent):
     config_file = os.path.abspath( config_file )
     doxygen_path = doxygen_path
+
+    if not doxygen_path:
+        print('Documentation generation failed:')
+        print('Program doxygen not found')
+        return False
+
     old_cwd = os.getcwd()
     try:
         os.chdir( working_dir )
@@ -114,6 +120,9 @@ def build_doc( options,  make_release=False ):
 
     do_subst_in_file( 'doc/doxyfile', 'doc/doxyfile.in', subst_keys )
     ok = run_doxygen( options.doxygen_path, 'doc/doxyfile', 'doc', is_silent=options.silent )
+    if not ok:
+        exit(1)
+
     if not options.silent:
         print(open(warning_log_path, 'rb').read())
     index_path = os.path.abspath(os.path.join('doc', subst_keys['%HTML_OUTPUT%'], 'index.html'))


### PR DESCRIPTION
Running doxygen without existing doxygen program led to the following error message:

Deleting directory: dist/doxygen
Running:  /home/koalo/jsoncpp/doc/doxyfile
Traceback (most recent call last):
  File "doxybuild.py", line 169, in <module>
    main()
  File "doxybuild.py", line 166, in main
    build_doc( options )
  File "doxybuild.py", line 116, in build_doc
    ok = run_doxygen( options.doxygen_path, 'doc/doxyfile', 'doc',
is_silent=options.silent )
  File "doxybuild.py", line 67, in run_doxygen
    process = subprocess.Popen( cmd )
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 13] Permission denied

This patch introduces a better error message. Feel free to modify the way the error message is generated. I was just confused and had to look into the source code to understand that actually I forgot to install doxygen.