### PR TITLE
Speed up TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@
 # to allow C++11, though we are not yet building with -std=c++11
 
 #before_install: pyenv install 3.5.4 && pyenv global 3.5.4
+before_install: pyenv global 3.6
 # https://docs.travis-ci.com/user/languages/python/
 # "for Trusty, this means 2.7.6 and 3.4.3"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@
 # http://stackoverflow.com/questions/22111549/travis-ci-with-clang-3-4-and-c11/30925448#30925448
 # to allow C++11, though we are not yet building with -std=c++11
 
-before_install: pyenv install 3.5.4 && pyenv global 3.5.4
+#before_install: pyenv install 3.5.4 && pyenv global 3.5.4
+# https://docs.travis-ci.com/user/languages/python/
+# "for Trusty, this means 2.7.6 and 3.4.3"
 install:
 - if [[ $TRAVIS_OS_NAME == osx ]]; then
      brew update;


### PR DESCRIPTION
Even though TravisCI says Trusty has ["2.7.6 and 3.4.3"](https://docs.travis-ci.com/user/languages/python/), python-3.4.3 is missing pip3. TravisCI reports:

    The `pip3` command exists in these Python versions: 3.6, 3.6.3

We recently had to start using the very slow `pyenv install` for some other version of Python. But fortunately, 3.6 actually is available to pyenv now. So we save 3 minutes of build-time. (Actually, we just go back to the build-time we had last week, before TravisCI made some updates.)