### PR TITLE
Fix compilation errors for downstream projects caused by incorrect pkconfig paths

### DIFF
--- a/pkg-config/jsoncpp.pc.in
+++ b/pkg-config/jsoncpp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=@LIBRARY_INSTALL_DIR@
-includedir=@INCLUDE_INSTALL_DIR@
+libdir=${exec_prefix}/@LIBRARY_INSTALL_DIR@
+includedir=${prefix}/@INCLUDE_INSTALL_DIR@
 
 Name: jsoncpp
 Description: A C++ library for interacting with JSON


### PR DESCRIPTION
Recent commit 911e2b0fea ("By default use \<prefix\> relative paths when
installing") introduced relative install paths in CMake.  But this
interacts badly with commit e6f1cffdd3 from a year ago: now, the paths in
`pkgconfig/jsoncpp.pc` are relative, which is incorrect.

Before 911e2b0fea (1.7.2 on Archlinux), this was correct:

    $ head -4 /usr/lib/pkgconfig/jsoncpp.pc
    prefix=/usr
    exec_prefix=${prefix}
    libdir=/usr/lib
    includedir=/usr/include

After 911e2b0fea (1.7.3 on Archlinux), this is now incorrect:

    $ head -4 /usr/lib/pkgconfig/jsoncpp.pc
    prefix=/usr
    exec_prefix=${prefix}
    libdir=lib
    includedir=include

This change causes hard-to-debug compilation errors for projects that
depend on jsoncpp, for instance:

    CXXLD    libring.la
    /tmp/ring-daemon/src/ring-daemon/src/../libtool: line 7486: cd: lib: No such file or directory
    libtool:   error: cannot determine absolute directory name of 'lib'
    make[3]: *** [Makefile:679: libring.la] Error 1

This is because jsoncpp contributes `-Llib -ljsoncpp` to the LDFLAGS, via
the pkg-config machinery.  Notice the relative path in `-Llib`.

To fix this, simply revert commit e6f1cffdd3 ("Fix custom includedir &
libdir substitution in pkg-config").  The change in 911e2b0fea should have
the same effect.

See #279, #470 for references.