### PR TITLE
run valgrind in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,20 @@
 # http://about.travis-ci.org/docs/user/build-configuration/
 # This file can be validated on:
 # http://lint.travis-ci.org/
-before_install: sudo apt-get install cmake
+
+#before_install: sudo apt-get install -y cmake
+# cmake is pre-installed in Travis for both linux and osx
+
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq valgrind
+os:
+  - linux
 language: cpp
 compiler:
   - gcc
   - clang
-script: cmake -DJSONCPP_WITH_CMAKE_PACKAGE=$CMAKE_PKG -DBUILD_SHARED_LIBS=$SHARED_LIB -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_MAKE . && make && make jsoncpp_check
+script: ./travis.sh
 env:
   matrix:
     - SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false

--- a/dev.makefile
+++ b/dev.makefile
@@ -26,6 +26,9 @@ test-amalgamate:
 	python3.4 amalgamate.py
 	cd dist; gcc -I. -c jsoncpp.cpp
 
+valgrind:
+	valgrind --error-exitcode=42 --leak-check=full ./build/debug/src/test_lib_json/jsoncpp_test
+
 clean:
 	\rm -rf *.gz *.asc dist/
 

--- a/travis.sh
+++ b/travis.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+# This is called by `.travis.yml` via Travis CI.
+# Travis supplies $TRAVIS_OS_NAME.
+#  http://docs.travis-ci.com/user/multi-os/
+# Our .travis.yml also defines:
+#   - SHARED_LIB=ON/OFF
+#   - STATIC_LIB=ON/OFF
+#   - CMAKE_PKG=ON/OFF
+#   - BUILD_TYPE=release/debug
+#   - VERBOSE_MAKE=false/true
+#   - VERBOSE (set or not)
+
+# -e: fail on error
+# -v: show commands
+# -x: show expanded commands
+set -vex
+
+env | sort
+
+cmake -DJSONCPP_WITH_CMAKE_PACKAGE=$CMAKE_PKG -DBUILD_SHARED_LIBS=$SHARED_LIB -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_VERBOSE_MAKEFILE=$VERBOSE_MAKE .
+make
+
+# Python is not available in Travis for osx.
+#  https://github.com/travis-ci/travis-ci/issues/2320
+if [ "$TRAVIS_OS_NAME" != "osx" ]
+then
+  make jsoncpp_check
+  valgrind --error-exitcode=42 --leak-check=full ./src/test_lib_json/jsoncpp_test
+fi


### PR DESCRIPTION
Because this runs apt-get, it will not work as-is for OSX. So when
we have OSX in Travis, we will have to wrap this somehow. See #250.

Closes #222.