### PR TITLE
Fix missing initialization in Constructor.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -909,6 +909,7 @@ OurFeatures::OurFeatures()
     , allowDroppedNullPlaceholders_(false), allowNumericKeys_(false)
     , allowSingleQuotes_(false)
     , failIfExtra_(false)
+    , rejectDupKeys_(false)
     , allowSpecialFloats_(false)
 {
 }


### PR DESCRIPTION
OurFeatures() Constructor is not initializing variable rejectDupKeys_.