### PR TITLE
Removed locale dependency:

### DIFF
--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -25,14 +25,13 @@ struct Options
 };
 
 static std::string normalizeFloatingPointStr(double value) {
-  char buffer[32];
-#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__)
-  sprintf_s(buffer, sizeof(buffer), "%.16g", value);
-#else
-  snprintf(buffer, sizeof(buffer), "%.16g", value);
-#endif
-  buffer[sizeof(buffer) - 1] = 0;
-  std::string s(buffer);
+  std::stringstream str;
+  // Use stringstream with "C" locale so we always use "." as decimal point.
+  str.imbue(std::locale::classic());
+  str.precision(17);
+  str << value;
+  
+  std::string s = str.str();
   std::string::size_type index = s.find_last_of("eE");
   if (index != std::string::npos) {
     std::string::size_type hasSign =

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -596,37 +596,23 @@ bool Reader::decodeDouble(Token& token) {
 }
 
 bool Reader::decodeDouble(Token& token, Value& decoded) {
-  double value = 0;
-  const int bufferSize = 32;
-  int count;
-  int length = int(token.end_ - token.start_);
-
   // Sanity check to avoid buffer overflow exploits.
-  if (length < 0) {
+  if (int(token.end_ - token.start_) < 0) {
     return addError("Unable to parse token length", token);
   }
 
-  // Avoid using a string constant for the format control string given to
-  // sscanf, as this can cause hard to debug crashes on OS X. See here for more
-  // info:
-  //
-  //     http://developer.apple.com/library/mac/#DOCUMENTATION/DeveloperTools/gcc-4.0.1/gcc/Incompatibilities.html
-  char format[] = "%lf";
+  double value = 0;
+  std::string buffer(token.start_, token.end_);
+  std::stringstream str(buffer);
+  // Use stringstream with "C" locale so we always use "." as decimal point.
+  str.imbue(std::locale::classic());
 
-  if (length <= bufferSize) {
-    Char buffer[bufferSize + 1];
-    memcpy(buffer, token.start_, length);
-    buffer[length] = 0;
-    count = sscanf(buffer, format, &value);
-  } else {
-    std::string buffer(token.start_, token.end_);
-    count = sscanf(buffer.c_str(), format, &value);
+  str >> value;
+  
+  if (str.fail()) {
+    return addError("'" + std::string(token.start_, token.end_) + "' is not a number.", token);
   }
 
-  if (count != 1)
-    return addError("'" + std::string(token.start_, token.end_) +
-                        "' is not a number.",
-                    token);
   decoded = value;
   return true;
 }
@@ -1559,37 +1545,23 @@ bool OurReader::decodeDouble(Token& token) {
 }
 
 bool OurReader::decodeDouble(Token& token, Value& decoded) {
-  double value = 0;
-  const int bufferSize = 32;
-  int count;
-  int length = int(token.end_ - token.start_);
-
   // Sanity check to avoid buffer overflow exploits.
-  if (length < 0) {
+  if (int(token.end_ - token.start_) < 0) {
     return addError("Unable to parse token length", token);
   }
 
-  // Avoid using a string constant for the format control string given to
-  // sscanf, as this can cause hard to debug crashes on OS X. See here for more
-  // info:
-  //
-  //     http://developer.apple.com/library/mac/#DOCUMENTATION/DeveloperTools/gcc-4.0.1/gcc/Incompatibilities.html
-  char format[] = "%lf";
+  double value = 0;
+  std::string buffer(token.start_, token.end_);
+  std::stringstream str(buffer);
+  // Use stringstream with "C" locale so we always use "." as decimal point.
+  str.imbue(std::locale::classic());
 
-  if (length <= bufferSize) {
-    Char buffer[bufferSize + 1];
-    memcpy(buffer, token.start_, length);
-    buffer[length] = 0;
-    count = sscanf(buffer, format, &value);
-  } else {
-    std::string buffer(token.start_, token.end_);
-    count = sscanf(buffer.c_str(), format, &value);
+  str >> value;
+
+  if (str.fail()) {
+    return addError("'" + std::string(token.start_, token.end_) + "' is not a number.", token);
   }
 
-  if (count != 1)
-    return addError("'" + std::string(token.start_, token.end_) +
-                        "' is not a number.",
-                    token);
   decoded = value;
   return true;
 }

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -68,20 +68,6 @@ static inline void uintToString(LargestUInt value, char*& current) {
   } while (value != 0);
 }
 
-/** Change ',' to '.' everywhere in buffer.
- *
- * We had a sophisticated way, but it did not work in WinCE.
- * @see https://github.com/open-source-parsers/jsoncpp/pull/9
- */
-static inline void fixNumericLocale(char* begin, char* end) {
-  while (begin < end) {
-    if (*begin == ',') {
-      *begin = '.';
-    }
-    ++begin;
-  }
-}
-
 } // namespace Json {
 
 #endif // LIB_JSONCPP_JSON_TOOL_H_INCLUDED

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -106,40 +106,23 @@ std::string valueToString(UInt value) {
 #endif // # if defined(JSON_HAS_INT64)
 
 std::string valueToString(double value) {
-  // Allocate a buffer that is more than large enough to store the 16 digits of
-  // precision requested below.
-  char buffer[32];
-  int len = -1;
-
-// Print into the buffer. We need not request the alternative representation
-// that always has a decimal point because JSON doesn't distingish the
-// concepts of reals and integers.
-#if defined(_MSC_VER) && defined(__STDC_SECURE_LIB__) // Use secure version with
-                                                      // visual studio 2005 to
-                                                      // avoid warning.
-#if defined(WINCE)
-  len = _snprintf(buffer, sizeof(buffer), "%.17g", value);
-#else
-  len = sprintf_s(buffer, sizeof(buffer), "%.17g", value);
-#endif
-#else
-  if (isfinite(value)) {
-    len = snprintf(buffer, sizeof(buffer), "%.17g", value);
-  } else {
-    // IEEE standard states that NaN values will not compare to themselves
-    if (value != value) {
-      len = snprintf(buffer, sizeof(buffer), "null");
-    } else if (value < 0) {
-      len = snprintf(buffer, sizeof(buffer), "-1e+9999");
+    if (isfinite(value)) {
+      // Use stringstream with "C" locale so we always use "." as decimal point.
+      std::stringstream str;
+      str.imbue(std::locale::classic());
+      str.precision(17);
+      str << value;
+      return str.str();
     } else {
-      len = snprintf(buffer, sizeof(buffer), "1e+9999");
+      // IEEE standard states that NaN values will not compare to themselves
+      if (value != value) {
+        return std::string("null");
+      } else if (value < 0) {
+        return std::string("-1e+9999");
+      } else {
+        return std::string("1e+9999");
+      }
     }
-    // For those, we do not need to call fixNumLoc, but it is fast.
-  }
-#endif
-  assert(len >= 0);
-  fixNumericLocale(buffer, buffer + len);
-  return buffer;
 }
 
 std::string valueToString(bool value) { return value ? "true" : "false"; }


### PR DESCRIPTION
- use stringstream instead of sprintf/sscanf
- removed fixNumericLocale hack
- some test still fail, this is due to incorrect python test runner.

