### PR TITLE
Suppress implicit-fallthrough warnings from GCC 7

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1237,7 +1237,7 @@ bool OurReader::readToken(Token& token) {
     token.type_ = tokenString;
     ok = readStringSingleQuote();
     break;
-    } // else continue
+    } // else fall through
   case '/':
     token.type_ = tokenComment;
     ok = readComment();


### PR DESCRIPTION
GCC 7, when compiling with -Wimplicit-fallthrough=1 or higher, issues a warning which can be suppressed using a comment that matches certain regular expressions. The comment change does just that: signal to GCC that the fall through is intentional.

Fixes #676