### PR TITLE
Remove -pedantic for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wno-sign-conversion")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # using GCC
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wextra -pedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wextra")
   # not yet ready for -Wsign-conversion
 endif()
 


### PR DESCRIPTION
`-pedantic` issues all warnings demanded by strict ISO C/C++; rejecting extensions that do not follow ISO C/C++. Without this option, certain GNU extensions and traditional C/C++ features are supported as well. Is this really intended for building jsoncpp?

For instance, building jsoncpp with the `-pedantic` option fails for musl toolchains on x86 because of an incompatible posix_memalign declaration. However, without `-pedantic` there is no error anymore.

[1] https://gcc.gnu.org/ml/gcc-patches/2015-05/msg01425.html