### PR TITLE
std::snprintf not part of std for MinGW32 using c++11

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -30,7 +30,9 @@
 #elif defined(__ANDROID__) || defined(__QNXNTO__)
 #define snprintf snprintf
 #elif __cplusplus >= 201103L
+#if !defined(__MINGW32__)
 #define snprintf std::snprintf
+#endif
 #endif
 
 #if defined(__QNXNTO__)

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -57,7 +57,9 @@
 #elif defined(__ANDROID__) || defined(__QNXNTO__)
 #define snprintf snprintf
 #elif __cplusplus >= 201103L
+#if !defined(__MINGW32__)
 #define snprintf std::snprintf
+#endif
 #endif
 
 #if defined(__BORLANDC__)  


### PR DESCRIPTION
Unfortunately MinGW32 (GCC 4.8.1-4) refuses to bulid jsoncpp. Giving the following error:

    jsoncpp\src\lib_json\json_reader.cpp:33:18: error: 'snprintf' is not a member of 'std'
       #define snprintf std::snprintf

This issue has been covered before (#231 and #244). Although this is most likely a bug in MinGW32, but as the project is inactive (and it is still shipped with the Windows build of QtCreator), I propose to add the following if clause here. If MinGW32 is detected std::snprintf is not used, but simply the old C library snprintf instead.