### PR TITLE
Use std::aligned_storage for static JSON null

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -23,17 +23,15 @@
 
 namespace Json {
 
-// This is a walkaround to avoid the static initialization of Value::null.
-// kNull must be word-aligned to avoid crashing on ARM.  We use an alignment of
-// 8 (instead of 4) as a bit of future-proofing.
-#if defined(__ARMEL__)
-#define ALIGNAS(byte_alignment) __attribute__((aligned(byte_alignment)))
-#else
-#define ALIGNAS(byte_alignment)
-#endif
-static const unsigned char ALIGNAS(8) kNull[sizeof(Value)] = { 0 };
-const unsigned char& kNullRef = kNull[0];
-const Value& Value::null = reinterpret_cast<const Value&>(kNullRef);
+//Aligned memory template. Fixes earlier workaround for ARM compilers.
+template<typename T>
+using byte_align_memory = typename std::aligned_storage<sizeof(T),
+      std::alignment_of<T>::value>::type;
+// Initialize memory for Value Object to zero.
+static const byte_align_memory<Value> kNull {};
+static const void* kNullRef = &kNull;
+//Typecast to Json Value Object.
+const Value& Value::null = *static_cast<const Value*>(kNullRef);
 const Value& Value::nullRef = null;
 
 const Int Value::minInt = Int(~(UInt(-1) / 2));

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -29,6 +29,9 @@ using byte_align_memory = typename std::aligned_storage<sizeof(T),
       std::alignment_of<T>::value>::type;
 // Initialize memory for Value Object to zero.
 static const byte_align_memory<Value> kNull {};
+static const void* kNullRef = &kNull;
+//Typecast to Json Value Object.
+const Value& Value::null = *static_cast<const Value*>(kNullRef);
 #else
 // This is a walkaround to avoid the static initialization of Value::null.
 // kNull must be word-aligned to avoid crashing on ARM.  We use an alignment of
@@ -42,9 +45,6 @@ static const unsigned char ALIGNAS(8) kNull[sizeof(Value)] = { 0 };
 const unsigned char& kNullRef = kNull[0];
 const Value& Value::null = reinterpret_cast<const Value&>(kNullRef);
 #endif
-static const void* kNullRef = &kNull;
-//Typecast to Json Value Object.
-const Value& Value::null = *static_cast<const Value*>(kNullRef);
 const Value& Value::nullRef = null;
 
 const Int Value::minInt = Int(~(UInt(-1) / 2));


### PR DESCRIPTION
Patch for https://github.com/open-source-parsers/jsoncpp/issues/184
All test cases pass for x86 and Arm compiler.
