### PR TITLE
gcc-4.9, clang (3.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,24 @@
 # to allow C++11, though we are not yet building with -std=c++11
 
 install:
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+# /usr/bin/gcc is 4.6 always, but gcc-X.Y is available.
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+# /usr/bin/clang is our version already, and clang-X.Y does not exist.
+#- if [ "$CXX" = "clang++" ]; then export CXX="clang++-3.7" CC="clang-3.7"; fi
+- echo ${PATH}
+- ls /usr/local
+- ls /usr/local/bin
+- export PATH=/usr/local/bin:/usr/bin:${PATH}
+- echo ${CXX}
+- ${CXX} --version
+- which valgrind
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-4.8
-    - g++-4.8
+    - gcc-4.9
+    - g++-4.9
     - clang
     - valgrind
 os:
@@ -29,6 +39,5 @@ env:
     - SHARED_LIB=ON  STATIC_LIB=ON CMAKE_PKG=ON  BUILD_TYPE=release VERBOSE_MAKE=false
     - SHARED_LIB=OFF STATIC_LIB=ON CMAKE_PKG=OFF BUILD_TYPE=debug   VERBOSE_MAKE=true VERBOSE
 notifications:
-  email:
-    - aaronjjacobs@gmail.com
+  email: false
 sudo: false


### PR DESCRIPTION
Travis CI APT is tricky. We cannot select a clang version if we select a gcc version. But the default clang (3.0) is good enough for now.