### PR TITLE
Fix shared/static lib build conflict

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ environment:
 build_script:
   - cmake --version
   - cd c:\projects\jsoncpp
-  - cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=%CD:\=/%/install -DCMAKE_BUILD_TYPE=Release .
+  - cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=%CD:\=/%/install -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=ON .
   - cmake --build . --config Release --target install
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,30 +1,17 @@
-# This is a comment.
-
-version: build.{build}
-
-os: Windows Server 2012 R2
-
 clone_folder: c:\projects\jsoncpp
 
-platform:
-    - Win32
-    - x64
+environment:
+  matrix:
+    - CMAKE_GENERATOR: Visual Studio 12 2013
+    - CMAKE_GENERATOR: Visual Studio 12 2013 Win64
+    - CMAKE_GENERATOR: Visual Studio 14 2015
+    - CMAKE_GENERATOR: Visual Studio 14 2015 Win64
 
-configuration:
-    - Debug
-    - Release
-
-# scripts to run before build
-before_build:
-    - echo "Running cmake..."
-    - cd c:\projects\jsoncpp
-    - cmake --version
-    - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
-    - if %PLATFORM% == Win32 cmake .
-    - if %PLATFORM% == x64 cmake -G "Visual Studio 12 2013 Win64" .
-
-build:
-    project: jsoncpp.sln        # path to Visual Studio solution or project
+build_script:
+  - cmake --version
+  - cd c:\projects\jsoncpp
+  - cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX=%CD:\=/%/install -DCMAKE_BUILD_TYPE=Release .
+  - cmake --build . --config Release --target install
 
 deploy:
     provider: GitHub

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -95,8 +95,12 @@ ENDIF()
 IF(BUILD_STATIC_LIBS)
     ADD_LIBRARY(jsoncpp_lib_static STATIC ${PUBLIC_HEADERS} ${jsoncpp_sources})
     SET_TARGET_PROPERTIES( jsoncpp_lib_static PROPERTIES VERSION ${JSONCPP_VERSION} SOVERSION ${JSONCPP_SOVERSION})
-    SET_TARGET_PROPERTIES( jsoncpp_lib_static PROPERTIES OUTPUT_NAME jsoncpp
-                           DEBUG_OUTPUT_NAME jsoncpp${DEBUG_LIBNAME_SUFFIX} )
+    # avoid name clashes on windows as the shared import lib is also named jsoncpp.lib
+    if (NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)
+      set (STATIC_SUFFIX "_static")
+    endif ()
+    set_target_properties (jsoncpp_lib_static PROPERTIES OUTPUT_NAME jsoncpp${STATIC_SUFFIX}
+                                                         DEBUG_OUTPUT_NAME jsoncpp${STATIC_SUFFIX}${DEBUG_LIBNAME_SUFFIX})
 
     INSTALL( TARGETS jsoncpp_lib_static ${INSTALL_EXPORT}
              RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}


### PR DESCRIPTION
When both static and shared lib build are enabled, there is a conflict between the static and import lib ; both are named jsoncpp.lib and the test was incorrectly linked to the static lib but built with JSON_DLL flag and so failed to import symbols with the dllimport keyword. We propose to fix this by appending a "_static" suffix to the static lib when the shared lib is also enabled, so as by default (shared=0, static=1) the behavior is still the same.
This fixes #631.

Also, the appveyor script was messy and mixed msvc versions and 32/64 bits configurations.