### PR TITLE
GCC warning removal for long long

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using GCC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Wno-long-long")
 endif()
 
 IF(JSONCPP_WITH_WARNING_AS_ERROR)


### PR DESCRIPTION
I got below warning message on x86 linux machine :
"jsoncpp-0.10.2-p1/include/json/config.h:100: warning: ISO C++ 1998 does not support ‘long long’"
gcc version 4.4.7 20120313 (Red Hat 4.4.7-4) (GCC)
In reference to 
https://github.com/open-source-parsers/jsoncpp/pull/292
long long is supported in c++-11, for old compilers i.e 0.x.y branch this patch should be merged.