### PR TITLE
MSVC warning fixes in tests

### DIFF
--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -3,8 +3,12 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(disable : 4996)
+#endif
 
 /* This executable is used for testing parser/writer using real JSON files.
  */
@@ -13,10 +17,6 @@
 #include <algorithm> // sort
 #include <sstream>
 #include <stdio.h>
-
-#if defined(_MSC_VER) && _MSC_VER >= 1310
-#pragma warning(disable : 4996) // disable fopen deprecation warning
-#endif
 
 struct Options
 {
@@ -328,4 +328,6 @@ int main(int argc, const char* argv[]) {
   }
 }
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3,8 +3,12 @@
 // recognized in your jurisdiction.
 // See file LICENSE for detail or copy at http://jsoncpp.sourceforge.net/LICENSE
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(disable : 4996)
+#endif
 
 #include "jsontest.h"
 #include <json/config.h>
@@ -2591,4 +2595,6 @@ int main(int argc, const char* argv[]) {
   return runner.runCommandLine(argc, argv);
 }
 
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
- only use "#pragma GCC" on GCC-compatible compilers
- suppress deprecation warnings also on MSVC