### PR TITLE
Supporting GCC 6.0

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -62,7 +62,7 @@ static inline bool InRange(double d, T min, U max) {
 }
 #else  // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
 static inline double integerToDouble(Json::UInt64 value) {
-  return static_cast<double>(Int64(value / 2)) * 2.0 + Int64(value & 1);
+  return static_cast<double>(Int64(value / 2)) * 2.0 + static_cast<double>(Int64(value & 1));
 }
 
 template <typename T> static inline double integerToDouble(T value) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -39,7 +39,7 @@ static inline double uint64ToDouble(Json::UInt64 value) {
 #else  // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
 static inline double uint64ToDouble(Json::UInt64 value) {
   return static_cast<double>(Json::Int64(value / 2)) * 2.0 +
-         Json::Int64(value & 1);
+         static_cast<double>(Json::Int64(value & 1));
 }
 #endif // if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
 


### PR DESCRIPTION
This patch is also needed to build success for GCC 6.0.
Refer issue - https://github.com/open-source-parsers/jsoncpp/issues/411