### PR TITLE
Ensure Json::Value::null{,Ref} are initialized at compile time.

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -230,9 +230,12 @@ public:
 #endif // ifndef JSON_USE_CPPTL_SMALLMAP
 #endif // ifndef JSONCPP_DOC_EXCLUDE_IMPLEMENTATION
 
-public:
+private:
   struct StaticInitTag {};
-  Value(StaticInitTag); ///< A special constructor for Value::null.
+  Value(StaticInitTag); ///< A special constructor for Value::kNull.
+  static const Value kNull;
+
+public:
   /** \brief Create a default Value of the given type.
 
     This is a very useful constructor.

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -246,6 +246,8 @@ Json::Value arr_value(Json::arrayValue); // []
 Json::Value obj_value(Json::objectValue); // {}
 \endcode
   */
+  struct StaticInitTag {};
+  Value(StaticInitTag);
   Value(ValueType type = nullValue);
   Value(Int value);
   Value(UInt value);

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -232,7 +232,7 @@ public:
 
 private:
   struct StaticInitTag {};
-  Value(StaticInitTag); ///< A special constructor for Value::kNull.
+  explicit Value(StaticInitTag) {} ///< A special constructor for Value::kNull.
   static const Value kNull;
 
 public:

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -231,6 +231,8 @@ public:
 #endif // ifndef JSONCPP_DOC_EXCLUDE_IMPLEMENTATION
 
 public:
+  struct StaticInitTag {};
+  Value(StaticInitTag); ///< A special constructor for Value::null.
   /** \brief Create a default Value of the given type.
 
     This is a very useful constructor.
@@ -246,8 +248,6 @@ Json::Value arr_value(Json::arrayValue); // []
 Json::Value obj_value(Json::objectValue); // {}
 \endcode
   */
-  struct StaticInitTag {};
-  Value(StaticInitTag);
   Value(ValueType type = nullValue);
   Value(Int value);
   Value(UInt value);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -23,14 +23,6 @@
 
 namespace Json {
 
-// This is a walkaround to avoid the static initialization of Value::null.
-// kNull must be word-aligned to avoid crashing on ARM.  We use an alignment of
-// 8 (instead of 4) as a bit of future-proofing.
-#if defined(__ARMEL__)
-#define ALIGNAS(byte_alignment) __attribute__((aligned(byte_alignment)))
-#else
-#define ALIGNAS(byte_alignment)
-#endif
 static const Value kNull((Value::StaticInitTag()));
 const Value& Value::null = kNull;
 const Value& Value::nullRef = kNull;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -23,9 +23,9 @@
 
 namespace Json {
 
-static const Value kNull((Value::StaticInitTag()));
-const Value& Value::null = kNull;
-const Value& Value::nullRef = kNull;
+const Value  Value::kNull((Value::StaticInitTag()));
+const Value& Value::null = Value::kNull;
+const Value& Value::nullRef = Value::kNull;
 
 const Int Value::minInt = Int(~(UInt(-1) / 2));
 const Int Value::maxInt = Int(UInt(-1) / 2);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -31,9 +31,9 @@ namespace Json {
 #else
 #define ALIGNAS(byte_alignment)
 #endif
-static const unsigned char ALIGNAS(8) kNull[sizeof(Value)] = { 0 };
-const Value& Value::null = reinterpret_cast<const Value&>(kNull[0]);
-const Value& Value::nullRef = reinterpret_cast<const Value&>(kNull[0]);
+static const Value kNull((Value::StaticInitTag()));
+const Value& Value::null = kNull;
+const Value& Value::nullRef = kNull;
 
 const Int Value::minInt = Int(~(UInt(-1) / 2));
 const Int Value::maxInt = Int(UInt(-1) / 2);
@@ -306,6 +306,8 @@ bool Value::CZString::isStaticString() const { return storage_.policy_ == noDupl
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
+
+Value::Value(Value::StaticInitTag) {}
 
 /*! \internal Default constructor initialization must be equivalent to:
  * memset( this, 0, sizeof(Value) )

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -299,8 +299,6 @@ bool Value::CZString::isStaticString() const { return storage_.policy_ == noDupl
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 
-Value::Value(Value::StaticInitTag) {}
-
 /*! \internal Default constructor initialization must be equivalent to:
  * memset( this, 0, sizeof(Value) )
  * This optimization is used in ValueInternalMap fast allocator.

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -32,9 +32,8 @@ namespace Json {
 #define ALIGNAS(byte_alignment)
 #endif
 static const unsigned char ALIGNAS(8) kNull[sizeof(Value)] = { 0 };
-const unsigned char& kNullRef = kNull[0];
-const Value& Value::null = reinterpret_cast<const Value&>(kNullRef);
-const Value& Value::nullRef = null;
+const Value& Value::null = reinterpret_cast<const Value&>(kNull[0]);
+const Value& Value::nullRef = reinterpret_cast<const Value&>(kNull[0]);
 
 const Int Value::minInt = Int(~(UInt(-1) / 2));
 const Int Value::maxInt = Int(UInt(-1) / 2);


### PR DESCRIPTION
Demo:
Compiler: gcc 4.9.2
The following code crashs:

```
#include <json/json.h>
#include <string>

class A {
public:
    A() {
        std::string json = "{ \"x\":3 }\n";
        Json::Value root;
        Json::Reader reader;
        reader.parse(json, root);
    }
};

A a;
int main(){}
```

This bug was introduced in commit 48d9a92a1b4621e69533af543c1f0611abc47ddc.

gcc now puts Json::Value::null{,Ref} into bss section:

```
  $ nm libjsoncpp.a | c++filt | grep Value::null
  0000000000000000 B Json::Value::null
  0000000000000008 B Json::Value::nullRef
```

When we access them in constructor of global objects, since the order of
initialization is unpredictable, we may dereference a null pointer.

After applying this patch, gcc puts them into rodata section:

```
  $ nm libjsoncpp.a | c++filt | grep Value::null
  0000000000000008 R Json::Value::null
  0000000000000010 R Json::Value::nullRef
```
