### PR TITLE
Un-deprecate removeMember overloads, return void

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -518,13 +518,11 @@ Json::Value obj_value(Json::objectValue); // {}
   /// \pre type() is objectValue or nullValue
   /// \post type() is unchanged
   /// \deprecated
-  JSONCPP_DEPRECATED("")
-  Value removeMember(const char* key);
+  void removeMember(const char* key);
   /// Same as removeMember(const char*)
   /// \param key may contain embedded nulls.
   /// \deprecated
-  JSONCPP_DEPRECATED("")
-  Value removeMember(const JSONCPP_STRING& key);
+  void removeMember(const JSONCPP_STRING& key);
   /// Same as removeMember(const char* begin, const char* end, Value* removed),
   /// but 'key' is null-terminated.
   bool removeMember(const char* key, Value* removed);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1194,12 +1194,12 @@ void Value::removeMember(const char* key)
   if (type_ == nullValue)
     return;
 
-  CZString actualKey(key, strlen(key), CZString::noDuplication);
+  CZString actualKey(key, unsigned(strlen(key)), CZString::noDuplication);
   value_.map_->erase(actualKey);
 }
 void Value::removeMember(const JSONCPP_STRING& key)
 {
-  return removeMember(key.c_str());
+  removeMember(key.c_str());
 }
 
 bool Value::removeIndex(ArrayIndex index, Value* removed) {

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1187,18 +1187,17 @@ bool Value::removeMember(JSONCPP_STRING const& key, Value* removed)
 {
   return removeMember(key.data(), key.data() + key.length(), removed);
 }
-Value Value::removeMember(const char* key)
+void Value::removeMember(const char* key)
 {
   JSON_ASSERT_MESSAGE(type_ == nullValue || type_ == objectValue,
                       "in Json::Value::removeMember(): requires objectValue");
   if (type_ == nullValue)
-    return nullSingleton();
+    return;
 
-  Value removed;  // null
-  removeMember(key, key + strlen(key), &removed);
-  return removed; // still null if removeMember() did nothing
+  CZString actualKey(key, strlen(key), CZString::noDuplication);
+  value_.map_->erase(actualKey);
 }
-Value Value::removeMember(const JSONCPP_STRING& key)
+void Value::removeMember(const JSONCPP_STRING& key)
 {
   return removeMember(key.c_str());
 }


### PR DESCRIPTION
Sometimes we just want to remove something we don't need anymore. Having
to supply a return buffer for the removeMember function to return something
we don't care about is a nuisance. There are removeMember overloads that
don't need a return buffer but they are deprecated. This commit un-deprecates
these overloads and modifies them to return nothing (void) instead of the
object that was removed.

Further discussion: https://github.com/open-source-parsers/jsoncpp/pull/689

WARNING: Changes the return type of the formerly deprecated removeMember
overloads from Value to void. May break existing client code.