### PR TITLE
Use full CMake paths in pkg-config template

### DIFF
--- a/pkg-config/jsoncpp.pc.in
+++ b/pkg-config/jsoncpp.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: jsoncpp
 Description: A C++ library for interacting with JSON


### PR DESCRIPTION
Using full paths is more versatile. The current solution
breaks when specifying an absolute path for `CMAKE_INSTALL_INCLUDEDIR`
which is an otherwise supported option by CMake's `GNUInstallDirs`.