### PR TITLE
Add copyright information to .py files

### DIFF
--- a/devtools/__init__.py
+++ b/devtools/__init__.py
@@ -1,1 +1,6 @@
+# Copyright 2010 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 # module

--- a/devtools/antglob.py
+++ b/devtools/antglob.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
-# Baptiste Lepilleur, 2009
+# Copyright 2009 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
 from __future__ import print_function
 from dircache import listdir

--- a/devtools/fixeol.py
+++ b/devtools/fixeol.py
@@ -1,3 +1,8 @@
+# Copyright 2010 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 from __future__ import print_function
 import os.path
 

--- a/devtools/tarball.py
+++ b/devtools/tarball.py
@@ -1,3 +1,8 @@
+# Copyright 2010 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 from contextlib import closing
 import os
 import tarfile

--- a/makerelease.py
+++ b/makerelease.py
@@ -1,3 +1,8 @@
+# Copyright 2010 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 """Tag the sandbox for release, make source and doc tarballs.
 
 Requires Python 2.6
@@ -14,6 +19,7 @@ python makerelease.py 0.5.0 0.6.0-dev
 Note: This was for Subversion. Now that we are in GitHub, we do not
 need to build versioned tarballs anymore, so makerelease.py is defunct.
 """
+
 from __future__ import print_function
 import os.path
 import subprocess

--- a/scons-tools/globtool.py
+++ b/scons-tools/globtool.py
@@ -1,3 +1,8 @@
+# Copyright 2009 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 import fnmatch
 import os
 

--- a/scons-tools/srcdist.py
+++ b/scons-tools/srcdist.py
@@ -1,3 +1,8 @@
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 import os
 import os.path
 from fnmatch import fnmatch

--- a/scons-tools/substinfile.py
+++ b/scons-tools/substinfile.py
@@ -1,3 +1,8 @@
+# Copyright 2010 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 import re
 from SCons.Script import *  # the usual scons stuff you get in a SConscript
 import collections

--- a/scons-tools/targz.py
+++ b/scons-tools/targz.py
@@ -1,3 +1,8 @@
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 """tarball
 
 Tool-specific initialization for tarball.

--- a/test/cleantests.py
+++ b/test/cleantests.py
@@ -1,4 +1,10 @@
-# removes all files created during testing
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
+"""Removes all files created during testing."""
+
 import glob
 import os
 

--- a/test/generate_expected.py
+++ b/test/generate_expected.py
@@ -1,3 +1,8 @@
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 from __future__ import print_function
 import glob
 import os.path

--- a/test/pyjsontestrunner.py
+++ b/test/pyjsontestrunner.py
@@ -1,4 +1,11 @@
-# Simple implementation of a json test runner to run the test against json-py.
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
+"""Simple implementation of a json test runner to run the test against
+json-py."""
+
 from __future__ import print_function
 import sys
 import os.path

--- a/test/runjsontests.py
+++ b/test/runjsontests.py
@@ -1,3 +1,8 @@
+# Copyright 2007 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 from __future__ import print_function
 from __future__ import unicode_literals
 from io import open

--- a/test/rununittests.py
+++ b/test/rununittests.py
@@ -1,3 +1,8 @@
+# Copyright 2009 Baptiste Lepilleur
+# Distributed under MIT license, or public domain if desired and
+# recognized in your jurisdiction.
+# See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
+
 from __future__ import print_function
 from __future__ import unicode_literals
 from io import open


### PR DESCRIPTION
This change adds explicit copyright information too python
files files.  The copyright year used in each case is the
date of the first git commit of each file.

The goal is to allow jsoncpp to be integrated into the
chromium source tree which requires license information in
each source file.

fixes #234