### PR TITLE
Fix crash issue due to NULL value.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -398,6 +398,7 @@ Value::Value(double value) {
 
 Value::Value(const char* value) {
   initBasic(stringValue, true);
+  JSON_ASSERT_MESSAGE(value != NULL, "Null Value Passed to Value Constructor");	
   value_.string_ = duplicateAndPrefixStringValue(value, static_cast<unsigned>(strlen(value)));
 }
 


### PR DESCRIPTION
Null value in Value constructor will crash strlen(). Avoid crash with JSON_ASSERT_MESSAGE