### PR TITLE
change throw() to noexcept to conform to c++11

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -83,10 +83,16 @@
 // managable and fixes a set of common hard-to-find bugs.
 #if __cplusplus >= 201103L
 # define JSONCPP_OVERRIDE override
-#elif defined(_MSC_VER) && _MSC_VER > 1600
+# define JSONCPP_NOEXCEPT noexcept
+#elif defined(_MSC_VER) && _MSC_VER > 1600 && _MSC_VER < 1900
 # define JSONCPP_OVERRIDE override
+# define JSONCPP_NOEXCEPT throw()
+#elif defined(_MSC_VER) && _MSC_VER >= 1900
+# define JSONCPP_OVERRIDE override
+# define JSONCPP_NOEXCEPT noexcept
 #else
 # define JSONCPP_OVERRIDE
+# define JSONCPP_NOEXCEPT throw()
 #endif
 
 #ifndef JSON_HAS_RVALUE_REFERENCES

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -53,8 +53,8 @@ namespace Json {
 class JSON_API Exception : public std::exception {
 public:
   Exception(JSONCPP_STRING const& msg);
-  ~Exception() throw() JSONCPP_OVERRIDE;
-  char const* what() const throw() JSONCPP_OVERRIDE;
+  ~Exception() JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
+  char const* what() const JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
 protected:
   JSONCPP_STRING msg_;
 };

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -193,9 +193,9 @@ namespace Json {
 Exception::Exception(JSONCPP_STRING const& msg)
   : msg_(msg)
 {}
-Exception::~Exception() throw()
+Exception::~Exception() JSONCPP_NOEXCEPT
 {}
-char const* Exception::what() const throw()
+char const* Exception::what() const JSONCPP_NOEXCEPT
 {
   return msg_.c_str();
 }


### PR DESCRIPTION
throw() is deprecated in c++11. Should probably move to using noexcept instead

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3051.html