### PR TITLE
-std=c++11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,7 @@ project(
   version : '1.8.4',
   default_options : [
     'buildtype=release',
+    'cpp_std=c++11',
     'warning_level=1'],
   license : 'Public Domain',
   meson_version : '>= 0.41.1')


### PR DESCRIPTION
We set this is the Meson build to eliminate warnings, but
c++0x should still work, at least for now.

See #695 for discussion.