### PR TITLE
Fix C4996 warning with VS2017 by postponing the deprecation of Reader

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -32,7 +32,7 @@ namespace Json {
  *
  * \deprecated Use CharReader and CharReaderBuilder.
  */
-class JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") JSON_API Reader {
+class JSON_API Reader {
 public:
   typedef char Char;
   typedef const Char* Location;
@@ -52,11 +52,13 @@ public:
   /** \brief Constructs a Reader allowing all features
    * for parsing.
    */
+  JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") 
   Reader();
 
   /** \brief Constructs a Reader allowing the specified feature set
    * for parsing.
    */
+  JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead") 
   Reader(const Features& features);
 
   /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a>


### PR DESCRIPTION
Should fix #728.
This has been only tested locally running VS2017.