### PR TITLE
Change Value::append() to take its arg by value, then std::move it to its final destination.

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -434,7 +434,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /// \brief Append value to array at the end.
   ///
   /// Equivalent to jsonvalue[jsonvalue.size()] = value;
-  Value& append(const Value& value);
+  Value& append(Value value);
 
   /// Access an object value by name, create a null member if it does not exist.
   /// \note Because of our implementation, keys are limited to 2^30 -1 chars.

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1120,7 +1120,7 @@ Value const& Value::operator[](CppTL::ConstString const& key) const
 }
 #endif
 
-Value& Value::append(const Value& value) { return (*this)[size()] = value; }
+Value& Value::append(Value value) { return (*this)[size()] = std::move(value); }
 
 Value Value::get(char const* key, char const* cend, Value const& defaultValue) const
 {


### PR DESCRIPTION
As things are, the comment ```Equivalent to jsonvalue[jsonvalue.size()] = value;``` is not true because ```append()``` will sometimes make an extra copy.

Example: ```v.append("hello")``` is more expensive than ```v[v.size()] = "hello"```

By taking its argument by value and then ```std::move```ing that arg to the right place, we can actually make the two forms equivalent.

Tested: passes all existing tests.