### PR TITLE
Fix uninitialized value detected by valgrind

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -103,7 +103,7 @@ Reader::Reader(const Features& features)
 
 bool
 Reader::parse(const std::string& document, Value& root, bool collectComments) {
-  JSONCPP_STRING documentCopy(document.data(), document.data() + document.capacity());
+  JSONCPP_STRING documentCopy(document.data(), document.data() + document.length());
   std::swap(documentCopy, document_);
   const char* begin = document_.c_str();
   const char* end = begin + document_.length();


### PR DESCRIPTION
Fix issue reported in https://github.com/open-source-parsers/jsoncpp/issues/578
For std::string variable, length() is more readable than size().