### PR TITLE
StreamWriterBuilder

### DIFF
--- a/doc/jsoncpp.dox
+++ b/doc/jsoncpp.dox
@@ -73,24 +73,31 @@ for ( int index = 0; index < plugins.size(); ++index )  // Iterates over the seq
 setIndentLength( root["indent"].get("length", 3).asInt() );
 setIndentUseSpace( root["indent"].get("use_space", true).asBool() );
 
-// ...
-// At application shutdown to make the new configuration document:
 // Since Json::Value has implicit constructor for all value types, it is not
 // necessary to explicitly construct the Json::Value object:
 root["encoding"] = getCurrentEncoding();
 root["indent"]["length"] = getCurrentIndentLength();
 root["indent"]["use_space"] = getCurrentIndentUseSpace();
 
-Json::StyledWriter writer;
-// Make a new JSON document for the configuration. Preserve original comments.
-std::string outputConfig = writer.write( root );
+// To write into a steam with minimal memory overhead,
+// create a Builder for a StreamWriter.
+Json::StreamWriter::Builder builder;
+builder.withIndentation("   ");  // or whatever you like
 
-// You can also use streams.  This will put the contents of any JSON
+// Then build a StreamWriter.
+// (Of course, you can write to std::ostringstream if you prefer.)
+std::shared_ptr<Json::StreamWriter> writer(
+    builder.newStreamWriter( &std::cout );
+
+// Make a new JSON document for the configuration. Preserve original comments.
+writer->write( root );
+
+// If you like the defaults, you can insert directly into a stream.
+std::cout << root;
+
+// You can also read from a stream.  This will put the contents of any JSON
 // stream at a particular sub-value, if you'd like.
 std::cin >> root["subtree"];
-
-// And you can write to a stream, using the StyledWriter automatically.
-std::cout << root;
 \endcode
 
 \section _pbuild Build instructions

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -65,6 +65,13 @@ public:
     ~Builder();  // delete underlying StreamWriterBuilder
 
     void setCommentStyle(CommentStyle cs);  /// default: All
+    /** \brief Write in human-friendly style.
+
+        If "", then skip all indentation, newlines, and comments,
+        which implies CommentStyle::None.
+        Default: "\t"
+    */
+    void setIndentation(std::string indentation);
 
     /// Do not take ownership of sout, but maintain a reference.
     StreamWriter* newStreamWriter(std::ostream* sout);

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -31,7 +31,7 @@ Usage:
   using namespace Json;
   Value value;
   StreamWriter::Builder builder;
-  builder.setCommentStyle(StreamWriter::CommentStyle::None);
+  builder.withCommentStyle(StreamWriter::CommentStyle::None);
   std::shared_ptr<StreamWriter> writer(
     builder.newStreamWriter(&std::cout));
   writer->write(value);
@@ -66,24 +66,24 @@ public:
     Builder();
     ~Builder();  // delete underlying StreamWriterBuilder
 
-    void setCommentStyle(CommentStyle cs);  /// default: All
+    Builder& withCommentStyle(CommentStyle cs);  /// default: All
     /** \brief Write in human-friendly style.
 
         If "", then skip all indentation, newlines, and comments,
         which implies CommentStyle::None.
         Default: "\t"
     */
-    void setIndentation(std::string indentation);
+    Builder& withIndentation(std::string indentation);
     /** \brief Drop the "null" string from the writer's output for nullValues.
     * Strictly speaking, this is not valid JSON. But when the output is being
     * fed to a browser's Javascript, it makes for smaller output and the
     * browser can handle the output just fine.
     */
-    void setDropNullPlaceholders(bool v);
+    Builder& withDropNullPlaceholders(bool v);
     /** \brief Do not add \n at end of document.
      * Normally, we add an extra newline, just because.
      */
-    void setOmitEndingLineFeed(bool v);
+    Builder& withOmitEndingLineFeed(bool v);
     /** \brief Add a space after ':'.
      * If indentation is non-empty, we surround colon with whitespace,
      * e.g. " : "
@@ -91,7 +91,7 @@ public:
      * This seems dubious when the entire document is on a single line,
      * but we leave this here to repduce the behavior of the old `FastWriter`.
      */
-    void setEnableYAMLCompatibility(bool v);
+    Builder& withEnableYAMLCompatibility(bool v);
 
     /// Do not take ownership of sout, but maintain a reference.
     StreamWriter* newStreamWriter(std::ostream* sout) const;
@@ -103,6 +103,7 @@ std::string writeString(Value const& root, StreamWriter::Builder const& builder)
 
 
 /** \brief Abstract class for writers.
+ * \deprecated Use StreamWriter::Builder.
  */
 class JSON_API Writer {
 public:
@@ -118,6 +119,7 @@ public:
  *consumption,
  * but may be usefull to support feature such as RPC where bandwith is limited.
  * \sa Reader, Value
+ * \deprecated Use StreamWriter::Builder.
  */
 class JSON_API FastWriter : public Writer {
 public:
@@ -169,6 +171,7 @@ private:
  *#CommentPlacement.
  *
  * \sa Reader, Value, Value::setComment()
+ * \deprecated Use StreamWriter::Builder.
  */
 class JSON_API StyledWriter : public Writer {
 public:
@@ -230,6 +233,7 @@ private:
  *
  * \param indentation Each level will be indented by this amount extra.
  * \sa Reader, Value, Value::setComment()
+ * \deprecated Use StreamWriter::Builder.
  */
 class JSON_API StyledStreamWriter {
 public:

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -30,26 +30,20 @@ Usage:
 
   using namespace Json;
   Value value;
-  StreamWriterBuilderFactory f;
-  StreamWriter::Builder builder(&f);
+  StreamWriter::Builder builder;
   builder.setCommentStyle(StreamWriter::CommentStyle::None);
   std::shared_ptr<StreamWriter> writer(
     builder.newStreamWriter(&std::cout));
   writer->write(value);
   std::cout.flush();
 */
-class JSON_API StreamWriterBuilderFactory {
-public:
-  virtual ~StreamWriterBuilderFactory();
-  virtual StreamWriterBuilder* newStreamWriterBuilder() const;
-};
-
 class JSON_API StreamWriter {
 protected:
   std::ostream& sout_;  // not owned; will not delete
 public:
   enum class CommentStyle {None, Some, All};
 
+  /// Keep a reference, but do not take ownership of `sout`.
   StreamWriter(std::ostream* sout);
   virtual ~StreamWriter();
   /// Write Value into document as configured in sub-class.
@@ -62,8 +56,10 @@ public:
   /// \see http://stackoverflow.com/questions/14875052/pure-virtual-functions-and-binary-compatibility
   class Builder {
     StreamWriterBuilder* own_;
+    Builder(Builder const&);  // noncopyable
+    void operator=(Builder const&);  // noncopyable
   public:
-    Builder(StreamWriterBuilderFactory const*);
+    Builder();
     ~Builder();  // delete underlying StreamWriterBuilder
 
     void setCommentStyle(CommentStyle cs);  /// default: All

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -55,7 +55,7 @@ public:
   /// Write Value into document as configured in sub-class.
   /// \return zero on success
   /// \throw std::exception possibly, depending on configuration
-  virtual int write(Value const& root) const = 0;
+  virtual int write(Value const& root) = 0;
 
   /// Because this Builder is non-virtual, we can safely add
   /// methods without a major version bump.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -23,6 +23,35 @@ namespace Json {
 
 class Value;
 
+class JSON_API StreamWriter {
+protected:
+  std::ostream& sout_;  // not owned; will not delete
+public:
+  StreamWriter(std::ostream* sout);
+  virtual ~StreamWriter();
+  /// Write Value into document as configured in sub-class.
+  /// \return zero on success
+  /// \throw std::exception possibly, depending on configuration
+  virtual int write(Value const& root) const = 0;
+};
+
+class JSON_API StreamWriterBuilder {
+public:
+  virtual ~StreamWriterBuilder();
+  /// Do not delete stream (i.e. not owned), but keep a reference.
+  virtual StreamWriter* newStreamWriter(std::ostream* stream) const;
+};
+
+class JSON_API StreamWriterBuilderFactory {
+public:
+  virtual ~StreamWriterBuilderFactory();
+  virtual StreamWriterBuilder* newStreamWriterBuilder();
+};
+
+/// \brief Write into stringstream, then return string, for convenience.
+std::string writeString(Value const& root, StreamWriterBuilder const& builder);
+
+
 /** \brief Abstract class for writers.
  */
 class JSON_API Writer {

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -41,7 +41,11 @@ class JSON_API StreamWriter {
 protected:
   std::ostream& sout_;  // not owned; will not delete
 public:
-  enum class CommentStyle {None, Some, All};
+  /// `All`: Keep all comments.
+  /// `None`: Drop all comments.
+  /// Use `Most` to recover the odd behavior of previous versions.
+  /// Only `All` is currently implemented.
+  enum class CommentStyle {None, Most, All};
 
   /// Keep a reference, but do not take ownership of `sout`.
   StreamWriter(std::ostream* sout);

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -74,6 +74,24 @@ public:
         Default: "\t"
     */
     void setIndentation(std::string indentation);
+    /** \brief Drop the "null" string from the writer's output for nullValues.
+    * Strictly speaking, this is not valid JSON. But when the output is being
+    * fed to a browser's Javascript, it makes for smaller output and the
+    * browser can handle the output just fine.
+    */
+    void setDropNullPlaceholders(bool v);
+    /** \brief Do not add \n at end of document.
+     * Normally, we add an extra newline, just because.
+     */
+    void setOmitEndingLineFeed(bool v);
+    /** \brief Add a space after ':'.
+     * If indentation is non-empty, we surround colon with whitespace,
+     * e.g. " : "
+     * This will add back the trailing space when there is no indentation.
+     * This seems dubious when the entire document is on a single line,
+     * but we leave this here to repduce the behavior of the old `FastWriter`.
+     */
+    void setEnableYAMLCompatibility(bool v);
 
     /// Do not take ownership of sout, but maintain a reference.
     StreamWriter* newStreamWriter(std::ostream* sout) const;

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -76,12 +76,12 @@ public:
     void setIndentation(std::string indentation);
 
     /// Do not take ownership of sout, but maintain a reference.
-    StreamWriter* newStreamWriter(std::ostream* sout);
+    StreamWriter* newStreamWriter(std::ostream* sout) const;
   };
 };
 
 /// \brief Write into stringstream, then return string, for convenience.
-std::string writeString(Value const& root, StreamWriterBuilder const& builder);
+std::string writeString(Value const& root, StreamWriter::Builder const& builder);
 
 
 /** \brief Abstract class for writers.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -33,8 +33,10 @@ Usage:
   StreamWriterBuilderFactory f;
   StreamWriter::Builder builder(&f);
   builder.setCommentStyle(StreamWriter::CommentStyle::None);
-  std::shared_ptr<StreamWriter> writer(builder.newStreamWriter(&std::cout));
-  writer.write(value);
+  std::shared_ptr<StreamWriter> writer(
+    builder.newStreamWriter(&std::cout));
+  writer->write(value);
+  std::cout.flush();
 */
 class JSON_API StreamWriterBuilderFactory {
 public:

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -151,7 +151,6 @@ static int parseAndSaveValueTree(const std::string& input,
            reader.getFormattedErrorMessages().c_str());
     return 1;
   }
-
   if (!parseOnly) {
     FILE* factual = fopen(actual.c_str(), "wt");
     if (!factual) {
@@ -181,6 +180,14 @@ static std::string useStyledStreamWriter(
   std::ostringstream sout;
   writer.write(sout, root);
   return sout.str();
+}
+static std::string useBuiltStyledStreamWriter(
+    Json::Value const& root)
+{
+  Json::StreamWriterBuilderFactory f;
+  Json::StreamWriter::Builder builder(&f);
+  builder.setCommentStyle(Json::StreamWriter::CommentStyle::All);
+  return writeString(root, builder);
 }
 static int rewriteValueTree(
     const std::string& rewritePath,
@@ -248,6 +255,8 @@ static int parseCommandLine(
       opts->write = &useStyledWriter;
     } else if (writerName == "StyledStreamWriter") {
       opts->write = &useStyledStreamWriter;
+    } else if (writerName == "BuiltStyledStreamWriter") {
+      opts->write = &useBuiltStyledStreamWriter;
     } else {
       printf("Unknown '--json-writer %s'\n", writerName.c_str());
       return 4;

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -184,8 +184,7 @@ static std::string useStyledStreamWriter(
 static std::string useBuiltStyledStreamWriter(
     Json::Value const& root)
 {
-  Json::StreamWriterBuilderFactory f;
-  Json::StreamWriter::Builder builder(&f);
+  Json::StreamWriter::Builder builder;
   builder.setCommentStyle(Json::StreamWriter::CommentStyle::All);
   return writeString(root, builder);
 }

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -185,7 +185,7 @@ static std::string useBuiltStyledStreamWriter(
     Json::Value const& root)
 {
   Json::StreamWriter::Builder builder;
-  builder.setCommentStyle(Json::StreamWriter::CommentStyle::All);
+  builder.withCommentStyle(Json::StreamWriter::CommentStyle::All);
   return writeString(root, builder);
 }
 static int rewriteValueTree(

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -713,9 +713,11 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
 int BuiltStyledStreamWriter::write(Value const& root)
 {
   addChildValues_ = false;
-  indented_ = false;
+  indented_ = true;
   indentString_ = "";
   writeCommentBeforeValue(root);
+  if (!indented_) writeIndent();
+  indented_ = true;
   writeValue(root);
   writeCommentAfterValueOnSameLine(root);
   sout_ << "\n";
@@ -878,20 +880,17 @@ void BuiltStyledStreamWriter::writeCommentBeforeValue(Value const& root) {
   if (!root.hasComment(commentBefore))
     return;
 
-  sout_ << "\n";
-  writeIndent();
+  if (!indented_) writeIndent();
   const std::string& comment = root.getComment(commentBefore);
   std::string::const_iterator iter = comment.begin();
   while (iter != comment.end()) {
     sout_ << *iter;
     if (*iter == '\n' &&
        (iter != comment.end() && *(iter + 1) == '/'))
-      writeIndent();
+      // writeIndent();  // would write extra newline
+      sout_ << indentString_;
     ++iter;
   }
-
-  // Comments are stripped of trailing newlines, so add one here
-  sout_ << "\n";
   indented_ = false;
 }
 
@@ -900,9 +899,8 @@ void BuiltStyledStreamWriter::writeCommentAfterValueOnSameLine(Value const& root
     sout_ << " " + root.getComment(commentAfterOnSameLine);
 
   if (root.hasComment(commentAfter)) {
-    sout_ << "\n";
+    writeIndent();
     sout_ << root.getComment(commentAfter);
-    sout_ << "\n";
   }
 }
 

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -772,8 +772,8 @@ void BuiltStyledStreamWriter::writeArrayValue(Value const& value) {
   if (size == 0)
     pushValue("[]");
   else {
-    bool isArrayMultiLine = isMultineArray(value);
-    if (isArrayMultiLine) {
+    bool isMultiLine = (cs_ == CommentStyle::All) || isMultineArray(value);
+    if (isMultiLine) {
       writeWithIndent("[");
       indent();
       bool hasChildValue = !childValues_.empty();
@@ -969,14 +969,14 @@ void StreamWriter::Builder::setIndentation(std::string v)
 {
   own_->setIndentation(v);
 }
-StreamWriter* StreamWriter::Builder::newStreamWriter(std::ostream* sout)
+StreamWriter* StreamWriter::Builder::newStreamWriter(std::ostream* sout) const
 {
   return own_->newStreamWriter(sout);
 }
 
 /// Do not take ownership of sout, but maintain a reference.
 StreamWriter* newStreamWriter(std::ostream* sout);
-std::string writeString(Value const& root, StreamWriterBuilder const& builder) {
+std::string writeString(Value const& root, StreamWriter::Builder const& builder) {
   std::ostringstream sout;
   std::unique_ptr<StreamWriter> const sw(builder.newStreamWriter(&sout));
   sw->write(root);
@@ -986,7 +986,7 @@ std::string writeString(Value const& root, StreamWriterBuilder const& builder) {
 std::ostream& operator<<(std::ostream& sout, Value const& root) {
   StreamWriterBuilderFactory f;
   StreamWriter::Builder builder(&f);
-  builder.setCommentStyle(StreamWriter::CommentStyle::Some);
+  builder.setCommentStyle(StreamWriter::CommentStyle::All);
   std::shared_ptr<StreamWriter> writer(builder.newStreamWriter(&sout));
   writer->write(root);
   return sout;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -699,17 +699,24 @@ int MyStreamWriter::write(Value const& root) const
 class StreamWriterBuilder {
   typedef StreamWriter::CommentStyle CommentStyle;
   CommentStyle cs_;
+  std::string indentation_;
 public:
   virtual ~StreamWriterBuilder();
   virtual void setCommentStyle(CommentStyle cs);
+  virtual void setIndentation(std::string indentation);
   virtual StreamWriter* newStreamWriter(std::ostream* sout) const;
 };
 StreamWriterBuilder::~StreamWriterBuilder()
 {
 }
-void StreamWriterBuilder::setCommentStyle(CommentStyle cs)
+void StreamWriterBuilder::setCommentStyle(CommentStyle v)
 {
-  cs_ = cs;
+  cs_ = v;
+}
+void StreamWriterBuilder::setIndentation(std::string v)
+{
+  indentation_ = v;
+  if (indentation_.empty()) cs_ = CommentStyle::None;
 }
 StreamWriter* StreamWriterBuilder::newStreamWriter(std::ostream* stream) const
 {
@@ -732,9 +739,17 @@ StreamWriter::Builder::~Builder()
 {
   delete own_;
 }
-void StreamWriter::Builder::setCommentStyle(CommentStyle cs)
+void StreamWriter::Builder::setCommentStyle(CommentStyle v)
 {
-  own_->setCommentStyle(cs);
+  own_->setCommentStyle(v);
+}
+void StreamWriter::Builder::setIndentation(std::string v)
+{
+  own_->setIndentation(v);
+}
+StreamWriter* StreamWriter::Builder::newStreamWriter(std::ostream* sout)
+{
+  return own_->newStreamWriter(sout);
 }
 
 /// Do not take ownership of sout, but maintain a reference.

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1058,25 +1058,30 @@ StreamWriter::Builder::Builder(Builder const&)
 {abort();}
 void StreamWriter::Builder::operator=(Builder const&)
 {abort();}
-void StreamWriter::Builder::setCommentStyle(CommentStyle v)
+StreamWriter::Builder& StreamWriter::Builder::withCommentStyle(CommentStyle v)
 {
   own_->setCommentStyle(v);
+  return *this;
 }
-void StreamWriter::Builder::setIndentation(std::string v)
+StreamWriter::Builder& StreamWriter::Builder::withIndentation(std::string v)
 {
   own_->setIndentation(v);
+  return *this;
 }
-void StreamWriter::Builder::setDropNullPlaceholders(bool v)
+StreamWriter::Builder& StreamWriter::Builder::withDropNullPlaceholders(bool v)
 {
   own_->setDropNullPlaceholders(v);
+  return *this;
 }
-void StreamWriter::Builder::setOmitEndingLineFeed(bool v)
+StreamWriter::Builder& StreamWriter::Builder::withOmitEndingLineFeed(bool v)
 {
   own_->setOmitEndingLineFeed(v);
+  return *this;
 }
-void StreamWriter::Builder::setEnableYAMLCompatibility(bool v)
+StreamWriter::Builder& StreamWriter::Builder::withEnableYAMLCompatibility(bool v)
 {
   own_->setEnableYAMLCompatibility(v);
+  return *this;
 }
 StreamWriter* StreamWriter::Builder::newStreamWriter(std::ostream* sout) const
 {
@@ -1092,8 +1097,8 @@ std::string writeString(Value const& root, StreamWriter::Builder const& builder)
 
 std::ostream& operator<<(std::ostream& sout, Value const& root) {
   StreamWriter::Builder builder;
-  builder.setCommentStyle(StreamWriter::CommentStyle::All);
-  builder.setIndentation("\t");
+  builder.withCommentStyle(StreamWriter::CommentStyle::All);
+  builder.withIndentation("\t");
   std::shared_ptr<StreamWriter> writer(builder.newStreamWriter(&sout));
   writer->write(root);
   return sout;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -944,11 +944,17 @@ class StreamWriterBuilder {
   CommentStyle cs_;
   std::string indentation_;
 public:
+  StreamWriterBuilder();
   virtual ~StreamWriterBuilder();
   virtual void setCommentStyle(CommentStyle cs);
   virtual void setIndentation(std::string indentation);
   virtual StreamWriter* newStreamWriter(std::ostream* sout) const;
 };
+StreamWriterBuilder::StreamWriterBuilder()
+  : cs_(CommentStyle::All)
+  , indentation_("\t")
+{
+}
 StreamWriterBuilder::~StreamWriterBuilder()
 {
 }

--- a/test/runjsontests.py
+++ b/test/runjsontests.py
@@ -147,16 +147,23 @@ def main():
     else:
         input_path = None
     status = runAllTests(jsontest_executable_path, input_path,
-                          use_valgrind=options.valgrind,
-                          with_json_checker=options.with_json_checker,
-                          writerClass='StyledWriter')
+                         use_valgrind=options.valgrind,
+                         with_json_checker=options.with_json_checker,
+                         writerClass='StyledWriter')
     if status:
         sys.exit(status)
     status = runAllTests(jsontest_executable_path, input_path,
-                          use_valgrind=options.valgrind,
-                          with_json_checker=options.with_json_checker,
-                          writerClass='StyledStreamWriter')
-    sys.exit(status)
+                         use_valgrind=options.valgrind,
+                         with_json_checker=options.with_json_checker,
+                         writerClass='StyledStreamWriter')
+    if status:
+        sys.exit(status)
+    status = runAllTests(jsontest_executable_path, input_path,
+                         use_valgrind=options.valgrind,
+                         with_json_checker=options.with_json_checker,
+                         writerClass='BuiltStyledStreamWriter')
+    if status:
+        sys.exit(status)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Here, we use a *Builder* to configure a StreamWriter more easily.

We use virtual methods to hide the implementation. But we use a concrete wrapper to hide the virtual methods. This allows us to add new methods [without bumping the major version](http://stackoverflow.com/questions/14875052/pure-virtual-functions-and-binary-compatibility), maintaining binary-compatibility.

I plan to fix #103 using this new API, but for now `operator<<()` is functionally unchanged.

We still need a plan for `FastWriter`.

See #131.