### PR TITLE
Fix custom includedir & libdir substitution in pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ SET(LIB_SUFFIX "" CACHE STRING "Optional arch-dependent suffix for the library i
 
 SET(RUNTIME_INSTALL_DIR bin
     CACHE PATH "Install dir for executables and dlls")
-SET(ARCHIVE_INSTALL_DIR lib${LIB_SUFFIX}
+SET(ARCHIVE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}
     CACHE PATH "Install dir for static libraries")
-SET(LIBRARY_INSTALL_DIR lib${LIB_SUFFIX}
+SET(LIBRARY_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}
     CACHE PATH "Install dir for shared libraries")
-SET(INCLUDE_INSTALL_DIR include
+SET(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include
     CACHE PATH "Install dir for headers")
 SET(PACKAGE_INSTALL_DIR lib${LIB_SUFFIX}/cmake
     CACHE PATH "Install dir for cmake package config files")

--- a/pkg-config/jsoncpp.pc.in
+++ b/pkg-config/jsoncpp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@LIBRARY_INSTALL_DIR@
-includedir=${prefix}/@INCLUDE_INSTALL_DIR@
+libdir=@LIBRARY_INSTALL_DIR@
+includedir=@INCLUDE_INSTALL_DIR@
 
 Name: jsoncpp
 Description: A C++ library for interacting with JSON


### PR DESCRIPTION
Do not prepend ${prefix} to substituted includedir & libdir
in the pkg-config file -- if the paths are overriden by user, CMake puts
absolute paths there (even if user specifies a relative path). Instead,
use the absolute path provided by CMake and appropriately default
LIBRARY_INSTALL_DIR & INCLUDE_INSTALL_DIR to absolute paths with
${CMAKE_INSTALL_PREFIX} prepended.

Fixes: https://github.com/open-source-parsers/jsoncpp/issues/279