### PR TITLE
Add CMAKE_CXX_FLAGS for Intel compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,13 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   if (JSONCPP_WITH_STRICT_ISO AND NOT JSONCPP_WITH_WARNING_AS_ERROR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
   endif ()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  # using Intel compiler
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wconversion -Wshadow -Wextra -Werror=conversion")
+
+  if (JSONCPP_WITH_STRICT_ISO AND NOT JSONCPP_WITH_WARNING_AS_ERROR)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
+  endif ()
 endif()
 
 find_program(CCACHE_FOUND ccache)


### PR DESCRIPTION
The current CMakeLists.txt can't be used with the Intel compiler, because it relies on setting the necessary -std=c++11 switch in a compiler detection block based on `CMAKE_CXX_COMPILER_ID`.

The Intel compiler accepts the same warnings options as gcc (see [here](https://software.intel.com/en-us/node/523320)--link for v.15 of the compiler which is less recent than the current v.16, but as far as I know nothing significant has changed here), so I have copied the same `-W` flags used for gcc.

The result compiles and builds correctly, although it gives a number of compatibility and portability warnings that I don't see when compiling with Apple Clang.