### PR TITLE
Allocate the proper memory for formatString. Fix a warning with gcc 7.1

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -142,7 +142,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
   char buffer[36];
   int len = -1;
 
-  char formatString[6];
+  char formatString[15];
   snprintf(formatString, sizeof(formatString), "%%.%dg", precision);
 
   // Print into the buffer. We need not request the alternative representation


### PR DESCRIPTION
Warning:
```
/root/firefox-gcc-last/toolkit/components/jsoncpp/src/lib_json/json_writer.cpp:139:16: note: using the range [-2147483648, 2147483647] for directive argument
/root/firefox-gcc-last/toolkit/components/jsoncpp/src/lib_json/json_writer.cpp:146:10: note: 'sprintf' output between 5 and 15 bytes into a destination of size 6
   sprintf(formatString, "%%.%dg", precision);
   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```