### PR TITLE
explicit operator bool() for Json::Value

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -347,6 +347,23 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Return isNull()
   bool operator!() const;
 
+  /** \brief Return ! isNull();
+   *
+   * Example of usage:
+   * \code
+   * Json::Value root;
+   * std::cin >> root;
+   * 
+   * if (auto tag = root["tag"]) {
+   *    // Behavior if tag object with tag key exist
+   * } else {
+   *    // Behavior if tag object with tag key absent
+   * }
+   * \endcode
+   *
+   */
+  explicit operator bool() const;
+
   /// Remove all object members and array elements.
   /// \pre type() is arrayValue, objectValue, or nullValue
   /// \post type() is unchanged

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -344,9 +344,6 @@ Json::Value obj_value(Json::objectValue); // {}
   /// otherwise, false.
   bool empty() const;
 
-  /// Return isNull()
-  bool operator!() const;
-
   /** \brief Return ! isNull();
    *
    * Example of usage:

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -883,6 +883,8 @@ bool Value::empty() const {
 
 bool Value::operator!() const { return isNull(); }
 
+Value::operator bool() const { return ! isNull(); }
+
 void Value::clear() {
   JSON_ASSERT_MESSAGE(type_ == nullValue || type_ == arrayValue ||
                           type_ == objectValue,

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -881,8 +881,6 @@ bool Value::empty() const {
     return false;
 }
 
-bool Value::operator!() const { return isNull(); }
-
 Value::operator bool() const { return ! isNull(); }
 
 void Value::clear() {


### PR DESCRIPTION
More convenient c++11 way to work with null Json::Value objects then isNull() or operator!
http://en.wikibooks.org/wiki/More_C++_Idioms/Safe_bool#C.2B.2B11
