### PR TITLE
Restore BL's authorship attribution, and add "The Jsoncpp Authors" where it was missing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,13 +2,13 @@ The JsonCpp library's source code, including accompanying documentation,
 tests and demonstration applications, are licensed under the following
 conditions...
 
-The JsonCpp Authors explicitly disclaim copyright in all 
+Baptiste Lepilleur and The JsonCpp Authors explicitly disclaim copyright in all 
 jurisdictions which recognize such a disclaimer. In such jurisdictions, 
 this software is released into the Public Domain.
 
 In jurisdictions which do not recognize Public Domain property (e.g. Germany as of
-2010), this software is Copyright (c) 2007-2010 by The JsonCpp Authors, and is
-released under the terms of the MIT License (see below).
+2010), this software is Copyright (c) 2007-2010 by Baptiste Lepilleur and
+The JsonCpp Authors, and is released under the terms of the MIT License (see below).
 
 In jurisdictions which recognize Public Domain property, the user of this 
 software may choose to accept it either as 1) Public Domain, 2) under the 
@@ -23,7 +23,7 @@ described in clear, concise terms at:
 The full text of the MIT License follows:
 
 ========================================================================
-Copyright (c) 2007-2010 The JsonCpp Authors
+Copyright (c) 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/devtools/__init__.py
+++ b/devtools/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2010 The JsonCpp Authors
+# Copyright 2010 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/antglob.py
+++ b/devtools/antglob.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
-# Copyright 2009 The JsonCpp Authors
+# Copyright 2009 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/fixeol.py
+++ b/devtools/fixeol.py
@@ -1,4 +1,4 @@
-# Copyright 2010 The JsonCpp Authors
+# Copyright 2010 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/licenseupdater.py
+++ b/devtools/licenseupdater.py
@@ -6,7 +6,7 @@ from __future__ import print_function
 # and ends with the first blank line.
 LICENSE_BEGIN = "// Copyright "
 
-BRIEF_LICENSE = LICENSE_BEGIN + """2007-2010 The JsonCpp Authors
+BRIEF_LICENSE = LICENSE_BEGIN + """2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/devtools/tarball.py
+++ b/devtools/tarball.py
@@ -1,4 +1,4 @@
-# Copyright 2010 The JsonCpp Authors
+# Copyright 2010 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/allocator.h
+++ b/include/json/allocator.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/assertions.h
+++ b/include/json/assertions.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/autolink.h
+++ b/include/json/autolink.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/features.h
+++ b/include/json/features.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/forwards.h
+++ b/include/json/forwards.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/json.h
+++ b/include/json/json.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/makerelease.py
+++ b/makerelease.py
@@ -1,4 +1,4 @@
-# Copyright 2010 The JsonCpp Authors
+# Copyright 2010 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/globtool.py
+++ b/scons-tools/globtool.py
@@ -1,4 +1,4 @@
-# Copyright 2009 The JsonCpp Authors
+# Copyright 2009 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/srcdist.py
+++ b/scons-tools/srcdist.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/substinfile.py
+++ b/scons-tools/substinfile.py
@@ -1,4 +1,4 @@
-# Copyright 2010 The JsonCpp Authors
+# Copyright 2010 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/scons-tools/targz.py
+++ b/scons-tools/targz.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2011 Baptiste Lepilleur
+// Copyright 2007-2011 Baptiste Lepilleur and The JsonCpp Authors
 // Copyright (C) 2016 InfoTeCS JSC. All rights reserved.
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011 Baptiste Lepilleur
+// Copyright 2011 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1,4 +1,4 @@
-// Copyright 2011 Baptiste Lepilleur
+// Copyright 2011 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2007-2010 Baptiste Lepilleur
+// Copyright 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
 // Distributed under MIT license, or public domain if desired and
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/cleantests.py
+++ b/test/cleantests.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/generate_expected.py
+++ b/test/generate_expected.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/pyjsontestrunner.py
+++ b/test/pyjsontestrunner.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/runjsontests.py
+++ b/test/runjsontests.py
@@ -1,4 +1,4 @@
-# Copyright 2007 The JsonCpp Authors
+# Copyright 2007 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE

--- a/test/rununittests.py
+++ b/test/rununittests.py
@@ -1,4 +1,4 @@
-# Copyright 2009 The JsonCpp Authors
+# Copyright 2009 Baptiste Lepilleur and The JsonCpp Authors
 # Distributed under MIT license, or public domain if desired and
 # recognized in your jurisdiction.
 # See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE


### PR DESCRIPTION
Requested/noticed in https://github.com/open-source-parsers/jsoncpp/pull/610, and a followup to https://github.com/open-source-parsers/jsoncpp/pull/607 .