### PR TITLE
allow zeroes in strings

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -226,8 +226,8 @@ Json::Value obj_value(Json::objectValue); // {}
   Value(UInt64 value);
 #endif // if defined(JSON_HAS_INT64)
   Value(double value);
-  Value(const char* value);
-  Value(const char* beginValue, const char* endValue);
+  Value(const char* value); ///! Copy til first 0. (NULL causes to seg-fault.)
+  Value(const char* beginValue, const char* endValue); ///! Copy all, incl zeroes.
   /** \brief Constructs a value from a static string.
 
    * Like other value string constructor but do not duplicate the string for
@@ -239,7 +239,7 @@ Json::Value obj_value(Json::objectValue); // {}
    * \endcode
    */
   Value(const StaticString& value);
-  Value(const std::string& value);
+  Value(const std::string& value); ///! Copy data() til size(). Embedded zeroes too.
 #ifdef JSON_USE_CPPTL
   Value(const CppTL::ConstString& value);
 #endif
@@ -266,8 +266,8 @@ Json::Value obj_value(Json::objectValue); // {}
   bool operator!=(const Value& other) const;
   int compare(const Value& other) const;
 
-  const char* asCString() const;
-  std::string asString() const;
+  const char* asCString() const; ///! Embedded zeroes could cause you trouble!
+  std::string asString() const; ///! Embedded zeroes are possible.
 #ifdef JSON_USE_CPPTL
   CppTL::ConstString asConstString() const;
 #endif

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -518,7 +518,7 @@ private:
     LargestUInt uint_;
     double real_;
     bool bool_;
-    char* string_;
+    char* string_;  // actually ptr to unsigned, followed by str
     ObjectValues* map_;
   } value_;
   ValueType type_ : 8;

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1430,6 +1430,7 @@ bool OurReader::readObject(Token& tokenStart) {
       return addErrorAndRecover(
           "Missing ':' after object member name", colon, tokenObjectEnd);
     }
+    if (name.length() >= (1U<<30)) throw std::runtime_error("keylength >= 2^30");
     Value& value = currentValue()[name];
     nodes_.push(&value);
     bool ok = readValue();

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -191,8 +191,6 @@ void Value::CommentInfo::setComment(const char* text, size_t len) {
 
 // Notes: policy_ indicates if the string was allocated when
 // a string is stored.
-//
-// TODO: Check for length > 1GB, in Reader.
 
 Value::CZString::CZString(ArrayIndex index) : cstr_(0), index_(index) {}
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -100,6 +100,28 @@ static inline char* duplicateStringValue(const char* value,
   return newString;
 }
 
+/* Record the length as a prefix.
+ */
+static inline char* duplicatePrefixedStringValue(
+    const char* value,
+    unsigned int length = unknown)
+{
+  if (length == unknown)
+    length = (unsigned int)strlen(value);
+
+  // Avoid an integer overflow in the call to malloc below by limiting length
+  // to a sane value.
+  if (length >= (unsigned)Value::maxInt)
+    length = Value::maxInt - 1;
+
+  char* newString = static_cast<char*>(malloc(length + 1));
+  JSON_ASSERT_MESSAGE(newString != 0,
+                      "in Json::Value::duplicateStringValue(): "
+                      "Failed to allocate string value buffer");
+  memcpy(newString, value, length);
+  newString[length] = 0;
+  return newString;
+}
 /** Free the string duplicated by duplicateStringValue().
  */
 static inline void releaseStringValue(char* value) { free(value); }

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -77,24 +77,34 @@ void ValueIteratorBase::copy(const SelfType& other) {
 
 Value ValueIteratorBase::key() const {
   const Value::CZString czstring = (*current_).first;
-  if (czstring.c_str()) {
+  if (czstring.data()) {
     if (czstring.isStaticString())
-      return Value(StaticString(czstring.c_str()));
-    return Value(czstring.c_str());
+      return Value(StaticString(czstring.data()));
+    return Value(czstring.data(), czstring.data() + czstring.length());
   }
   return Value(czstring.index());
 }
 
 UInt ValueIteratorBase::index() const {
   const Value::CZString czstring = (*current_).first;
-  if (!czstring.c_str())
+  if (!czstring.data())
     return czstring.index();
   return Value::UInt(-1);
 }
 
-const char* ValueIteratorBase::memberName() const {
-  const char* name = (*current_).first.c_str();
+char const* ValueIteratorBase::memberName() const {
+  const char* name = (*current_).first.data();
   return name ? name : "";
+}
+
+char const* ValueIteratorBase::memberName(char const** end) const {
+  const char* name = (*current_).first.data();
+  if (!name) {
+    *end = NULL;
+    return NULL;
+  }
+  *end = name + (*current_).first.length();
+  return name;
 }
 
 // //////////////////////////////////////////////////////////////////

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -50,6 +50,16 @@ static bool containsControlCharacter(const char* str) {
   return false;
 }
 
+static bool containsControlCharacter0(const char* str, unsigned len) {
+  char const* end = str + len;
+  while (end != str) {
+    if (isControlCharacter(*str) || 0==*str)
+      return true;
+    ++str;
+  }
+  return false;
+}
+
 std::string valueToString(LargestInt value) {
   UIntToStringBuffer buffer;
   char* current = buffer + sizeof(buffer);
@@ -184,6 +194,84 @@ std::string valueToQuotedString(const char* value) {
   return result;
 }
 
+// https://github.com/upcaste/upcaste/blob/master/src/upcore/src/cstring/strnpbrk.cpp
+static char const* strnpbrk(char const* s, char const* accept, size_t n) {
+  assert((s || !n) && accept);
+
+  char const* const end = s + n;
+  for (char const* cur = s; cur < end; ++cur) {
+    int const c = *cur;
+    for (char const* a = accept; *a; ++a) {
+      if (*a == c) {
+        return cur;
+      }
+    }
+  }
+  return NULL;
+}
+static std::string valueToQuotedStringN(const char* value, unsigned length) {
+  if (value == NULL)
+    return "";
+  // Not sure how to handle unicode...
+  if (strnpbrk(value, "\"\\\b\f\n\r\t", length) == NULL &&
+      !containsControlCharacter0(value, length))
+    return std::string("\"") + value + "\"";
+  // We have to walk value and escape any special characters.
+  // Appending to std::string is not efficient, but this should be rare.
+  // (Note: forward slashes are *not* rare, but I am not escaping them.)
+  std::string::size_type maxsize =
+      length * 2 + 3; // allescaped+quotes+NULL
+  std::string result;
+  result.reserve(maxsize); // to avoid lots of mallocs
+  result += "\"";
+  char const* end = value + length;
+  for (const char* c = value; c != end; ++c) {
+    switch (*c) {
+    case '\"':
+      result += "\\\"";
+      break;
+    case '\\':
+      result += "\\\\";
+      break;
+    case '\b':
+      result += "\\b";
+      break;
+    case '\f':
+      result += "\\f";
+      break;
+    case '\n':
+      result += "\\n";
+      break;
+    case '\r':
+      result += "\\r";
+      break;
+    case '\t':
+      result += "\\t";
+      break;
+    // case '/':
+    // Even though \/ is considered a legal escape in JSON, a bare
+    // slash is also legal, so I see no reason to escape it.
+    // (I hope I am not misunderstanding something.)
+    // blep notes: actually escaping \/ may be useful in javascript to avoid </
+    // sequence.
+    // Should add a flag to allow this compatibility mode and prevent this
+    // sequence from occurring.
+    default:
+      if ((isControlCharacter(*c)) || (*c == 0)) {
+        std::ostringstream oss;
+        oss << "\\u" << std::hex << std::uppercase << std::setfill('0')
+            << std::setw(4) << static_cast<int>(*c);
+        result += oss.str();
+      } else {
+        result += *c;
+      }
+      break;
+    }
+  }
+  result += "\"";
+  return result;
+}
+
 // Class Writer
 // //////////////////////////////////////////////////////////////////
 Writer::~Writer() {}
@@ -248,7 +336,7 @@ void FastWriter::writeValue(const Value& value) {
       const std::string& name = *it;
       if (it != members.begin())
         document_ += ',';
-      document_ += valueToQuotedString(name.c_str());
+      document_ += valueToQuotedStringN(name.data(), name.length());
       document_ += yamlCompatiblityEnabled_ ? ": " : ":";
       writeValue(value[name]);
     }
@@ -289,8 +377,15 @@ void StyledWriter::writeValue(const Value& value) {
     pushValue(valueToString(value.asDouble()));
     break;
   case stringValue:
-    pushValue(valueToQuotedString(value.asCString()));
+  {
+    // Is NULL is possible for value.string_?
+    char const* str;
+    char const* end;
+    bool ok = value.getString(&str, &end);
+    if (ok) pushValue(valueToQuotedStringN(str, static_cast<unsigned>(end-str)));
+    else pushValue("");
     break;
+  }
   case booleanValue:
     pushValue(valueToString(value.asBool()));
     break;
@@ -767,8 +862,15 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
     pushValue(valueToString(value.asDouble()));
     break;
   case stringValue:
-    pushValue(valueToQuotedString(value.asCString()));
+  {
+    // Is NULL is possible for value.string_?
+    char const* str;
+    char const* end;
+    bool ok = value.getString(&str, &end);
+    if (ok) pushValue(valueToQuotedStringN(str, static_cast<unsigned>(end-str)));
+    else pushValue("");
     break;
+  }
   case booleanValue:
     pushValue(valueToString(value.asBool()));
     break;
@@ -787,7 +889,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
         std::string const& name = *it;
         Value const& childValue = value[name];
         writeCommentBeforeValue(childValue);
-        writeWithIndent(valueToQuotedString(name.c_str()));
+        writeWithIndent(valueToQuotedStringN(name.data(), name.length()));
         *sout_ << colonSymbol_;
         writeValue(childValue);
         if (++it == members.end()) {


### PR DESCRIPTION
Properly support UTF-8 by allowing embedded zeroes in strings.

fix #176.