### PR TITLE
fix appveyor 32-bit windows build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ before_build:
     - echo "Running cmake..."
     - cd c:\projects\jsoncpp
     - cmake --version
+    - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
     - if %PLATFORM% == Win32 cmake .
     - if %PLATFORM% == x64 cmake -G "Visual Studio 12 2013 Win64" .
 


### PR DESCRIPTION
* http://help.appveyor.com/discussions/problems/2229-v140-not-found-on-vs2105rc
```
Done Building Project "C:\projects\jsoncpp\jsoncpp.sln" (default targets) -- FAILED.

Build FAILED.

"C:\projects\jsoncpp\jsoncpp.sln" (default target) (1) ->
"C:\projects\jsoncpp\ALL_BUILD.vcxproj.metaproj" (default target) (2) ->
"C:\projects\jsoncpp\ZERO_CHECK.vcxproj" (default target) (3) ->
(PlatformPrepareForBuild target) ->
  C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.Cpp.Platform.targets(64,5): error MSB8020: The build tools for v140 (Platform Toolset = 'v140') cannot be found. To build using the v140 build tools, please install v140 build tools.  Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Upgrade Solution...". [C:\projects\jsoncpp\ZERO_CHECK.vcxproj]
```