### PR TITLE
Allow non-deprecated removeMember/removeIndex with null return pointer

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1175,7 +1175,7 @@ bool Value::removeMember(const char* key, const char* cend, Value* removed)
   ObjectValues::iterator it = value_.map_->find(actualKey);
   if (it == value_.map_->end())
     return false;
-  *removed = it->second;
+  if (removed) *removed = it->second;
   value_.map_->erase(it);
   return true;
 }
@@ -1212,7 +1212,7 @@ bool Value::removeIndex(ArrayIndex index, Value* removed) {
   if (it == value_.map_->end()) {
     return false;
   }
-  *removed = it->second;
+  if (removed) *removed = it->second;
   ArrayIndex oldSize = size();
   // shift left all items left, into the place of the "removed"
   for (ArrayIndex i = index; i < (oldSize - 1); ++i){


### PR DESCRIPTION
Sometimes we just want to remove something we don't need anymore. Having to supply a return buffer for the removeMember/removeIndex function to return something we don't care about is a nuisance. There are removeMember/removeIndex functions that don't need a return pointer but they are deprecated. This commit allows the non-deprecated versions to be called with a null pointer as the last argument to simplify things for callers who don't need to get something back.

For example:

```
Json::Value j;

j.removeMember("name"); // nice but deprecated

Json::Value r; j.removeMember("name",&r); // possible but annoying

j.removeMember("name",nullptr); // possible with this commit
```

Note: Implementation only (albeit very trivial), no test coverage.