### PR TITLE
json_writer: improve isfinite support on *nix

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -20,8 +20,25 @@
 #include <float.h>
 #define isfinite _finite
 #elif defined(__sun) && defined(__SVR4) //Solaris
+#if !defined(isfinite)
 #include <ieeefp.h>
 #define isfinite finite
+#endif
+#elif defined(_AIX)
+#if !defined(isfinite)
+#include <math.h>
+#define isfinite finite
+#endif
+#elif defined(__hpux)
+#if !defined(isfinite)
+#if defined(__ia64) && !defined(finite)
+#define isfinite(x) ((sizeof(x) == sizeof(float) ? \
+                     _Isfinitef(x) : _IsFinite(x)))
+#else
+#include <math.h>
+#define isfinite finite
+#endif
+#endif
 #else
 #include <cmath>
 #define isfinite std::isfinite


### PR DESCRIPTION
Based on a patches to CMake by:

Ådne Hovda <ahovda@openit.com>:

    commit 7b1cdb00279908cacabada92f8a53e4986465423

    jsoncpp: Provide 'isfinite' implementation on older AIX and HP-UX

    Newer AIX and HP-UX platforms provide 'isfinite' as a <math.h> macro.
    Older versions do not, so add the definition if it is not provided.

Michael Scott <michael.scott@gbgplc.com>:

    commit 9217b678b305d7df7471ba476a81bf28961fdfa3

    jsoncpp: Provide 'isfinite' impl on more HP-UX versions (#15576)

    Some versions of HP-UX do not define 'isfinite' or 'finite' in math.h
    for Itanium when preprocessing with C++, so we have to add the
    definition ourselves instead to map to the internal version.

Joerg Sonnenberger <joerg@bec.de>:

    commit 75644dafe54c21902f14cfe58cb8338b553b69d8

    jsoncpp: Fix compilation as C99 on Solaris

    In C99 mode, Solaris variants may already define isfinite, so check for
    the existence first.