### PR TITLE
Check for locale support in CMake

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -9,6 +9,34 @@ if( CMAKE_COMPILER_IS_GNUCXX )
   endif()
 endif( CMAKE_COMPILER_IS_GNUCXX )
 
+include(CheckIncludeFileCXX)
+include(CheckTypeSize)
+include(CheckStructHasMember)
+include(CheckCXXSymbolExists)
+
+check_include_file_cxx(clocale HAVE_CLOCALE)
+check_cxx_symbol_exists(localeconv clocale HAVE_LOCALECONV)
+
+if(CMAKE_VERSION VERSION_LESS 3.0.0)
+	# The "LANGUAGE CXX" parameter is not supported in CMake versions below 3,
+	# so the C compiler and header has to be used.
+	check_include_file(locale.h HAVE_LOCALE_H)
+	set(CMAKE_EXTRA_INCLUDE_FILES locale.h)
+	check_type_size("struct lconv" LCONV_SIZE)
+	unset(CMAKE_EXTRA_INCLUDE_FILES)
+	check_struct_has_member("struct lconv" decimal_point locale.h HAVE_DECIMAL_POINT)
+else()
+	set(CMAKE_EXTRA_INCLUDE_FILES clocale)
+	check_type_size(lconv LCONV_SIZE LANGUAGE CXX)
+	unset(CMAKE_EXTRA_INCLUDE_FILES)
+	check_struct_has_member(lconv decimal_point clocale HAVE_DECIMAL_POINT LANGUAGE CXX)
+endif()
+
+if(NOT (HAVE_CLOCALE AND HAVE_LCONV_SIZE AND HAVE_DECIMAL_POINT AND HAVE_LOCALECONV))
+	message(WARNING "Locale functionality is not supported")
+	add_definitions(-DNO_LOCALE_SUPPORT)
+endif()
+
 SET( JSONCPP_INCLUDE_DIR ../../include )
 
 SET( PUBLIC_HEADERS

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 if(NOT (HAVE_CLOCALE AND HAVE_LCONV_SIZE AND HAVE_DECIMAL_POINT AND HAVE_LOCALECONV))
 	message(WARNING "Locale functionality is not supported")
-	add_definitions(-DNO_LOCALE_SUPPORT)
+	add_definitions(-DJSONCPP_NO_LOCALE_SUPPORT)
 endif()
 
 SET( JSONCPP_INCLUDE_DIR ../../include )

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -6,7 +6,13 @@
 #ifndef LIB_JSONCPP_JSON_TOOL_H_INCLUDED
 #define LIB_JSONCPP_JSON_TOOL_H_INCLUDED
 
-#ifndef NO_LOCALE_SUPPORT
+
+// Also support old flag NO_LOCALE_SUPPORT
+#ifdef NO_LOCALE_SUPPORT
+#define JSONCPP_NO_LOCALE_SUPPORT
+#endif
+
+#ifndef JSONCPP_NO_LOCALE_SUPPORT
 #include <clocale>
 #endif
 
@@ -18,7 +24,7 @@
 
 namespace Json {
 static char getDecimalPoint() {
-#ifdef NO_LOCALE_SUPPORT
+#ifdef JSONCPP_NO_LOCALE_SUPPORT
   return '\0';
 #else
   struct lconv* lc = localeconv();


### PR DESCRIPTION
This should improve #527 by checking for locale support at configure time.

Example output from our Android build with this change:
```
-- Looking for C++ include clocale
-- Looking for C++ include clocale - found
-- Check size of lconv
-- Check size of lconv - done
-- Performing Test HAVE_DECIMAL_POINT
-- Performing Test HAVE_DECIMAL_POINT - Failed
-- Looking for localeconv
-- Looking for localeconv - not found
CMake Warning at third_party/jsoncpp/src/lib_json/CMakeLists.txt:25 (message):
  Locale functionality is not supported
```

I would also like to suggest changing `NO_LOCALE_SUPPORT` to `JSONCPP_NO_LOCALE_SUPPORT` as to not clutter the global namespace. But this would break builds relying on `NO_LOCALE_SUPPORT`, so I didn't implement it.