### PR TITLE
Precision

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -133,17 +133,20 @@ std::string valueToString(UInt value) {
 
 #endif // # if defined(JSON_HAS_INT64)
 
-std::string valueToString(double value, bool useSpecialFloats) {
+std::string valueToString(double value, bool useSpecialFloats, int precision) {
   // Allocate a buffer that is more than large enough to store the 16 digits of
   // precision requested below.
   char buffer[32];
   int len = -1;
 
+  char formatString[6];
+  sprintf(formatString, "%%.%dg", precision);
+
   // Print into the buffer. We need not request the alternative representation
   // that always has a decimal point because JSON doesn't distingish the
   // concepts of reals and integers.
   if (isfinite(value)) {
-    len = snprintf(buffer, sizeof(buffer), "%.17g", value);
+    len = snprintf(buffer, sizeof(buffer), formatString, value);
   } else {
     // IEEE standard states that NaN values will not compare to themselves
     if (value != value) {
@@ -160,7 +163,7 @@ std::string valueToString(double value, bool useSpecialFloats) {
   return buffer;
 }
 
-std::string valueToString(double value) { return valueToString(value, false); }
+std::string valueToString(double value) { return valueToString(value, false, 17); }
 
 std::string valueToString(bool value) { return value ? "true" : "false"; }
 
@@ -906,7 +909,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), useSpecialFloats_));
+    pushValue(valueToString(value.asDouble(), useSpecialFloats_, 17));
     break;
   case stringValue:
   {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1675,6 +1675,43 @@ JSONTEST_FIXTURE(ValueTest, specialFloats) {
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 }
 
+JSONTEST_FIXTURE(ValueTest, precision) {
+    Json::StreamWriterBuilder b;
+    b.settings_["precision"] = 5;
+
+    Json::Value v = 100.0/3;
+    std::string expected = "33.333";
+    std::string result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+    
+    v = 0.25000000;
+    expected = "0.25";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    v = 0.2563456;
+    expected = "0.25635";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 1;
+    expected = "0.3";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 17;
+    v = 1234857476305.256345694873740545068;
+    expected = "1234857476305.2563";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 24;
+    v = 0.256345694873740545068;
+    expected = "0.25634569487374054";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+}
+
 struct WriterTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE(WriterTest, dropNullPlaceholders) {
@@ -2489,6 +2526,7 @@ int main(int argc, const char* argv[]) {
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, zeroes);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, zeroesInKeys);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, specialFloats);
+  JSONTEST_REGISTER_FIXTURE(runner, ValueTest, precision);
 
   JSONTEST_REGISTER_FIXTURE(runner, WriterTest, dropNullPlaceholders);
   JSONTEST_REGISTER_FIXTURE(runner, StreamWriterTest, dropNullPlaceholders);


### PR DESCRIPTION
My suggestion on how to fix issue #284. Sorry, it took so long. Stressful work and vacations delayed this.

StreamWriterBuilder has now a setting `precision` that can take values between 0 and 17. Default is always 17 as well as with deprecated classes where there is no option to limit precision.

Also added a small test to test different issues with precision and with changing the precision setting.

I hope this is solving the issue. Let me know if something is missing in your opinion.