### PR TITLE
Use std::unique_ptr correctly across compiler and language versions

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -51,6 +51,16 @@
 #define JSON_API
 #endif
 
+#if !defined(JSON_HAS_UNIQUE_PTR)
+#if __cplusplus >= 201103L
+#define JSON_HAS_UNIQUE_PTR (1)
+#elif _MSC_VER >= 1600
+#define JSON_HAS_UNIQUE_PTR (1)
+#else
+#define JSON_HAS_UNIQUE_PTR (0)
+#endif
+#endif
+
 // If JSON_NO_INT64 is defined, then Json only support C++ "int" type for
 // integer
 // Storages, and 64 bits integer support is disabled.

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -44,7 +44,7 @@ static int       stackDepth_g = 0;  // see readValue()
 namespace Json {
 
 #if __GNUC__ >= 6
-typedef std::scoped_ptr<CharReader> const  CharReaderPtr;
+typedef std::unique_ptr<CharReader> const  CharReaderPtr;
 #else
 typedef std::auto_ptr<CharReader>          CharReaderPtr;
 #endif

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -43,7 +43,7 @@ static int       stackDepth_g = 0;  // see readValue()
 
 namespace Json {
 
-#if __GNUC__ >= 6
+#if JSON_HAS_UNIQUE_PTR
 typedef std::unique_ptr<CharReader> const  CharReaderPtr;
 #else
 typedef std::auto_ptr<CharReader>          CharReaderPtr;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -54,7 +54,7 @@
 
 namespace Json {
 
-#if __GNUC__ >= 6
+#if JSON_HAS_UNIQUE_PTR
 typedef std::unique_ptr<StreamWriter> const  StreamWriterPtr;
 #else
 typedef std::auto_ptr<StreamWriter>          StreamWriterPtr;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -55,7 +55,7 @@
 namespace Json {
 
 #if __GNUC__ >= 6
-typedef std::scoped_ptr<StreamWriter> const  StreamWriterPtr;
+typedef std::unique_ptr<StreamWriter> const  StreamWriterPtr;
 #else
 typedef std::auto_ptr<StreamWriter>          StreamWriterPtr;
 #endif


### PR DESCRIPTION
Previously, the code tried to avoid a `-Wdeprecated-declarations` warning by avoiding `std::auto_ptr` (since #413). However, the implementation has two issues:

1. It uses `std::scoped_ptr`, which as far as I can tell is a nonexistent type. `std::unique_ptr` is presumably what was meant.
2. It avoids `auto_ptr` whenver we're using GCC6. This means we don't dodge warnings for GCC5 or clang (which also support C++11). It also means that using GCC6 in C++03 mode fails, because `std::unique_ptr` doesn't exist there.

This fixes both of these issues, using `std::unique_ptr` in C++11 (and MSVC2010) and above.

Tested on GCC 5.4.1, GCC 6.2.0 and Clang 5.0.0-svn300863 in both C++03 and C++11 modes.