### PR TITLE
Added support for omitting the last newline in the StyledWriter

### DIFF
--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -219,6 +219,8 @@ public: // overridden from Writer
    */
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
+  void omitEndingLineFeed();
+
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
@@ -241,6 +243,7 @@ private:
   unsigned int rightMargin_;
   unsigned int indentSize_;
   bool addChildValues_;
+  bool omitEndingLineFeed_;
 };
 
 /** \brief Writes a Value in <a HREF="http://www.json.org">JSON</a> format in a

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -394,7 +394,9 @@ void FastWriter::writeValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledWriter::StyledWriter()
-    : rightMargin_(74), indentSize_(3), addChildValues_() {}
+    : rightMargin_(74), indentSize_(3), addChildValues_(), omitEndingLineFeed_(false) {}
+    
+void StyledWriter::omitEndingLineFeed() { omitEndingLineFeed_ = true; }
 
 JSONCPP_STRING StyledWriter::write(const Value& root) {
   document_ = "";
@@ -403,7 +405,8 @@ JSONCPP_STRING StyledWriter::write(const Value& root) {
   writeCommentBeforeValue(root);
   writeValue(root);
   writeCommentAfterValueOnSameLine(root);
-  document_ += "\n";
+  if (!omitEndingLineFeed_)
+    document_ += "\n";
   return document_;
 }
 


### PR DESCRIPTION
I came across a use case where it is not desirable to have a newline at the end when using the StyledWriter. Similarly to the FastWriter, I added the option to omit that newline. This is disabled by default, hence it should not break any existing usage of the StyledWriter.