### PR TITLE
Fix undefined name "sys"

### DIFF
--- a/devtools/fixeol.py
+++ b/devtools/fixeol.py
@@ -5,6 +5,7 @@
 
 from __future__ import print_function
 import os.path
+import sys
 
 def fix_source_eol(path, is_dry_run = True, verbose = True, eol = '\n'):
     """Makes sure that all sources have the specified eol sequence (default: unix)."""


### PR DESCRIPTION
`sys.stderr` is used in an `except` clause of `fix_source_eol()` but it will cause `NameError: name 'sys' is not defined` because the `sys` module is never imported.