### PR TITLE
Remove defaulted default constructor

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -889,7 +889,6 @@ bool Reader::good() const {
 class OurFeatures {
 public:
   static OurFeatures all();
-  OurFeatures() = default;
   bool allowComments_;
   bool strictRoot_;
   bool allowDroppedNullPlaceholders_;


### PR DESCRIPTION
Fix for issue #374: The defaulted default constructor has no effect, it would not initialize any bool member.