### PR TITLE
fix find_program() bug: no result in not-win sys

### DIFF
--- a/doxybuild.py
+++ b/doxybuild.py
@@ -31,7 +31,7 @@ def find_program(*filenames):
     paths = os.environ.get('PATH', '').split(os.pathsep)
     suffixes = ('win32' in sys.platform) and '.exe .com .bat .cmd' or ''
     for filename in filenames:
-        for name in [filename+ext for ext in suffixes.split()]:
+        for name in [filename+ext for ext in suffixes.split(' ')]:
             for directory in paths:
                 full_path = os.path.join(directory, name)
                 if os.path.isfile(full_path):


### PR DESCRIPTION
if str.split() without args, all empty string will drop