### PR TITLE
Allow an optional suffix on the debug library name in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ IF(NOT WIN32)
     ENDIF(NOT CMAKE_BUILD_TYPE)
 ENDIF(NOT WIN32)
 
+SET(DEBUG_LIBNAME_SUFFIX "" CACHE STRING "Optional suffix to append to the library name for a debug build")
 SET(LIB_SUFFIX "" CACHE STRING "Optional arch-dependent suffix for the library installation directory")
 
 SET(RUNTIME_INSTALL_DIR bin

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -2,7 +2,7 @@ if( CMAKE_COMPILER_IS_GNUCXX )
   #Get compiler version.
   execute_process( COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                    OUTPUT_VARIABLE GNUCXX_VERSION )
- 
+
   #-Werror=* was introduced -after- GCC 4.1.2
   if( GNUCXX_VERSION VERSION_GREATER 4.1.2 )
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=strict-aliasing")
@@ -43,7 +43,8 @@ IF(BUILD_SHARED_LIBS)
     ADD_DEFINITIONS( -DJSON_DLL_BUILD )
     ADD_LIBRARY(jsoncpp_lib SHARED ${PUBLIC_HEADERS} ${jsoncpp_sources})
     SET_TARGET_PROPERTIES( jsoncpp_lib PROPERTIES VERSION ${JSONCPP_VERSION} SOVERSION ${JSONCPP_VERSION_MAJOR})
-    SET_TARGET_PROPERTIES( jsoncpp_lib PROPERTIES OUTPUT_NAME jsoncpp )
+    SET_TARGET_PROPERTIES( jsoncpp_lib PROPERTIES OUTPUT_NAME jsoncpp
+                           DEBUG_OUTPUT_NAME jsoncpp${DEBUG_LIBNAME_SUFFIX} )
 
     INSTALL( TARGETS jsoncpp_lib ${INSTALL_EXPORT}
          RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
@@ -61,7 +62,8 @@ ENDIF()
 IF(BUILD_STATIC_LIBS)
     ADD_LIBRARY(jsoncpp_lib_static STATIC ${PUBLIC_HEADERS} ${jsoncpp_sources})
     SET_TARGET_PROPERTIES( jsoncpp_lib_static PROPERTIES VERSION ${JSONCPP_VERSION} SOVERSION ${JSONCPP_VERSION_MAJOR})
-    SET_TARGET_PROPERTIES( jsoncpp_lib_static PROPERTIES OUTPUT_NAME jsoncpp )
+    SET_TARGET_PROPERTIES( jsoncpp_lib_static PROPERTIES OUTPUT_NAME jsoncpp
+                           DEBUG_OUTPUT_NAME jsoncpp${DEBUG_LIBNAME_SUFFIX} )
 
     INSTALL( TARGETS jsoncpp_lib_static ${INSTALL_EXPORT}
          RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}


### PR DESCRIPTION
When compiling as a dependency for other applications it can be useful to keep the release & debug libraries in the same directory. This requires that the library names are different.

The patch adds a CMake option specify a suffix on the debug build and defaults to an empty string to match existing behaviour. 