### PR TITLE
Remove -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,10 +97,10 @@ endif( MSVC )
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # using regular Clang or AppleClang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wconversion -Wshadow -Wno-sign-conversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wno-sign-conversion")
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using GCC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wconversion -Wshadow -Wextra -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wextra -pedantic")
   # not yet ready for -Wsign-conversion
 endif()
 


### PR DESCRIPTION
`-Werror` shouldn't be used in released code since it can cause random build failures on moderate warnings. It also depends on the used toolchain since different toolchains may or may not print the same warnings.