### PR TITLE
include stdint.h for using int64_t and uint64_t

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -6,7 +6,8 @@
 #ifndef JSON_CONFIG_H_INCLUDED
 #define JSON_CONFIG_H_INCLUDED
 #include <stddef.h>
-#include <string> //typdef String
+#include <string> //typedef String
+#include <stdint.h> //typedef int64_t uint64_t
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1


### PR DESCRIPTION
Linux needs this header to use int64_t and uint64_t