### PR TITLE
pyenv install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@
 # http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
 # to allow C++11, though we are not yet building with -std=c++11
 
-before_install: pyenv global 3.5
+before_install: pyenv install 3.5.4 && pyenv global 3.5.4
 install:
 - if [[ $TRAVIS_OS_NAME == osx ]]; then
      brew update;


### PR DESCRIPTION
```
Unfortunately, since our latest image update, Python 3.5 doesn't come pre-installed anymore. Hence, you will have to install it via `pyenv` as a first step e.g.

before_install
  - pyenv install 3.5.0 && pyenv global 3.5.0

support@travis-ci.com
```