### PR TITLE
Add value_type to improve integration with boost

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -190,6 +190,9 @@ public:
   typedef Json::LargestUInt LargestUInt;
   typedef Json::ArrayIndex ArrayIndex;
 
+  // Required for boost integration, e. g. BOOST_TEST
+  typedef std::string value_type;
+
   static const Value& null;  ///< We regret this reference to a global instance; prefer the simpler Value().
   static const Value& nullRef;  ///< just a kludge for binary-compatibility; same as null
   static Value const& nullSingleton(); ///< Prefer this to null or nullRef.


### PR DESCRIPTION
Without value_type, Boost.Test version 1.65.0 throws a compiler error when a Json::Value object is compared to another with BOOST_TEST. Example and further discussion are in https://github.com/open-source-parsers/jsoncpp/issues/671.