### PR TITLE
CZString assignment operator - pass by reference

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -213,7 +213,7 @@ private:
     CZString(char const* str, unsigned length, DuplicationPolicy allocate);
     CZString(CZString const& other);
     ~CZString();
-    CZString& operator=(CZString other);
+    CZString& operator=(CZString& other);
     bool operator<(CZString const& other) const;
     bool operator==(CZString const& other) const;
     ArrayIndex index() const;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -247,7 +247,7 @@ void Value::CZString::swap(CZString& other) {
   std::swap(index_, other.index_);
 }
 
-Value::CZString& Value::CZString::operator=(CZString other) {
+Value::CZString& Value::CZString::operator=(CZString& other) {
   swap(other);
   return *this;
 }


### PR DESCRIPTION
The assignment operator of CZString is not passed by reference. It is reported as issue in static analyser tool.