### PR TITLE
general compile error and warning fixes

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -24,9 +24,9 @@
 #define JSON_USE_EXCEPTION 1
 #endif
 
-/// If defined, indicates that the source file is amalgated
+/// If defined, indicates that the source file is amalgamated
 /// to prevent private header inclusion.
-/// Remarks: it is automatically defined in the generated amalgated header.
+/// Remarks: it is automatically defined in the generated amalgamated header.
 // #define JSON_IS_AMALGAMATION
 
 #ifdef JSON_IN_CPPTL

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <set>
 #include <limits>
+#include <stdio.h>
+#include <string.h>
 
 #if defined(_MSC_VER)
 #if !defined(WINCE) && defined(__STDC_SECURE_LIB__) && _MSC_VER >= 1500 // VC++ 9.0 and above 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -18,6 +18,7 @@
 #endif
 #include <cstddef> // size_t
 #include <algorithm> // min()
+#include <string.h>
 
 #define JSON_ASSERT_UNREACHABLE assert(false)
 
@@ -190,6 +191,7 @@ static inline void releaseStringValue(char* value, unsigned) {
 
 namespace Json {
 
+#if JSON_USE_EXCEPTION
 Exception::Exception(JSONCPP_STRING const& msg)
   : msg_(msg)
 {}
@@ -213,6 +215,7 @@ JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg)
 {
   throw LogicError(msg);
 }
+#endif
 
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -15,6 +15,8 @@
 #include <cassert>
 #include <cstring>
 #include <cstdio>
+#include <stdio.h>
+#include <string.h>
 
 #if defined(_MSC_VER) && _MSC_VER >= 1200 && _MSC_VER < 1800 // Between VC++ 6.0 and VC++ 11.0
 #include <float.h>
@@ -42,7 +44,9 @@
 #else
 #include <cmath>
 #if !(defined(__QNXNTO__)) // QNX already defines isfinite
+#ifndef isfinite
 #define isfinite std::isfinite
+#endif
 #endif
 #endif
 
@@ -143,7 +147,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
   int len = -1;
 
   char formatString[6];
-  sprintf(formatString, "%%.%dg", precision);
+  sprintf(formatString, "%%.%ug", precision);
 
   // Print into the buffer. We need not request the alternative representation
   // that always has a decimal point because JSON doesn't distingish the


### PR DESCRIPTION
. fix a bunch of missing string and stdio headers (really weird that these crept into the code...?)
. typo amalgated -> amalgamated
. add #if JSON_USE_EXCEPTION guard around exception-throwing code
. change format string "%%.%dg" to "%%.%ug" for an unsigned int
