### PR TITLE
Update json_reader.cpp

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -44,8 +44,8 @@
 #pragma warning(disable : 4996)
 #endif
 
-static int const stackLimit_g = 1000;
-static int       stackDepth_g = 0;  // see readValue()
+thread_local static int const stackLimit_g = 1000;
+thread_local static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 


### PR DESCRIPTION
Fix a race condition in the JSON parser when called from multiple threads.

Tested with gcc 5.3.1 (fails without the fix, succeeds with the fix).