### PR TITLE
Backport 'reject duplicate keys' option to Reader.

### DIFF
--- a/include/json/features.h
+++ b/include/json/features.h
@@ -52,6 +52,9 @@ public:
 
   /// \c true if numeric object key are allowed. Default: \c false.
   bool allowNumericKeys_;
+
+  /// \c true if duplicate keys within an object should be rejected. Default: \c false.
+  bool rejectDupKeys_;
 };
 
 } // namespace Json

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -65,7 +65,8 @@ typedef std::auto_ptr<CharReader>   CharReaderPtr;
 
 Features::Features()
     : allowComments_(true), strictRoot_(false),
-      allowDroppedNullPlaceholders_(false), allowNumericKeys_(false) {}
+      allowDroppedNullPlaceholders_(false), allowNumericKeys_(false),
+      rejectDupKeys_(false) {}
 
 Features Features::all() { return Features(); }
 
@@ -491,6 +492,11 @@ bool Reader::readObject(Token& tokenStart) {
     if (!readToken(colon) || colon.type_ != tokenMemberSeparator) {
       return addErrorAndRecover(
           "Missing ':' after object member name", colon, tokenObjectEnd);
+    }
+    if (features_.rejectDupKeys_ && currentValue().isMember(name)) {
+      JSONCPP_STRING msg = "Duplicate key: '" + name + "'";
+      return addErrorAndRecover(
+          msg, tokenName, tokenObjectEnd);
     }
     Value& value = currentValue()[name];
     nodes_.push(&value);


### PR DESCRIPTION
I have a use of jsoncpp that requires access to the numeric spans provided by structured error messages, but also needs the ability to reject duplicate keys. Because StructuredError is defined as an inner class of the private OurCharReader, it is much simpler to backport this option rather than refactor to expose structured errors through CharReader.