### PR TITLE
Specify float constant as float

### DIFF
--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1254,7 +1254,7 @@ JSONTEST_FIXTURE(ValueTest, nonIntegers) {
 
   // A 16-digit floating point number.
   val = Json::Value(2199023255552000.0f);
-  JSONTEST_ASSERT_EQUAL(float(2199023255552000), val.asFloat());
+  JSONTEST_ASSERT_EQUAL(float(2199023255552000.0f), val.asFloat());
   JSONTEST_ASSERT_STRING_EQUAL("2199023255552000",
                                normalizeFloatingPointStr(val.asString()));
 


### PR DESCRIPTION
Otherwise, on some 32 bit platforms this may not fit into long and compilation will fail:

    src/test_lib_json/main.cpp:1260: error: integer constant is too large for 'long' type