### PR TITLE
Revert "Use std namespace for snprintf."

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -29,8 +29,6 @@
 
 #if defined(_MSC_VER) && _MSC_VER < 1500 // VC++ 8.0 and below
 #define snprintf _snprintf
-#else
-#define snprintf std::snprintf
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400 // VC++ 8.0


### PR DESCRIPTION
This reverts commit 1c58876185d2a4ed87dac4a54b82f607e74f55fd.

snprintf() is not in the std namespace. This fixes the build error below:

src/lib_json/json_writer.cpp:33:18: error: 'snprintf' is not a member of 'std'