### PR TITLE
Use macro for `override`

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -77,6 +77,12 @@
 
 #endif // defined(_MSC_VER)
 
+#if defined(_MSC_VER) && _MSC_VER <= 1600 // MSVC <= 2010
+# define JSONCPP_OVERRIDE
+#else
+# define JSONCPP_OVERRIDE override
+#endif // MSVC <= 2010
+
 
 #ifndef JSON_HAS_RVALUE_REFERENCES
 

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -333,9 +333,9 @@ public:
   Json::Value settings_;
 
   CharReaderBuilder();
-  ~CharReaderBuilder() override;
+  ~CharReaderBuilder() JSONCPP_OVERRIDE;
 
-  CharReader* newCharReader() const override;
+  CharReader* newCharReader() const JSONCPP_OVERRIDE;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -53,8 +53,8 @@ namespace Json {
 class JSON_API Exception : public std::exception {
 public:
   Exception(JSONCPP_STRING const& msg);
-  ~Exception() throw() override;
-  char const* what() const throw() override;
+  ~Exception() throw() JSONCPP_OVERRIDE;
+  char const* what() const throw() JSONCPP_OVERRIDE;
 protected:
   JSONCPP_STRING msg_;
 };

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -112,12 +112,12 @@ public:
   Json::Value settings_;
 
   StreamWriterBuilder();
-  ~StreamWriterBuilder() override;
+  ~StreamWriterBuilder() JSONCPP_OVERRIDE;
 
   /**
    * \throw std::exception if something goes wrong (e.g. invalid settings)
    */
-  StreamWriter* newStreamWriter() const override;
+  StreamWriter* newStreamWriter() const JSONCPP_OVERRIDE;
 
   /** \return true if 'settings' are legal and consistent;
    *   otherwise, indicate bad settings via 'invalid'.
@@ -158,7 +158,7 @@ class JSON_API FastWriter : public Writer {
 
 public:
   FastWriter();
-  ~FastWriter() override {}
+  ~FastWriter() JSONCPP_OVERRIDE {}
 
   void enableYAMLCompatibility();
 
@@ -172,7 +172,7 @@ public:
   void omitEndingLineFeed();
 
 public: // overridden from Writer
-  JSONCPP_STRING write(const Value& root) override;
+  JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
 private:
   void writeValue(const Value& value);
@@ -210,14 +210,14 @@ private:
 class JSON_API StyledWriter : public Writer {
 public:
   StyledWriter();
-  ~StyledWriter() override {}
+  ~StyledWriter() JSONCPP_OVERRIDE {}
 
 public: // overridden from Writer
   /** \brief Serialize a Value in <a HREF="http://www.json.org">JSON</a> format.
    * \param root Value to serialize.
    * \return String containing the JSON document that represents the root value.
    */
-  JSONCPP_STRING write(const Value& root) override;
+  JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
 private:
   void writeValue(const Value& value);

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1907,7 +1907,7 @@ public:
   {}
   bool parse(
       char const* beginDoc, char const* endDoc,
-      Value* root, JSONCPP_STRING* errs) override {
+      Value* root, JSONCPP_STRING* errs) JSONCPP_OVERRIDE {
     bool ok = reader_.parse(beginDoc, endDoc, *root, collectComments_);
     if (errs) {
       *errs = reader_.getFormattedErrorMessages();

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -839,7 +839,7 @@ struct BuiltStyledStreamWriter : public StreamWriter
       JSONCPP_STRING const& endingLineFeedSymbol,
       bool useSpecialFloats,
       unsigned int precision);
-  int write(Value const& root, JSONCPP_OSTREAM* sout) override;
+  int write(Value const& root, JSONCPP_OSTREAM* sout) JSONCPP_OVERRIDE;
 private:
   void writeValue(Value const& value);
   void writeArrayValue(Value const& value);

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -271,8 +271,8 @@ TestResult& checkStringEqual(TestResult& result,
     }                                                                          \
                                                                                \
   public: /* overidden from TestCase */                                        \
-    const char* testName() const override { return #FixtureType "/" #name; }    \
-    void runTestCase() override;                                                \
+    const char* testName() const JSONCPP_OVERRIDE { return #FixtureType "/" #name; }    \
+    void runTestCase() JSONCPP_OVERRIDE;                                                \
   };                                                                           \
                                                                                \
   void Test##FixtureType##name::runTestCase()


### PR DESCRIPTION
b/c MS VS2010 is supposed to be C++11 but does not fulfull
the entire standard.

Resolves #410.
Re: #430.