### PR TITLE
Allow Json::Value to be used in a boolean context

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -403,6 +403,9 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Return isNull()
   bool operator!() const;
 
+  /// Return !isNull()
+  operator bool() const;
+
   /// Remove all object members and array elements.
   /// \pre type() is arrayValue, objectValue, or nullValue
   /// \post type() is unchanged

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -400,9 +400,6 @@ Json::Value obj_value(Json::objectValue); // {}
   /// otherwise, false.
   bool empty() const;
 
-  /// Return isNull()
-  bool operator!() const;
-
   /// Return !isNull()
   operator bool() const;
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -401,7 +401,7 @@ Json::Value obj_value(Json::objectValue); // {}
   bool empty() const;
 
   /// Return !isNull()
-  operator bool() const;
+  explicit operator bool() const;
 
   /// Remove all object members and array elements.
   /// \pre type() is arrayValue, objectValue, or nullValue

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -962,8 +962,6 @@ bool Value::empty() const {
     return false;
 }
 
-bool Value::operator!() const { return isNull(); }
-
 Value::operator bool() const { return ! isNull(); }
 
 void Value::clear() {

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -964,6 +964,8 @@ bool Value::empty() const {
 
 bool Value::operator!() const { return isNull(); }
 
+Value::operator bool() const { return ! isNull(); }
+
 void Value::clear() {
   JSON_ASSERT_MESSAGE(type_ == nullValue || type_ == arrayValue ||
                           type_ == objectValue,

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -304,6 +304,12 @@ JSONTEST_FIXTURE(ValueTest, null) {
   JSONTEST_ASSERT_STRING_EQUAL("", null_.asString());
 
   JSONTEST_ASSERT_EQUAL(Json::Value::null, null_);
+
+  // Test using a Value in a boolean context (false iff null)
+  JSONTEST_ASSERT_EQUAL(null_,false);
+  JSONTEST_ASSERT_EQUAL(object1_,true);
+  JSONTEST_ASSERT_EQUAL(!null_,true);
+  JSONTEST_ASSERT_EQUAL(!object1_,false);
 }
 
 JSONTEST_FIXTURE(ValueTest, strings) {


### PR DESCRIPTION
In a boolean context, a Value is `false` if it is null, and `true` if it is not null. This was already implemented partially by `operator!` and is now supported fully by adding implicit conversion of Value to bool (through `operator bool`).

For example:

```cpp
Json::Value v;
...

// We already had this before (through operator!):
if (!v) {
    // Executed if v is null
}

// This commit adds the following (through the new operator bool):
if (v) {
    // Executed if v is not null
}
```

Includes test coverage.