### PR TITLE
Refactor authorship information for more technical accuracy.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,111 @@
 Baptiste Lepilleur <blep@users.sourceforge.net>
+
+Aaron Jacobs <aaronjjacobs@gmail.com>
+Aaron Jacobs <jacobsa@google.com>
+Adam Boseley <ABoseley@agjunction.com>
+Adam Boseley <adam.boseley@gmail.com>
+Aleksandr Derbenev <13alexac@gmail.com>
+Alexander Gazarov <DrMetallius@users.noreply.github.com>
+Alexander V. Brezgin <abrezgin@appliedtech.ru>
+Alexandr Brezgin <albrezgin@mail.ru>
+Alexey Kruchinin <alexey@mopals.com>
+Anton Indrawan <anton.indrawan@gmail.com>
+Baptiste Jonglez <git@bitsofnetworks.org>
+Baptiste Lepilleur <baptiste.lepilleur@gmail.com>
+Baruch Siach <baruch@tkos.co.il>
+Ben Boeckel <mathstuf@gmail.com>
+Benjamin Knecht <bknecht@logitech.com>
+Bernd Kuhls <bernd.kuhls@t-online.de>
+Billy Donahue <billydonahue@google.com>
+Braden McDorman <bmcdorman@gmail.com>
+Brandon Myers <bmyers1788@gmail.com>
+Brendan Drew <brendan.drew@daqri.com>
+chason <cxchao802@gmail.com>
+Chris Gilling <cgilling@iparadigms.com>
+Christopher Dawes <christopher.dawes.1981@googlemail.com>
+Christopher Dunn <cdunn2001@gmail.com>
+Chuck Atkins <chuck.atkins@kitware.com>
+Cody P Schafer <dev@codyps.com>
+Connor Manning <connor@hobu.co>
+Cory Quammen <cory.quammen@kitware.com>
+Cristóvão B da Cruz e Silva <CrisXed@gmail.com>
+Daniel Krügler <daniel.kruegler@gmail.com>
+Dani-Hub <daniel.kruegler@googlemail.com>
+Dan Liu <gzliudan>
+datadiode <datadiode@users.noreply.github.com>
+datadiode <jochen.neubeck@vodafone.de>
+David Seifert <soap@gentoo.org>
+David West <david-west@idexx.com>
+dawesc <chris.dawes@eftlab.co.uk>
+Dmitry Marakasov <amdmi3@amdmi3.ru>
+dominicpezzuto <dom@dompezzuto.com>
+Don Milham <dmilham@gmail.com>
+drgler <daniel.kruegler@gmail.com>
+ds283 <D.Seery@sussex.ac.uk>
+Egor Tensin <Egor.Tensin@gmail.com>
+eightnoteight <mr.eightnoteight@gmail.com>
+Evince <baneyue@gmail.com>
+filipjs <filipjs@users.noreply.github.com>
+findblar <ft@finbarr.ca>
+Florian Meier <florian.meier@koalo.de>
+Gaëtan Lehmann <gaetan.lehmann@gmail.com>
+Gaurav <g.gupta@samsung.com>
+Gergely Nagy <ngg@ngg.hu>
+Gida Pataki <gida.pataki@prezi.com>
+I3ck <buckmartin@buckmartin.de>
+Iñaki Baz Castillo <ibc@aliax.net>
+Jacco <jacco@geul.net>
+Jean-Christophe Fillion-Robin <jchris.fillionr@kitware.com>
+Jonas Platte <mail@jonasplatte.de>
+Jörg Krause <joerg.krause@embedded.rocks>
+Keith Lea <keith@whamcitylights.com>
+Kevin Grant <kbradleygrant@gmail.com>
+Kirill V. Lyadvinsky <jia3ep@gmail.com>
+Kirill V. Lyadvinsky <mail@codeatcpp.com>
+Kobi Gurkan <kobigurk@gmail.com>
+Magnus Bjerke Vik <mbvett@gmail.com>
+Malay Shah <malays@users.sourceforge.net>
+Mara Kim <hacker.root@gmail.com>
+Marek Kotewicz <marek.kotewicz@gmail.com>
+Mark Lakata <mark@lakata.org>
+Mark Zeren <mzeren@vmware.com>
+Martin Buck <buckmartin@buckmartin.de>
+Martyn Gigg <martyn.gigg@gmail.com>
+Mattes D <github@xoft.cz>
+Matthias Loy <matthias.loy@hbm.com>
+Merlyn Morgan-Graham <kavika@gmail.com>
+Michael Shields <mshields@google.com>
+Michał Górny <mgorny@gentoo.org>
+Mike Naberezny <mike@naberezny.com>
+mloy <matthias.loy@googlemail.com>
+Motti <lanzkron@gmail.com>
+nnkur <nnkur@mail.ru>
+Omkar Wagh <owagh@owaghlinux.ny.tower-research.com>
+paulo <paulobrizolara@users.noreply.github.com>
+pavel.pimenov <pavel.pimenov@gmail.com>
+Paweł Bylica <chfast@gmail.com>
+Péricles Lopes Machado <pericles.raskolnikoff@gmail.com>
+Peter Spiess-Knafl <psk@autistici.org>
+pffang <pffang@vip.qq.com>
+Rémi Verschelde <remi@verschelde.fr>
+renu555 <renu.tyagi@samsung.com>
+Robert Dailey <rcdailey@gmail.com>
+Sam Clegg <sbc@chromium.org>
+selaselah <selah@outlook.com>
+Sergiy80 <sil2004@gmail.com>
+sergzub <sergzub@gmail.com>
+Stefan Schweter <stefan@schweter.it>
+Steffen Kieß <Steffen.Kiess@ipvs.uni-stuttgart.de>
+Steven Hahn <hahnse@ornl.gov>
+Stuart Eichert <stuart@fivemicro.com>
+SuperManitu <supermanitu@gmail.com>
+Techwolf <dring@g33kworld.net>
+Tengiz Sharafiev <btolfa+github@gmail.com>
+Tomasz Maciejewski <tmaciejewsk@gmail.com>
+Vicente Olivert Riera <Vincent.Riera@imgtec.com>
+xiaoyur347 <xiaoyur347@gmail.com>
+ycqiu <429148848@qq.com>
+yiqiju <fred_ju@selinc.com>
+Yu Xiaolei <dreifachstein@gmail.com>
+
+Google Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -2,12 +2,12 @@ The JsonCpp library's source code, including accompanying documentation,
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The author (Baptiste Lepilleur) explicitly disclaims copyright in all 
+The JsonCpp Authors explicitly disclaim copyright in all 
 jurisdictions which recognize such a disclaimer. In such jurisdictions, 
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
-2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur, and is
+2010), this software is Copyright (c) 2007-2010 by The JsonCpp Authors, and is
 released under the terms of the MIT License (see below).
 
 In jurisdictions which recognize Public Domain property, the user of this 
@@ -23,7 +23,7 @@ described in clear, concise terms at:
 The full text of the MIT License follows:
 
 ========================================================================
-Copyright (c) 2007-2010 Baptiste Lepilleur
+Copyright (c) 2007-2010 The JsonCpp Authors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/devtools/__init__.py
+++ b/devtools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2010 Baptiste Lepilleur
+# Copyright 2010 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/antglob.py
+++ b/devtools/antglob.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
-# Copyright 2009 Baptiste Lepilleur
+# Copyright 2009 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/fixeol.py
+++ b/devtools/fixeol.py
@@ -1,4 +1,4 @@
-# Copyright 2010 Baptiste Lepilleur
+# Copyright 2010 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/licenseupdater.py
+++ b/devtools/licenseupdater.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 # and ends with the first blank line.
 LICENSE_BEGIN = "// Copyright "
 
-BRIEF_LICENSE = LICENSE_BEGIN + """2007-2010 Baptiste Lepilleur
+BRIEF_LICENSE = LICENSE_BEGIN + """2007-2010 The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/tarball.py
+++ b/devtools/tarball.py
@@ -1,4 +1,4 @@
-# Copyright 2010 Baptiste Lepilleur
+# Copyright 2010 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/makerelease.py
+++ b/makerelease.py
@@ -1,4 +1,4 @@
-# Copyright 2010 Baptiste Lepilleur
+# Copyright 2010 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/globtool.py
+++ b/scons-tools/globtool.py
@@ -1,4 +1,4 @@
-# Copyright 2009 Baptiste Lepilleur
+# Copyright 2009 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/srcdist.py
+++ b/scons-tools/srcdist.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/substinfile.py
+++ b/scons-tools/substinfile.py
@@ -1,4 +1,4 @@
-# Copyright 2010 Baptiste Lepilleur
+# Copyright 2010 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/targz.py
+++ b/scons-tools/targz.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/cleantests.py
+++ b/test/cleantests.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/generate_expected.py
+++ b/test/generate_expected.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/pyjsontestrunner.py
+++ b/test/pyjsontestrunner.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/runjsontests.py
+++ b/test/runjsontests.py
@@ -1,4 +1,4 @@
-# Copyright 2007 Baptiste Lepilleur
+# Copyright 2007 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/rununittests.py
+++ b/test/rununittests.py
@@ -1,4 +1,4 @@
-# Copyright 2009 Baptiste Lepilleur
+# Copyright 2009 The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE


### PR DESCRIPTION
Google advises its employees to add Google Inc. as an author, but that hasn't
been done yet and would be super inconvenient. So instead I've refactored the
file to refer to "The JsonCpp Authors", which are listed in the AUTHORS file.

The AUTHORS file itself is generated via:

    git log --pretty="%an <%ae>%n%cn <%ce>" | sort | uniq

Plus the addition of "Google Inc." as a copyright author. (Google owns the work
of anyone contributing from an @google.com address, for example.)

The list contains some probable duplicates where people have used more than one
email address. I didn't deduplicate because -- well, who's to say they're
duplicates, anyway? :)