### PR TITLE
Issue #595:- Reader Parser to handle escape chars.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1653,6 +1653,7 @@ bool OurReader::decodeString(Token& token, JSONCPP_STRING& decoded) {
     else if (c == '\\') {
       if (current == end)
         return addError("Empty escape sequence in string", token, current);
+      decoded += '\\';
       Char escape = *current++;
       switch (escape) {
       case '"':
@@ -1665,19 +1666,19 @@ bool OurReader::decodeString(Token& token, JSONCPP_STRING& decoded) {
         decoded += '\\';
         break;
       case 'b':
-        decoded += '\b';
+        decoded += 'b';
         break;
       case 'f':
-        decoded += '\f';
+        decoded += 'f';
         break;
       case 'n':
-        decoded += '\n';
+        decoded += 'n';
         break;
       case 'r':
-        decoded += '\r';
+        decoded += 'r';
         break;
       case 't':
-        decoded += '\t';
+        decoded += 't';
         break;
       case 'u': {
         unsigned int unicode;


### PR DESCRIPTION
re: #595 

Referred from, JSON.org: "A string is a sequence of zero or more Unicode characters, wrapped in double quotes, using backslash escapes. A character is represented as a single character string. A string is very much like a C or Java string."
```
Test Case-1
String Input :- "abc\b"
Expected Output  from reader parser :- "abc\\b"
Observed behavior on JSONCPP :- "abc^H"
OUTPUT After Above Code changes :- "abc\\b"

Test Case-2
String Input :- "abc\bd"
Expected Output  from reader parser :- "abc\\bd"
Observed behavior on JSONCPP :- "abd"
OUTPUT After Above Code changes :- "abc\\bd"
```