### PR TITLE
Change ${CMAKE_BINARY_DIR} to ${CMAKE_CURRENT_BINARY_DIR}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ IF(JSONCPP_WITH_PKGCONFIG_SUPPORT)
 		"pkg-config/jsoncpp.pc.in"
 		"pkg-config/jsoncpp.pc"
 		@ONLY)
-	INSTALL(FILES "${CMAKE_BINARY_DIR}/pkg-config/jsoncpp.pc"
+	INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/pkg-config/jsoncpp.pc"
 		DESTINATION "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig")
 ENDIF()
 


### PR DESCRIPTION
- if building as a submodule of another repository, installation of pkg-config files can fail because they may not be in the top-level binary directory

- this seems to happen because the CMake INSTALL command references ${CMAKE_BINARY_DIR}

- changing the INSTALL command to use ${CMAKE_CURRENT_BINARY_DIR} allows CMake to find the files for installation