### PR TITLE
Remove override keyword from dtors

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -333,7 +333,7 @@ public:
   Json::Value settings_;
 
   CharReaderBuilder();
-  ~CharReaderBuilder() override;
+  virtual ~CharReaderBuilder();
 
   CharReader* newCharReader() const override;
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -40,7 +40,7 @@ namespace Json {
 class JSON_API Exception : public std::exception {
 public:
   Exception(std::string const& msg);
-  ~Exception() throw() override;
+  virtual ~Exception() throw();
   char const* what() const throw() override;
 protected:
   std::string msg_;

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -112,7 +112,7 @@ public:
   Json::Value settings_;
 
   StreamWriterBuilder();
-  ~StreamWriterBuilder() override;
+  virtual ~StreamWriterBuilder();
 
   /**
    * \throw std::exception if something goes wrong (e.g. invalid settings)
@@ -158,7 +158,7 @@ class JSON_API FastWriter : public Writer {
 
 public:
   FastWriter();
-  ~FastWriter() override {}
+  virtual ~FastWriter() {}
 
   void enableYAMLCompatibility();
 
@@ -210,7 +210,7 @@ private:
 class JSON_API StyledWriter : public Writer {
 public:
   StyledWriter();
-  ~StyledWriter() override {}
+  virtaul ~StyledWriter() {}
 
 public: // overridden from Writer
   /** \brief Serialize a Value in <a HREF="http://www.json.org">JSON</a> format.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -210,7 +210,7 @@ private:
 class JSON_API StyledWriter : public Writer {
 public:
   StyledWriter();
-  virtaul ~StyledWriter() {}
+  virtual ~StyledWriter() {}
 
 public: // overridden from Writer
   /** \brief Serialize a Value in <a HREF="http://www.json.org">JSON</a> format.


### PR DESCRIPTION
This is to silent issues reported in https://github.com/open-source-parsers/jsoncpp/issues/410