### PR TITLE
math.h -> cmath.  Add macro case for isfinite to use std namespace.

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -13,7 +13,7 @@
 #include <utility>
 #include <set>
 #include <assert.h>
-#include <math.h>
+#include <cmath>
 #include <stdio.h>
 #include <string.h>
 
@@ -21,16 +21,16 @@
 #include <float.h>
 #define isfinite _finite
 #define snprintf _snprintf
+#elif defined(__sun) && defined(__SVR4) //Solaris
+#include <ieeefp.h>
+#define isfinite finite
+#else
+#define isfinite std::isfinite
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0
 // Disable warning about strdup being deprecated.
 #pragma warning(disable : 4996)
-#endif
-
-#if defined(__sun) && defined(__SVR4) //Solaris
-#include <ieeefp.h>
-#define isfinite finite
 #endif
 
 namespace Json {


### PR DESCRIPTION
Possible solution for #214.  Requires replacing the `math.h` include with `cmath`, so if there was a reason for using that, this might not be an acceptable fix.