### PR TITLE
Add Move constructors

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -67,40 +67,21 @@
 // Storages, and 64 bits integer support is disabled.
 // #define JSON_NO_INT64 1
 
-#if defined(_MSC_VER) // MSVC
-	#if _MSC_VER <= 1200 // MSVC 6
-		// Microsoft Visual Studio 6 only support conversion from __int64 to double
-		// (no conversion from unsigned __int64).
-		#define JSON_USE_INT64_DOUBLE_CONVERSION 1
-		// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
-		// characters in the debug information)
-		// All projects I've ever seen with VS6 were using this globally (not bothering
-		// with pragma push/pop).
-		#pragma warning(disable : 4786)
-	#endif // MSVC 6
+#if defined(_MSC_VER) && _MSC_VER <= 1200 // MSVC 6
+// Microsoft Visual Studio 6 only support conversion from __int64 to double
+// (no conversion from unsigned __int64).
+#define JSON_USE_INT64_DOUBLE_CONVERSION 1
+// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
+// characters in the debug information)
+// All projects I've ever seen with VS6 were using this globally (not bothering
+// with pragma push/pop).
+#pragma warning(disable : 4786)
+#endif // if defined(_MSC_VER)  &&  _MSC_VER < 1200 // MSVC 6
 
-	#if _MSC_VER >= 1500 // MSVC 2008
-		/// Indicates that the following function is deprecated.
-		#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
-	#endif
-
-	#if _MSC_VER >= 1600 // MSVC 2010
-		#define JSON_HAS_RVALUE_REFERENCES
-	#endif 
-#endif // defined(_MSC_VER)
-
-
-#ifdef __clang__
-	#if __has_feature(cxx_rvalue_references)
-		#define JSON_HAS_RVALUE_REFERENCES
-	#endif 
-#elif defined __GNUC__
-	#if defined(__GXX_EXPERIMENTAL_CXX0X__) 
-		#define JSON_HAS_RVALUE_REFERENCES
-	#endif
-#endif // __clang__ || __GNUC__
-
-
+#if defined(_MSC_VER) && _MSC_VER >= 1500 // MSVC 2008
+/// Indicates that the following function is deprecated.
+#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+#endif
 
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -83,6 +83,28 @@
 #define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
 #endif
 
+#ifndef JSON_HAS_RVALUE_REFERENCES
+
+#if defined(_MSC_VER) && _MSC_VER >= 1600 // MSVC >= 2010
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif // MSVC >= 2010
+
+#ifdef __clang__
+#if __has_feature(cxx_rvalue_references)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif 
+#elif defined __GNUC__ // not clang (gcc comes later since clang emulates gcc)
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#define JSON_HAS_RVALUE_REFERENCES 1
+#endif
+#endif // __clang__ || __GNUC__
+
+#endif // not defined JSON_HAS_RVALUE_REFERENCES
+
+#ifndef JSON_HAS_RVALUE_REFERENCES
+#define JSON_HAS_RVALUE_REFERENCES 0
+#endif 
+
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)
 #endif // if !defined(JSONCPP_DEPRECATED)

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -67,21 +67,40 @@
 // Storages, and 64 bits integer support is disabled.
 // #define JSON_NO_INT64 1
 
-#if defined(_MSC_VER) && _MSC_VER <= 1200 // MSVC 6
-// Microsoft Visual Studio 6 only support conversion from __int64 to double
-// (no conversion from unsigned __int64).
-#define JSON_USE_INT64_DOUBLE_CONVERSION 1
-// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
-// characters in the debug information)
-// All projects I've ever seen with VS6 were using this globally (not bothering
-// with pragma push/pop).
-#pragma warning(disable : 4786)
-#endif // if defined(_MSC_VER)  &&  _MSC_VER < 1200 // MSVC 6
+#if defined(_MSC_VER) // MSVC
+	#if _MSC_VER <= 1200 // MSVC 6
+		// Microsoft Visual Studio 6 only support conversion from __int64 to double
+		// (no conversion from unsigned __int64).
+		#define JSON_USE_INT64_DOUBLE_CONVERSION 1
+		// Disable warning 4786 for VS6 caused by STL (identifier was truncated to '255'
+		// characters in the debug information)
+		// All projects I've ever seen with VS6 were using this globally (not bothering
+		// with pragma push/pop).
+		#pragma warning(disable : 4786)
+	#endif // MSVC 6
 
-#if defined(_MSC_VER) && _MSC_VER >= 1500 // MSVC 2008
-/// Indicates that the following function is deprecated.
-#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
-#endif
+	#if _MSC_VER >= 1500 // MSVC 2008
+		/// Indicates that the following function is deprecated.
+		#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+	#endif
+
+	#if _MSC_VER >= 1600 // MSVC 2010
+		#define JSON_HAS_RVALUE_REFERENCES
+	#endif 
+#endif // defined(_MSC_VER)
+
+
+#ifdef __clang__
+	#if __has_feature(cxx_rvalue_references)
+		#define JSON_HAS_RVALUE_REFERENCES
+	#endif 
+#elif defined __GNUC__
+	#if defined(__GXX_EXPERIMENTAL_CXX0X__) 
+		#define JSON_HAS_RVALUE_REFERENCES
+	#endif
+#endif // __clang__ || __GNUC__
+
+
 
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -171,7 +171,7 @@ private:
     CZString(ArrayIndex index);
     CZString(const char* cstr, DuplicationPolicy allocate);
     CZString(const CZString& other);
-#ifdef JSON_HAS_RVALUE_REFERENCES
+#if JSON_HAS_RVALUE_REFERENCES
     CZString(CZString&& other);
 #endif
     ~CZString();
@@ -241,7 +241,7 @@ Json::Value obj_value(Json::objectValue); // {}
   Value(bool value);
   /// Deep copy.
   Value(const Value& other);
-#ifdef JSON_HAS_RVALUE_REFERENCES
+#if JSON_HAS_RVALUE_REFERENCES
   /// Move constructor
   Value(Value&& other);
 #endif 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -171,6 +171,9 @@ private:
     CZString(ArrayIndex index);
     CZString(const char* cstr, DuplicationPolicy allocate);
     CZString(const CZString& other);
+#ifdef JSON_HAS_RVALUE_REFERENCES
+	CZString(CZString&& other);
+#endif
     ~CZString();
     CZString& operator=(CZString other);
     bool operator<(const CZString& other) const;

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -238,6 +238,10 @@ Json::Value obj_value(Json::objectValue); // {}
   Value(bool value);
   /// Deep copy.
   Value(const Value& other);
+#ifdef JSON_HAS_RVALUE_REFERENCES
+  /// Move constructor
+  Value(Value&& other);
+#endif 
   ~Value();
 
   // Deep copy, then swap(other).

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -172,7 +172,7 @@ private:
     CZString(const char* cstr, DuplicationPolicy allocate);
     CZString(const CZString& other);
 #ifdef JSON_HAS_RVALUE_REFERENCES
-	CZString(CZString&& other);
+    CZString(CZString&& other);
 #endif
     ~CZString();
     CZString& operator=(CZString other);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -376,6 +376,15 @@ Value::Value(const Value& other)
   }
 }
 
+#ifdef JSON_HAS_RVALUE_REFERENCES
+// Move constructor
+Value::Value(Value&& other)
+{
+	initBasic(nullValue);
+	swap(other);
+}
+#endif 
+
 Value::~Value() {
   switch (type_) {
   case nullValue:

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -182,6 +182,15 @@ Value::CZString::CZString(const CZString& other)
                      ? noDuplication : duplicate)
                  : other.index_) {}
 
+#ifdef JSON_HAS_RVALUE_REFERENCES
+Value::CZString::CZString(CZString&& other)
+	: cstr_(other.cstr_)
+	, index_(other.index_)
+{
+	other.cstr_ = nullptr;
+}
+#endif
+
 Value::CZString::~CZString() {
   if (cstr_ && index_ == duplicate)
     releaseStringValue(const_cast<char*>(cstr_));

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -184,10 +184,10 @@ Value::CZString::CZString(const CZString& other)
 
 #ifdef JSON_HAS_RVALUE_REFERENCES
 Value::CZString::CZString(CZString&& other)
-	: cstr_(other.cstr_)
-	, index_(other.index_)
+  : cstr_(other.cstr_),
+  index_(other.index_)
 {
-	other.cstr_ = nullptr;
+  other.cstr_ = 0;
 }
 #endif
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -182,7 +182,7 @@ Value::CZString::CZString(const CZString& other)
                      ? noDuplication : duplicate)
                  : other.index_) {}
 
-#ifdef JSON_HAS_RVALUE_REFERENCES
+#if JSON_HAS_RVALUE_REFERENCES
 Value::CZString::CZString(CZString&& other)
   : cstr_(other.cstr_),
   index_(other.index_)
@@ -385,7 +385,7 @@ Value::Value(const Value& other)
   }
 }
 
-#ifdef JSON_HAS_RVALUE_REFERENCES
+#if JSON_HAS_RVALUE_REFERENCES
 // Move constructor
 Value::Value(Value&& other)
 {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1878,6 +1878,23 @@ JSONTEST_FIXTURE(IteratorTest, distance) {
   JSONTEST_ASSERT_STRING_EQUAL("b", str);
 }
 
+struct RValueTest : JsonTest::TestCase {};
+
+JSONTEST_FIXTURE(RValueTest, moveConstruction) {
+	Json::Value json;
+	json["key"] = "value";	
+#ifdef JSON_HAS_RVALUE_REFERENCES
+	Json::Value moved = std::move(json);
+	JSONTEST_ASSERT_EQUAL(Json::nullValue, json); // Doesn't have to be 'null' but I can't find a JSONTEST_ASSERT_NOT_EQUAL
+#else
+	Json::Value moved = json;
+	JSONTEST_ASSERT_EQUAL(Json::objectValue, json.type());
+	JSONTEST_ASSERT_EQUAL(Json::stringValue, json["key"].type());
+#endif
+	JSONTEST_ASSERT_EQUAL(Json::objectValue, moved.type());
+	JSONTEST_ASSERT_EQUAL(Json::stringValue, moved["key"].type());
+}
+
 int main(int argc, const char* argv[]) {
   JsonTest::Runner runner;
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, checkNormalizeFloatingPointStr);
@@ -1926,6 +1943,8 @@ int main(int argc, const char* argv[]) {
   JSONTEST_REGISTER_FIXTURE(runner, CharReaderFailIfExtraTest, commentAfterBool);
 
   JSONTEST_REGISTER_FIXTURE(runner, IteratorTest, distance);
+
+  JSONTEST_REGISTER_FIXTURE(runner, RValueTest, moveConstruction);
 
   return runner.runCommandLine(argc, argv);
 }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1881,18 +1881,14 @@ JSONTEST_FIXTURE(IteratorTest, distance) {
 struct RValueTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE(RValueTest, moveConstruction) {
-	Json::Value json;
-	json["key"] = "value";	
-#ifdef JSON_HAS_RVALUE_REFERENCES
-	Json::Value moved = std::move(json);
-	JSONTEST_ASSERT_EQUAL(Json::nullValue, json); // Doesn't have to be 'null' but I can't find a JSONTEST_ASSERT_NOT_EQUAL
-#else
-	Json::Value moved = json;
-	JSONTEST_ASSERT_EQUAL(Json::objectValue, json.type());
-	JSONTEST_ASSERT_EQUAL(Json::stringValue, json["key"].type());
+#if JSON_HAS_RVALUE_REFERENCES
+  Json::Value json;
+  json["key"] = "value";	
+  Json::Value moved = std::move(json);
+  JSONTEST_ASSERT_EQUAL(Json::nullValue, json); // Doesn't have to be 'null' but I can't find a JSONTEST_ASSERT_NOT_EQUAL
+  JSONTEST_ASSERT_EQUAL(Json::objectValue, moved.type());
+  JSONTEST_ASSERT_EQUAL(Json::stringValue, moved["key"].type());
 #endif
-	JSONTEST_ASSERT_EQUAL(Json::objectValue, moved.type());
-	JSONTEST_ASSERT_EQUAL(Json::stringValue, moved["key"].type());
 }
 
 int main(int argc, const char* argv[]) {


### PR DESCRIPTION
Add move constructors to Json::Value and Json::Value::CZString 

As requested by issue #223: Json::Value should support move semantics


