### PR TITLE
Add comment to README with instructions on installing to a specific path

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ format to store user input files.
 Thanks to David Seifert (@SoapGentoo), we (the maintainers) now use [meson](http://mesonbuild.com/) and [ninja](https://ninja-build.org/) to build for debugging, as well as for continuous integration (see [`travis.sh`](travis.sh) ). Other systems may work, but minor things like version strings might break.
 
 First, install both meson (which requires Python3) and ninja.
+If you wish to install to a directory other than /usr/local, set an environment variable called DESTDIR with the desired path:
+    DESTDIR=/path/to/install/dir
 
 Then,
 


### PR DESCRIPTION
By default, ninja / meson install to /usr/local or the system equivalent. Some users (such as myself) work in complex environments where it is impossible or undesirable to install to such a location. While it didn't take much work for me to find out how to do this, it is beneficial to explicitly state it in the installation instructions.