### PR TITLE
Rename variable empty to emptyString

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -343,7 +343,7 @@ bool Value::CZString::isStaticString() const { return storage_.policy_ == noDupl
  * This optimization is used in ValueInternalMap fast allocator.
  */
 Value::Value(ValueType vtype) {
-  static char const empty[] = "";
+  static char const emptyString[] = "";
   initBasic(vtype);
   switch (vtype) {
   case nullValue:
@@ -357,7 +357,7 @@ Value::Value(ValueType vtype) {
     break;
   case stringValue:
     // allocated_ == false, so this is safe.
-    value_.string_ = const_cast<char*>(static_cast<char const*>(empty));
+    value_.string_ = const_cast<char*>(static_cast<char const*>(emptyString));
     break;
   case arrayValue:
   case objectValue:


### PR DESCRIPTION
Rename variable empty to emptyString in Value constructor to avoid shadowing of Value::empty().

GCC 4.8 produces the warning about this:
lib_json/json_value.cpp: In constructor ‘Json::Value::Value(Json::ValueType)’:
lib_json/json_value.cpp:346:27: warning: declaration of ‘empty’ shadows a member of 'this' [-Wshadow]