### PR TITLE
Use override keyword with Visual Studio.

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -80,7 +80,9 @@
 // In c++11 the override keyword allows you to explicity define that a function
 // is intended to override the base-class version.  This makes the code more
 // managable and fixes a set of common hard-to-find bugs.
-#if __cplusplus >= 201103L
+#if __cplusplus >= 201103L 
+# define JSONCPP_OVERRIDE override
+#elif defined(_MSC_VER) && _MSC_VER > 1600
 # define JSONCPP_OVERRIDE override
 #else
 # define JSONCPP_OVERRIDE


### PR DESCRIPTION
On Visual Studio 2015 the macro `__cplusplus=199711L` (see http://rextester.com/CDCA6582), so the `override` keyword won't be used even though it is available. This adds an additional check to ensure the `override` keyword is used with recent versions of Visual Studio.