### PR TITLE
Fix a border case which causes Value::CommentInfo::setComment() to crash

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -142,8 +142,10 @@ Value::CommentInfo::~CommentInfo() {
 }
 
 void Value::CommentInfo::setComment(const char* text) {
-  if (comment_)
+  if (comment_) {
     releaseStringValue(comment_);
+    comment_ = 0;
+  }
   JSON_ASSERT(text != 0);
   JSON_ASSERT_MESSAGE(
       text[0] == '\0' || text[0] == '/',


### PR DESCRIPTION
Unpredictable behavior happens when comment_ is not 0 and JSON_ASSERT_MESSAGE() throws.