### PR TITLE
Avoid memory error

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -103,7 +103,7 @@ Reader::Reader(const Features& features)
 
 bool
 Reader::parse(const std::string& document, Value& root, bool collectComments) {
-  JSONCPP_STRING documentCopy(document.data(), document.data() + document.capacity());
+  JSONCPP_STRING documentCopy(document.data(), document.data() + document.length());
   std::swap(documentCopy, document_);
   const char* begin = document_.c_str();
   const char* end = begin + document_.length();

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -103,8 +103,7 @@ Reader::Reader(const Features& features)
 
 bool
 Reader::parse(const std::string& document, Value& root, bool collectComments) {
-  JSONCPP_STRING documentCopy(document.data(), document.data() + document.length());
-  std::swap(documentCopy, document_);
+  document_.assign(document.begin(), document.end());
   const char* begin = document_.c_str();
   const char* end = begin + document_.length();
   return parse(begin, end, root, collectComments);


### PR DESCRIPTION
But simply use `.assign()` instead of the extra copy. (See comment from @BillyDonhue at #580.)

See #578. Thanks @ya1gaurav and @cinemast.

(@SoapGentoo, thanks for the Meson stuff. Beautiful!)