### PR TITLE
std::string -> String

### DIFF
--- a/include/json/thing.h
+++ b/include/json/thing.h
@@ -113,22 +113,6 @@ Json::Thing obj_value(Json::objectThing); // {}
   Thing(double value);
   Thing(const char* value); ///< Copy til first 0. (NULL causes to seg-fault.)
   Thing(const char* begin, const char* end); ///< Copy all, incl zeroes.
-  /** \brief Constructs a value from a static string.
-
-   * Like other value string constructor but do not duplicate the string for
-   * internal storage. The given string must remain alive after the call to this
-   * constructor.
-   * \note This works only for null-terminated strings. (We cannot change the
-   *   size of this class, so we have nowhere to store the length,
-   *   which might be computed later for various operations.)
-   *
-   * Example of usage:
-   * \code
-   * static StaticString foo("some text");
-   * Json::Thing aThing(foo);
-   * \endcode
-   */
-  Thing(const StaticString& value);
   Thing(const String& value); ///< Copy data() til size(). Embedded zeroes too.
   Thing(bool value);
   /// Deep copy.
@@ -265,19 +249,6 @@ Json::Thing obj_value(Json::objectThing); // {}
   /// that name.
   /// \param key may contain embedded nulls.
   const Thing& operator[](const String& key) const;
-  /** \brief Access an object value by name, create a null member if it does not
-   exist.
-
-   * If the object has no entry for that name, then the member name used to store
-   * the new entry is not duplicated.
-   * Example of use:
-   * \code
-   * Json::Thing object;
-   * static const StaticString code("code");
-   * object[code] = 1234;
-   * \endcode
-   */
-  Thing& operator[](const StaticString& key);
   /// Return the member named key if it exist, defaultThing otherwise.
   /// \note deep copy
   Thing get(const char* key, const Thing& defaultThing) const;

--- a/include/json/thing.h
+++ b/include/json/thing.h
@@ -5,7 +5,6 @@
  * Then we will move the Exceptions, Iterators, and Paths here too.
  * For now, we are working on the API we *want*.
  */
-#include <string>
 #include <vector>
 
 // Disable warning C4251: <data member>: <type> needs to have dll-interface to
@@ -53,9 +52,10 @@ namespace Json {
  * but the Value API does *not* check bounds. That is the responsibility
  * of the caller.
  */
+template <String>
 class JSON_API Thing {
 public:
-  typedef std::vector<std::string> Members;
+  typedef std::vector<String> Members;
   //typedef ThingIterator iterator;
   //typedef ThingConstIterator const_iterator;
 
@@ -129,7 +129,7 @@ Json::Thing obj_value(Json::objectThing); // {}
    * \endcode
    */
   Thing(const StaticString& value);
-  Thing(const std::string& value); ///< Copy data() til size(). Embedded zeroes too.
+  Thing(const String& value); ///< Copy data() til size(). Embedded zeroes too.
   Thing(bool value);
   /// Deep copy.
   Thing(const Thing& other);
@@ -159,7 +159,7 @@ Json::Thing obj_value(Json::objectThing); // {}
   int compare(const Thing& other) const;
 
   const char* asCString() const; ///< Embedded zeroes could cause you trouble!
-  std::string asString() const; ///< Embedded zeroes are possible.
+  String asString() const; ///< Embedded zeroes are possible.
   /** Get raw char* of string-value.
    *  \return false if !string. (Seg-fault if str or end are NULL.)
    */
@@ -260,11 +260,11 @@ Json::Thing obj_value(Json::objectThing); // {}
   const Thing& operator[](const char* key) const;
   /// Access an object value by name, create a null member if it does not exist.
   /// \param key may contain embedded nulls.
-  Thing& operator[](const std::string& key);
+  Thing& operator[](const String& key);
   /// Access an object value by name, returns null if there is no member with
   /// that name.
   /// \param key may contain embedded nulls.
-  const Thing& operator[](const std::string& key) const;
+  const Thing& operator[](const String& key) const;
   /** \brief Access an object value by name, create a null member if it does not
    exist.
 
@@ -288,7 +288,7 @@ Json::Thing obj_value(Json::objectThing); // {}
   /// Return the member named key if it exist, defaultThing otherwise.
   /// \note deep copy
   /// \param key may contain embedded nulls.
-  Thing get(const std::string& key, const Thing& defaultThing) const;
+  Thing get(const String& key, const Thing& defaultThing) const;
   /// Most general and efficient version of isMember()const, get()const,
   /// and operator[]const
   /// \note As stated elsewhere, behavior is undefined if (end-begin) >= 2^30
@@ -308,7 +308,7 @@ Json::Thing obj_value(Json::objectThing); // {}
   /// Same as removeMember(const char*)
   /// \param key may contain embedded nulls.
   /// \deprecated
-  Thing removeMember(const std::string& key);
+  Thing removeMember(const String& key);
   /// Same as removeMember(const char* begin, const char* end, Thing* removed),
   /// but 'key' is null-terminated.
   bool removeMember(const char* key, Thing* removed);
@@ -318,8 +318,8 @@ Json::Thing obj_value(Json::objectThing); // {}
       \param key may contain embedded nulls.
       \return true iff removed (no exceptions)
   */
-  bool removeMember(std::string const& key, Thing* removed);
-  /// Same as removeMember(std::string const& key, Thing* removed)
+  bool removeMember(String const& key, Thing* removed);
+  /// Same as removeMember(String const& key, Thing* removed)
   bool removeMember(const char* begin, const char* end, Thing* removed);
   /** \brief Remove the indexed array element.
 
@@ -334,8 +334,8 @@ Json::Thing obj_value(Json::objectThing); // {}
   bool isMember(const char* key) const;
   /// Return true if the object has a member named key.
   /// \param key may contain embedded nulls.
-  bool isMember(const std::string& key) const;
-  /// Same as isMember(std::string const& key)const
+  bool isMember(const String& key) const;
+  /// Same as isMember(String const& key)const
   bool isMember(const char* begin, const char* end) const;
 
   /// \brief Return a list of the member names.
@@ -346,17 +346,17 @@ Json::Thing obj_value(Json::objectThing); // {}
   Members getMemberNames() const;
 
   /// \deprecated Always pass len.
-  JSONCPP_DEPRECATED("Use setComment(std::string const&) instead.")
+  JSONCPP_DEPRECATED("Use setComment(String const&) instead.")
   void setComment(const char* comment, CommentPlacement placement);
   /// Comments must be //... or /* ... */
   void setComment(const char* comment, size_t len, CommentPlacement placement);
   /// Comments must be //... or /* ... */
-  void setComment(const std::string& comment, CommentPlacement placement);
+  void setComment(const String& comment, CommentPlacement placement);
   bool hasComment(CommentPlacement placement) const;
   /// Include delimiters and embedded newlines.
-  std::string getComment(CommentPlacement placement) const;
+  String getComment(CommentPlacement placement) const;
 
-  std::string toStyledString() const;
+  String toStyledString() const;
 
   const_iterator begin() const;
   const_iterator end() const;


### PR DESCRIPTION
Template `std::string` as `String`.

Maybe this is pointless? The issue is not so much the representation of the JSON strings in the API, but rather of _serialization_. I want to allow users to specify how we translate between internal `char*` and the public representation. Users should be able to supply their own converters:

``` cpp
template<>
fromJson<String>(char const* beg, char const* end, String* result) {
  ...
}
template<>
toJson<String>(String const& input, (*alloc)(size_t n), char const** result) {
}
```

We can provide defaults for `std::string`, but our default would not handle UTF-32, e.g.

What to you think? (See #423.)
