### PR TITLE
Fix non-rvalue Json::Value assignment operator (should copy, not move)

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -327,10 +327,7 @@ Json::Value obj_value(Json::objectValue); // {}
 
   /// Deep copy, then swap(other).
   /// \note Over-write existing comments. To preserve comments, use #swapPayload().
-  Value& operator=(const Value& other);
-#if JSON_HAS_RVALUE_REFERENCES
-  Value& operator=(Value&& other);
-#endif
+  Value& operator=(Value other);
 
   /// Swap everything.
   void swap(Value& other);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -518,18 +518,10 @@ Value::~Value() {
   value_.uint_ = 0;
 }
 
-Value& Value::operator=(const Value& other) {
-  swap(const_cast<Value&>(other));
-  return *this;
-}
-
-#if JSON_HAS_RVALUE_REFERENCES
-Value& Value::operator=(Value&& other) {
-  initBasic(nullValue);
+Value& Value::operator=(Value other) {
   swap(other);
   return *this;
 }
-#endif
 
 void Value::swapPayload(Value& other) {
   ValueType temp = type_;


### PR DESCRIPTION
Pull request #635 has changed the behavior of non-rvalue assignment operator from copying the 'other' value to swapping with it. There is a lot of wrong with it.

This pull request reverts to the earlier assignment operator, with 'other' passed by value rather than const&. Now that Json::Value has a move constructor, such assignment operator covers both move and non-move cases.