### PR TITLE
Move the existing value to "removed" argument; removed is optional (could be nullptr)

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1186,10 +1186,11 @@ bool Value::removeMember(const char* key, const char* cend, Value* removed)
   ObjectValues::iterator it = value_.map_->find(actualKey);
   if (it == value_.map_->end())
     return false;
+  if (removed)
 #if JSON_HAS_RVALUE_REFERENCES
-  *removed = std::move(it->second);
+    *removed = std::move(it->second);
 #else
-  *removed = it->second;
+    *removed = it->second;
 #endif
   value_.map_->erase(it);
   return true;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1186,7 +1186,11 @@ bool Value::removeMember(const char* key, const char* cend, Value* removed)
   ObjectValues::iterator it = value_.map_->find(actualKey);
   if (it == value_.map_->end())
     return false;
+#if JSON_HAS_RVALUE_REFERENCES
+  *removed = std::move(it->second);
+#else
   *removed = it->second;
+#endif
   value_.map_->erase(it);
   return true;
 }


### PR DESCRIPTION
Hi guys,

There're two commits here. 
The first one could be considered to be a minor bug fix (_std::move_).
The second one is disputable. It slightly changes _Value::removeMember_ interface, so it could take _nullptr_ as the "removed" argument. It seems to be a pretty common use case since that extra returned value is not needed for everyone. Also, changing tons of code to support the new _removeMember_ interface could be much easier with this nullptr-feature.

Regards