### PR TITLE
Fix meson.build to allow using jsoncpp as a subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,7 @@ import('pkgconfig').generate(
   description : 'A C++ library for interacting with JSON')
 
 # for libraries bundling jsoncpp
-declare_dependency(
+jsoncpp_dep = declare_dependency(
   include_directories : jsoncpp_include_directories,
   link_with : jsoncpp_lib,
   version : meson.project_version(),


### PR DESCRIPTION
Fix meson.build so that jsoncpp can be used as a meson subproject, potentially wrapped.
Previously the declared dependency object has no name and cannot be retrived var `get_variable()` from the parent project and cannot be used directly, which also prevents jsonspp to be used as a fallback subproject in `dependency()`.