### PR TITLE
Use C++ std headers.  Defer to proper isfinite for MSVC and GCC.

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -12,25 +12,25 @@
 #include <sstream>
 #include <utility>
 #include <set>
-#include <assert.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
+#include <cstdio>
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #include <float.h>
 #define isfinite _finite
 #define snprintf _snprintf
+#elif defined(__sun) && defined(__SVR4) //Solaris
+#include <ieeefp.h>
+#define isfinite finite
+#else
+#include <cmath>
+#define isfinite std::isfinite
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0
 // Disable warning about strdup being deprecated.
 #pragma warning(disable : 4996)
-#endif
-
-#if defined(__sun) && defined(__SVR4) //Solaris
-#include <ieeefp.h>
-#define isfinite finite
 #endif
 
 namespace Json {

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -16,7 +16,7 @@
 #include <cstring>
 #include <cstdio>
 
-#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
+#if defined(_MSC_VER) && _MSC_VER >= 1200 // VC++ 6.0 and above
 #include <float.h>
 #define isfinite _finite
 #define snprintf _snprintf
@@ -26,6 +26,11 @@
 #else
 #include <cmath>
 #define isfinite std::isfinite
+#endif
+
+#if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
+#include <float.h>
+#define snprintf _snprintf
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -29,6 +29,8 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #define snprintf _snprintf
+#else
+#define snprintf std::snprintf
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -16,10 +16,9 @@
 #include <cstring>
 #include <cstdio>
 
-#if defined(_MSC_VER) && _MSC_VER >= 1200 // VC++ 6.0 and above
+#if defined(_MSC_VER) && _MSC_VER >= 1200 && _MSC_VER < 1800 // Between VC++ 6.0 and VC++ 11.0
 #include <float.h>
 #define isfinite _finite
-#define snprintf _snprintf
 #elif defined(__sun) && defined(__SVR4) //Solaris
 #include <ieeefp.h>
 #define isfinite finite
@@ -29,7 +28,6 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
-#include <float.h>
 #define snprintf _snprintf
 #endif
 


### PR DESCRIPTION
This request contains two commits for solving two issues:
 - #214, which is only related to compilers *besides* MSVC/Sun.  This fixes the GCC compilation error when `cmath` has been included in a project prior to building JsonCpp, and unifies the include format with the rest of JsonCpp to prefer the C++ standard headers.
 - @Dani-Hub's fix for correcting the preprocessor logic to make sure `isfinite` works on certain versions of MSVC.