### PR TITLE
Add RPATH to dynamic library build on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,11 @@ IF(NOT WIN32)
     ENDIF()
 ENDIF()
 
+# Enable runtime search path support for dynamic libraries on OSX
+IF(APPLE)
+    SET(CMAKE_MACOSX_RPATH 1)
+ENDIF()
+
 SET(DEBUG_LIBNAME_SUFFIX "" CACHE STRING "Optional suffix to append to the library name for a debug build")
 SET(LIB_SUFFIX "" CACHE STRING "Optional arch-dependent suffix for the library installation directory")
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -46,6 +46,11 @@ IF(BUILD_SHARED_LIBS)
     SET_TARGET_PROPERTIES( jsoncpp_lib PROPERTIES OUTPUT_NAME jsoncpp
                            DEBUG_OUTPUT_NAME jsoncpp${DEBUG_LIBNAME_SUFFIX} )
 
+    # Set library's runtime search path on OSX
+    IF(APPLE)
+        SET_TARGET_PROPERTIES( jsoncpp_lib PROPERTIES INSTALL_RPATH "@loader_path/." )
+    ENDIF()
+
     INSTALL( TARGETS jsoncpp_lib ${INSTALL_EXPORT}
          RUNTIME DESTINATION ${RUNTIME_INSTALL_DIR}
          LIBRARY DESTINATION ${LIBRARY_INSTALL_DIR}


### PR DESCRIPTION
Fix #534 