### PR TITLE
Localize stackDepth to each Reader instance

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -240,6 +240,7 @@ private:
   std::string commentsBefore_;
   Features features_;
   bool collectComments_;
+	int stackDepth_;
 };  // Reader
 
 /** Interface for reading JSON from a char array.

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -43,7 +43,6 @@
 #endif
 
 static int const stackLimit_g = 1000;
-static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
@@ -135,7 +134,7 @@ bool Reader::parse(const char* beginDoc,
     nodes_.pop();
   nodes_.push(&root);
 
-  stackDepth_g = 0;  // Yes, this is bad coding, but options are limited.
+  stackDepth_ = 0;  // Yes, this is bad coding, but options are limited.
   bool successful = readValue();
   Token token;
   skipCommentTokens(token);
@@ -162,8 +161,8 @@ bool Reader::readValue() {
   // But this deprecated class has a security problem: Bad input can
   // cause a seg-fault. This seems like a fair, binary-compatible way
   // to prevent the problem.
-  if (stackDepth_g >= stackLimit_g) throwRuntimeError("Exceeded stackLimit in readValue().");
-  ++stackDepth_g;
+  if (stackDepth_ >= stackLimit_g) throwRuntimeError("Exceeded stackLimit in readValue().");
+  ++stackDepth_;
 
   Token token;
   skipCommentTokens(token);
@@ -237,7 +236,7 @@ bool Reader::readValue() {
     lastValue_ = &currentValue();
   }
 
-  --stackDepth_g;
+  --stackDepth_;
   return successful;
 }
 


### PR DESCRIPTION
Previously it was a global variable, which renders Json::Reader thread unsafe.