### PR TITLE
Include stdint.h necessary for int64_t and uint64_t

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -7,6 +7,7 @@
 #define JSON_CONFIG_H_INCLUDED
 #include <stddef.h>
 #include <string> //typdef String
+#include <stdint.h> //typedef int64_t, uint64_t
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1


### PR DESCRIPTION
Otherwise failures like these one can happen during the configure phase
of other applications that use jsoncpp, like upmpdcli for instance:

checking jsoncpp/json/json.h usability... yes
checking jsoncpp/json/json.h presence... yes
checking for jsoncpp/json/json.h... yes
configure: error: libjsoncpp not found.

And this is the actual problem that you can see in config.log:

configure:5233: checking for jsoncpp/json/json.h
configure:5233: result: yes
configure:5259: /usr/bin/mipsel-linux-g++ -o conftest conftest.cpp
-lmicrohttpd -lmpdclient -lpthread  -ljsoncpp >&5
In file included from /usr/include/jsoncpp/json/autolink.h:9:0,
                 from /usr/include/jsoncpp/json/json.h:9,
                 from conftest.cpp:26:
/usr/include/jsoncpp/json/config.h:155:9: error: 'int64_t' does not name
a type
 typedef int64_t Int64;
         ^
/usr/include/jsoncpp/json/config.h:156:9: error: 'uint64_t' does not
name a type
 typedef uint64_t UInt64;
         ^

Signed-off-by: Vicente Olivert Riera <Vincent.Riera@imgtec.com>