### PR TITLE
Optimize removing negligible values

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -534,6 +534,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /** \brief Remove the named map member.
 
       Update 'removed' iff removed.
+      'removed' can be NULL if removed value is negligible.
       \param key may contain embedded nulls.
       \return true iff removed (no exceptions)
   */
@@ -544,6 +545,7 @@ Json::Value obj_value(Json::objectValue); // {}
 
       O(n) expensive operations.
       Update 'removed' iff removed.
+      'removed' can be NULL if removed value is negligible.
       \return true iff removed (no exceptions)
   */
   bool removeIndex(ArrayIndex i, Value* removed);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1175,7 +1175,8 @@ bool Value::removeMember(const char* key, const char* cend, Value* removed)
   ObjectValues::iterator it = value_.map_->find(actualKey);
   if (it == value_.map_->end())
     return false;
-  *removed = it->second;
+  if (removed)
+    *removed = it->second;
   value_.map_->erase(it);
   return true;
 }
@@ -1219,7 +1220,8 @@ bool Value::removeIndex(ArrayIndex index, Value* removed) {
   if (it == value_.map_->end()) {
     return false;
   }
-  *removed = it->second;
+  if (removed)
+    *removed = it->second;
   ArrayIndex oldSize = size();
   // shift left all items left, into the place of the "removed"
   for (ArrayIndex i = index; i < (oldSize - 1); ++i){

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -217,6 +217,15 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   did = object1_.removeMember("some other id", &got);
   JSONTEST_ASSERT_EQUAL(Json::Value("bar"), got);
   JSONTEST_ASSERT_EQUAL(false, did);
+
+  // Remove negligible value.
+  object1_["negligible"] = "foo";
+  Json::ArrayIndex objectSize = object1_.size();
+  JSONTEST_ASSERT_EQUAL(Json::Value("foo"), object1_["negligible"]);
+  JSONTEST_ASSERT_EQUAL(true, object1_.removeMember("negligible", NULL));
+  JSONTEST_ASSERT_EQUAL(objectSize - 1, object1_.size());
+  JSONTEST_ASSERT_EQUAL(false, object1_.removeMember("negligible", NULL));
+  JSONTEST_ASSERT_EQUAL(objectSize - 1, object1_.size());
 }
 
 JSONTEST_FIXTURE(ValueTest, arrays) {
@@ -263,7 +272,13 @@ JSONTEST_FIXTURE(ValueTest, arrays) {
   JSONTEST_ASSERT_EQUAL(true, array1_.removeIndex(2, &got));
   JSONTEST_ASSERT_EQUAL(Json::Value(17), got);
   JSONTEST_ASSERT_EQUAL(false, array1_.removeIndex(2, &got)); // gone now
+
+  // Remove negligible value.
+  Json::ArrayIndex arraySize = array1_.size();
+  JSONTEST_ASSERT_EQUAL(true, array1_.removeIndex(0, NULL));
+  JSONTEST_ASSERT_EQUAL(arraySize -1, array1_.size());
 }
+
 JSONTEST_FIXTURE(ValueTest, arrayIssue252)
 {
   int count = 5;


### PR DESCRIPTION
Sometimes I don't care about removed value, so it will be easier just forget it (and not need to add local variable for it).