### PR TITLE
Trivial fixes in CZString constructors.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -196,7 +196,7 @@ void Value::CommentInfo::setComment(const char* text, size_t len) {
 Value::CZString::CZString(ArrayIndex index) : cstr_(0), index_(index) {}
 
 Value::CZString::CZString(char const* str, unsigned length, DuplicationPolicy allocate)
-    : cstr_(allocate == duplicate ? duplicateStringValue(str) : str)
+    : cstr_(allocate == duplicate ? duplicateStringValue(str, length) : str)
 {
   storage_.policy_ = allocate;
   storage_.length_ = length;
@@ -204,7 +204,7 @@ Value::CZString::CZString(char const* str, unsigned length, DuplicationPolicy al
 
 Value::CZString::CZString(const CZString& other)
     : cstr_(other.storage_.policy_ != noDuplication && other.cstr_ != 0
-                ? duplicateStringValue(other.cstr_)
+                ? duplicateStringValue(other.cstr_, other.storage_.length_)
                 : other.cstr_)
 {
   storage_.policy_ = (other.cstr_

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -201,6 +201,11 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   JSONTEST_ASSERT_EQUAL(Json::Value("foo"), object1_["some other id"]);
   JSONTEST_ASSERT_EQUAL(Json::Value("foo"), object1_["some other id"]);
 
+  static char const keyWithNulls[] = "key\0with\0nulls";
+  std::string const strKeyWithNulls(keyWithNulls, sizeof keyWithNulls);
+  object1_[strKeyWithNulls] = "object1_[keyWithNulls]";
+  JSONTEST_ASSERT_EQUAL(Json::Value("object1_[keyWithNulls]"), object1_[strKeyWithNulls]);
+
   // Remove.
   Json::Value got;
   bool did;
@@ -210,6 +215,12 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   got = Json::Value("bar");
   did = object1_.removeMember("some other id", &got);
   JSONTEST_ASSERT_EQUAL(Json::Value("bar"), got);
+  JSONTEST_ASSERT_EQUAL(false, did);
+
+  did = object1_.removeMember(strKeyWithNulls, &got);
+  JSONTEST_ASSERT_EQUAL(Json::Value("object1_[keyWithNulls]"), got);
+  JSONTEST_ASSERT_EQUAL(true, did);
+  did = object1_.removeMember(strKeyWithNulls, &got);
   JSONTEST_ASSERT_EQUAL(false, did);
 }
 


### PR DESCRIPTION
Value::CZString::CZString(char const* str, unsigned length, DuplicationPolicy allocate) with allocate == duplicate does not seem to happen.
It may be favorable to just not support that case, but rather add an assert(allocate != duplicate).