### PR TITLE
Build without warnings with -pedantic enabled.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -340,7 +340,7 @@ Value::Value(const Value& other)
   case stringValue:
     if (other.value_.string_) {
       value_.string_ = duplicateStringValue(other.value_.string_);
-      allocated_ = true;
+      allocated_ |= true;
     } else {
       value_.string_ = 0;
       allocated_ = false;


### PR DESCRIPTION
I was trying to bundle amalgamated JsonCpp in a project that is being built with `-Werror` and `-pedantic` and had to make this change to avoid a bitfield overflow warning:

```
  CXX(target) Release/obj.target/project/third/jsoncpp.o
../third/jsoncpp.cpp: In copy constructor ‘Json::Value::Value(const Json::Value&)’:
../third/jsoncpp.cpp:1831:18: error: overflow in implicit constant conversion [-Werror=overflow]
       allocated_ = true;
                  ^
cc1plus: all warnings being treated as errors
make[2]: *** [Release/obj.target/project/third/jsoncpp.o] Error 1
```

It's kind of a silly change (so feel free to reject) but since it's the only warning emitted I thought it might be worth pulling in.