### PR TITLE
Reimplement the new Builders

### DIFF
--- a/doc/jsoncpp.dox
+++ b/doc/jsoncpp.dox
@@ -92,13 +92,13 @@ features without losing binary-compatibility.
 \code
 // For convenience, use `writeString()` with a specialized builder.
 Json::StreamWriterBuilder wbuilder;
-wbuilder.settings["indentation"] = "\t";
+wbuilder.settings_["indentation"] = "\t";
 std::string document = Json::writeString(wbuilder, root);
 
 // Here, using a specialized Builder, we discard comments and
 // record errors as we parse.
 Json::CharReaderBuilder rbuilder;
-rbuilder.settings["collectComments"] = false;
+rbuilder.settings_["collectComments"] = false;
 std::string errs;
 bool ok = Json::parseFromStream(rbuilder, std::cin, &root, &errs);
 \endcode

--- a/doc/jsoncpp.dox
+++ b/doc/jsoncpp.dox
@@ -92,13 +92,13 @@ features without losing binary-compatibility.
 \code
 // For convenience, use `writeString()` with a specialized builder.
 Json::StreamWriterBuilder wbuilder;
-wbuilder.settings_["indentation"] = "\t";
+wbuilder.settings_["indentation"] = "\t";  // simple Json::Value
 std::string document = Json::writeString(wbuilder, root);
 
 // Here, using a specialized Builder, we discard comments and
 // record errors as we parse.
 Json::CharReaderBuilder rbuilder;
-rbuilder.settings_["collectComments"] = false;
+rbuilder.settings_["collectComments"] = false;  // simple Json::Value
 std::string errs;
 bool ok = Json::parseFromStream(rbuilder, std::cin, &root, &errs);
 \endcode

--- a/doc/jsoncpp.dox
+++ b/doc/jsoncpp.dox
@@ -103,6 +103,22 @@ std::string errs;
 bool ok = Json::parseFromStream(rbuilder, std::cin, &root, &errs);
 \endcode
 
+Yes, compile-time configuration-checking would be helpful,
+but `Json::Value` lets you
+write and read the builder configuration, which is better! In other words,
+you can configure your JSON parser using JSON.
+
+CharReaders and StreamWriters are not thread-safe, but they are re-usable.
+\code
+Json::CharReaderBuilder rbuilder;
+cfg >> rbuilder.settings_;
+std::unique_ptr<Json::CharReader> const reader(rbuilder.newCharReader());
+reader->parse(start, stop, &value1, &errs);
+// ...
+reader->parse(start, stop, &value2, &errs);
+// etc.
+\endcode
+
 \section _pbuild Build instructions
 The build instructions are located in the file 
 <a HREF="https://github.com/open-source-parsers/jsoncpp/blob/master/README.md">README.md</a> in the top-directory of the project.
@@ -137,5 +153,7 @@ and recognized in your jurisdiction.
 
 \author Baptiste Lepilleur <blep@users.sourceforge.net> (originator)
 \version \include version
+We make strong guarantees about binary-compatibility, consistent with
+<a href="http://apr.apache.org/versioning.html">the Apache versioning scheme</a>.
 \sa version.h
 */

--- a/doc/jsoncpp.dox
+++ b/doc/jsoncpp.dox
@@ -53,23 +53,26 @@ preserved.
 Json::Value root;   // 'root' will contain the root value after parsing.
 std::cin >> root;
 
+// You can also read into a particular sub-value.
+std::cin >> root["subtree"];
+
 // Get the value of the member of root named 'encoding', return 'UTF-8' if there is no
 // such member.
 std::string encoding = root.get("encoding", "UTF-8" ).asString();
-// Get the value of the member of root named 'encoding', return a 'null' value if
+// Get the value of the member of root named 'encoding'; return a 'null' value if
 // there is no such member.
 const Json::Value plugins = root["plug-ins"];
 for ( int index = 0; index < plugins.size(); ++index )  // Iterates over the sequence elements.
    loadPlugIn( plugins[index].asString() );
    
-setIndentLength( root["indent"].get("length", 3).asInt() );
-setIndentUseSpace( root["indent"].get("use_space", true).asBool() );
+foo::setIndentLength( root["indent"].get("length", 3).asInt() );
+foo::setIndentUseSpace( root["indent"].get("use_space", true).asBool() );
 
 // Since Json::Value has implicit constructor for all value types, it is not
 // necessary to explicitly construct the Json::Value object:
-root["encoding"] = getCurrentEncoding();
-root["indent"]["length"] = getCurrentIndentLength();
-root["indent"]["use_space"] = getCurrentIndentUseSpace();
+root["encoding"] = foo::getCurrentEncoding();
+root["indent"]["length"] = foo::getCurrentIndentLength();
+root["indent"]["use_space"] = foo::getCurrentIndentUseSpace();
 
 // If you like the defaults, you can insert directly into a stream.
 std::cout << root;
@@ -80,27 +83,24 @@ std::cout << std::endl;
 \endcode
 
 \section _advanced Advanced usage
-We are finalizing the new *Builder* API, which will be in versions
-`1.4.0` and `0.8.0` when released. Until then, you may continue to
-use the old API, include `Writer`, `Reader`, and `Feature`.
+
+Configure *builders* to create *readers* and *writers*. For
+configuration, we use our own `Json::Value` (rather than
+standard setters/getters) so that we can add
+features without losing binary-compatibility.
+
 \code
-
-// EXPERIMENTAL
-// Or use `writeString()` for convenience, with a specialized builder.
+// For convenience, use `writeString()` with a specialized builder.
 Json::StreamWriterBuilder wbuilder;
-builder.indentation_ = "\t";
-std::string document = Json::writeString(root, wbuilder);
+wbuilder.settings["indentation"] = "\t";
+std::string document = Json::writeString(wbuilder, root);
 
-// You can also read into a particular sub-value.
-std::cin >> root["subtree"];
-
-// EXPERIMENTAL
-// Here we use a specialized Builder, discard comments, and
-// record errors.
+// Here, using a specialized Builder, we discard comments and
+// record errors as we parse.
 Json::CharReaderBuilder rbuilder;
-rbuilder.collectComments_ = false;
+rbuilder.settings["collectComments"] = false;
 std::string errs;
-Json::parseFromStream(rbuilder, std::cin, &root["subtree"], &errs);
+bool ok = Json::parseFromStream(rbuilder, std::cin, &root, &errs);
 \endcode
 
 \section _pbuild Build instructions

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -298,12 +298,16 @@ public:
   /** Configuration of this builder.
     These are case-sensitive.
     Available settings (case-sensitive):
-    - "collectComments": false or true (default=true)
-    - TODO: other features ...
+    - "collectComments": false or true
+    - "allowComments"
+    - "strictRoot"
+    - "allowDroppedNullPlaceholders"
+    - "allowNumericKeys"
+
     You can examine 'settings_` yourself
     to see the defaults. You can also write and read them just like any
     JSON Value.
-    \sa setDefaults(Json::Value*)
+    \sa setDefaults()
     */
   Json::Value settings_;
 
@@ -312,7 +316,7 @@ public:
 
   virtual CharReader* newCharReader() const;
 
-  /** \return true if 'settings' are illegal and consistent;
+  /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
    */
   bool validate(Json::Value* invalid) const;

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -296,12 +296,14 @@ public:
   // Note: We use a Json::Value so that we can add data-members to this class
   // without a major version bump.
   /** Configuration of this builder.
+    These are case-sensitive.
     Available settings (case-sensitive):
     - "collectComments": false or true (default=true)
     - TODO: other features ...
-    But don't trust these docs. You can examine 'settings_` yourself
+    You can examine 'settings_` yourself
     to see the defaults. You can also write and read them just like any
     JSON Value.
+    \sa setDefaults(Json::Value*)
     */
   Json::Value settings_;
 
@@ -316,8 +318,16 @@ public:
   bool validate(Json::Value* invalid) const;
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
+   * \remark Defaults:
+   * \snippet src/lib_json/json_reader.cpp CharReaderBuilderStrictMode
    */
   static void setDefaults(Json::Value* settings);
+  /** Same as old Features::strictMode().
+   * \pre 'settings' != NULL (but Json::null is fine)
+   * \remark Defaults:
+   * \snippet src/lib_json/json_reader.cpp CharReaderBuilderDefaults
+   */
+  static void strictMode(Json::Value* settings);
 };
 
 /** Consume entire stream and use its begin/end.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -41,16 +41,6 @@ class JSON_API StreamWriter {
 protected:
   std::ostream* sout_;  // not owned; will not delete
 public:
-  /// Scoped enums are not available until C++11.
-  struct CommentStyle {
-    /// Decide whether to write comments.
-    enum Enum {
-      None,  ///< Drop all comments.
-      Most,  ///< Recover odd behavior of previous versions (not implemented yet).
-      All  ///< Keep all comments.
-    };
-  };
-
   StreamWriter();
   virtual ~StreamWriter();
   /** Write Value into document as configured in sub-class.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -121,6 +121,8 @@ public:
   bool validate(Json::Value* invalid) const;
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
+   * \remark Defaults:
+   * \snippet src/lib_json/json_writer.cpp StreamWriterBuilderDefaults
    */
   static void setDefaults(Json::Value* settings);
 };

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -99,11 +99,13 @@ public:
   // without a major version bump.
   /** Configuration of this builder.
     Available settings (case-sensitive):
-    - "commentStyle": "None", "Some", or "All" (default="All")
-    - "indentation":  (default="\t")
-    But don't trust these docs. You can examine 'settings_` yourself
+    - "commentStyle": "None", "Some", or "All"
+    - "indentation":  "<anything>"
+
+    You can examine 'settings_` yourself
     to see the defaults. You can also write and read them just like any
     JSON Value.
+    \sa setDefaults()
     */
   Json::Value settings_;
 
@@ -115,7 +117,7 @@ public:
    */
   virtual StreamWriter* newStreamWriter(std::ostream* sout) const;
 
-  /** \return true if 'settings' are illegal and consistent;
+  /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
    */
   bool validate(Json::Value* invalid) const;

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -69,8 +69,10 @@ public:
   };  // Factory
 };  // StreamWriter
 
-/// \brief Write into stringstream, then return string, for convenience.
-std::string writeString(Value const& root, StreamWriter::Factory const& factory);
+/** \brief Write into stringstream, then return string, for convenience.
+ * A StreamWriter will be created from the factory, used, and then deleted.
+ */
+std::string writeString(StreamWriter::Factory const& factory, Value const& root);
 
 
 /** \brief Build a StreamWriter implementation.

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -185,7 +185,7 @@ static std::string useBuiltStyledStreamWriter(
     Json::Value const& root)
 {
   Json::StreamWriterBuilder builder;
-  return writeString(root, builder);
+  return Json::writeString(builder, root);
 }
 static int rewriteValueTree(
     const std::string& rewritePath,

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -925,13 +925,20 @@ CharReader* CharReaderBuilder::newCharReader() const
 
   bool collectComments = settings_["collectComments"].asBool();
   Features features = Features::all();
-  // TODO: Fill in features.
+  features.allowComments_ = settings_["allowComments"].asBool();
+  features.strictRoot_ = settings_["strictRoot"].asBool();
+  features.allowDroppedNullPlaceholders_ = settings_["allowDroppedNullPlaceholders"].asBool();
+  features.allowNumericKeys_ = settings_["allowNumericKeys"].asBool();
   return new OldReader(collectComments, features);
 }
 static void getValidReaderKeys(std::set<std::string>* valid_keys)
 {
   valid_keys->clear();
   valid_keys->insert("collectComments");
+  valid_keys->insert("allowComments");
+  valid_keys->insert("strictRoot");
+  valid_keys->insert("allowDroppedNullPlaceholders");
+  valid_keys->insert("allowNumericKeys");
 }
 bool CharReaderBuilder::validate(Json::Value* invalid) const
 {

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -952,9 +952,25 @@ bool CharReaderBuilder::validate(Json::Value* invalid) const
   return valid;
 }
 // static
+void CharReaderBuilder::strictMode(Json::Value* settings)
+{
+//! [CharReaderBuilderStrictMode]
+  (*settings)["allowComments"] = false;
+  (*settings)["strictRoot"] = true;
+  (*settings)["allowDroppedNullPlaceholders"] = false;
+  (*settings)["allowNumericKeys"] = false;
+//! [CharReaderBuilderStrictMode]
+}
+// static
 void CharReaderBuilder::setDefaults(Json::Value* settings)
 {
+//! [CharReaderBuilderDefaults]
   (*settings)["collectComments"] = true;
+  (*settings)["allowComments"] = true;
+  (*settings)["strictRoot"] = false;
+  (*settings)["allowDroppedNullPlaceholders"] = false;
+  (*settings)["allowNumericKeys"] = false;
+//! [CharReaderBuilderDefaults]
 }
 
 //////////////////////////////////

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <memory>
 #include <set>
+#include <stdexcept>
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #define snprintf _snprintf

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -16,6 +16,7 @@
 #include <istream>
 #include <sstream>
 #include <memory>
+#include <set>
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #define snprintf _snprintf
@@ -912,14 +913,48 @@ public:
 };
 
 CharReaderBuilder::CharReaderBuilder()
-  : collectComments_(true)
-  , features_(Features::all())
-{}
+{
+  setDefaults(&settings_);
+}
 CharReaderBuilder::~CharReaderBuilder()
 {}
 CharReader* CharReaderBuilder::newCharReader() const
 {
-  return new OldReader(collectComments_, features_);
+  if (!validate(NULL)) throw std::runtime_error("invalid settings");
+  // TODO: Maybe serialize the invalid settings into the exception.
+
+  bool collectComments = settings_["collectComments"].asBool();
+  Features features = Features::all();
+  // TODO: Fill in features.
+  return new OldReader(collectComments, features);
+}
+static void getValidReaderKeys(std::set<std::string>* valid_keys)
+{
+  valid_keys->clear();
+  valid_keys->insert("collectComments");
+}
+bool CharReaderBuilder::validate(Json::Value* invalid) const
+{
+  Json::Value my_invalid;
+  if (!invalid) invalid = &my_invalid;  // so we do not need to test for NULL
+  Json::Value& inv = *invalid;
+  bool valid = true;
+  std::set<std::string> valid_keys;
+  getValidReaderKeys(&valid_keys);
+  Value::Members keys = settings_.getMemberNames();
+  size_t n = keys.size();
+  for (size_t i = 0; i < n; ++i) {
+    std::string const& key = keys[i];
+    if (valid_keys.find(key) == valid_keys.end()) {
+      inv[key] = settings_[key];
+    }
+  }
+  return valid;
+}
+// static
+void CharReaderBuilder::setDefaults(Json::Value* settings)
+{
+  (*settings)["collectComments"] = true;
 }
 
 //////////////////////////////////

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1008,8 +1008,10 @@ bool StreamWriterBuilder::validate(Json::Value* invalid) const
 // static
 void StreamWriterBuilder::setDefaults(Json::Value* settings)
 {
+  //! [StreamWriterBuilderDefaults]
   (*settings)["commentStyle"] = "All";
   (*settings)["indentation"] = "\t";
+  //! [StreamWriterBuilderDefaults]
 }
 
 /*

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -676,11 +676,21 @@ bool StyledStreamWriter::hasCommentForValue(const Value& value) {
 //////////////////////////
 // BuiltStyledStreamWriter
 
+/// Scoped enums are not available until C++11.
+struct CommentStyle {
+  /// Decide whether to write comments.
+  enum Enum {
+    None,  ///< Drop all comments.
+    Most,  ///< Recover odd behavior of previous versions (not implemented yet).
+    All  ///< Keep all comments.
+  };
+};
+
 struct BuiltStyledStreamWriter : public StreamWriter
 {
   BuiltStyledStreamWriter(
       std::string const& indentation,
-      StreamWriter::CommentStyle::Enum cs,
+      CommentStyle::Enum cs,
       std::string const& colonSymbol,
       std::string const& nullSymbol,
       std::string const& endingLineFeedSymbol);
@@ -713,7 +723,7 @@ private:
 };
 BuiltStyledStreamWriter::BuiltStyledStreamWriter(
       std::string const& indentation,
-      StreamWriter::CommentStyle::Enum cs,
+      CommentStyle::Enum cs,
       std::string const& colonSymbol,
       std::string const& nullSymbol,
       std::string const& endingLineFeedSymbol)
@@ -963,11 +973,11 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const
 
   std::string indentation = settings_["indentation"].asString();
   std::string cs_str = settings_["commentStyle"].asString();
-  StreamWriter::CommentStyle::Enum cs = StreamWriter::CommentStyle::All;
+  CommentStyle::Enum cs = CommentStyle::All;
   if (cs_str == "All") {
-    cs = StreamWriter::CommentStyle::All;
+    cs = CommentStyle::All;
   } else if (cs_str == "None") {
-    cs = StreamWriter::CommentStyle::None;
+    cs = CommentStyle::None;
   } else {
     return NULL;
   }
@@ -1031,7 +1041,7 @@ StreamWriter* OldCompressingStreamWriterBuilder::newStreamWriter() const
     endingLineFeedSymbol = "";
   }
   return new BuiltStyledStreamWriter(
-      "", StreamWriter::CommentStyle::None,
+      "", CommentStyle::None,
       colonSymbol, nullSymbol, endingLineFeedSymbol);
 }
 

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <utility>
 #include <set>
+#include <stdexcept>
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1005,10 +1005,10 @@ StreamWriter* OldCompressingStreamWriterBuilder::newStreamWriter(
       colonSymbol, nullSymbol, endingLineFeedSymbol);
 }
 
-std::string writeString(Value const& root, StreamWriter::Factory const& builder) {
+std::string writeString(StreamWriter::Factory const& builder, Value const& root) {
   std::ostringstream sout;
-  StreamWriterPtr const sw(builder.newStreamWriter(&sout));
-  sw->write(root);
+  StreamWriterPtr const writer(builder.newStreamWriter(&sout));
+  writer->write(root);
   return sout.str();
 }
 


### PR DESCRIPTION
We need a version which can be augmented with binary-compatibility. So we use our own Json::Value for configuration. (#131)