### PR TITLE
Ignore empty comments in input.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -150,7 +150,8 @@ void Value::CommentInfo::setComment(const char* text, size_t len) {
   JSON_ASSERT_MESSAGE(
       text[0] == '\0' || text[0] == '/',
       "in Json::Value::setComment(): Comments must start with /");
-  // It seems that /**/ style comments are acceptable as well.
+  // It seems that /**/ style comments are acceptable as well.But ignore empty comments, these are unnecessary.
+  if((text[2] == '\n' || !strcmp(text+2,"*/"))) return;
   comment_ = duplicateStringValue(text, len);
 }
 


### PR DESCRIPTION
Empty comments (// or /***/) are unnecessary if present in json input. Current patch ignores empty comments.