### PR TITLE
Incorrect byte shift when interpreting 32-bit utf-8 codepoints

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -209,7 +209,7 @@ static unsigned int utf8ToCodepoint(const char*& s, const char* e) {
     if (e - s < 4)
       return REPLACEMENT_CHARACTER;
 
-    unsigned int calculated = ((firstByte & 0x07) << 24)
+    unsigned int calculated = ((firstByte & 0x07) << 18)
       | ((static_cast<unsigned int>(s[1]) & 0x3F) << 12)
       | ((static_cast<unsigned int>(s[2]) & 0x3F) << 6)
       |  (static_cast<unsigned int>(s[3]) & 0x3F);


### PR DESCRIPTION
During review of my own JSON string escaping code against popular implementations, I noticed an inaccuracy in yours. Codepoints for 4-byte long utf-8 characters are calculated incorrectly:
```
    unsigned int calculated = ((firstByte & 0x07) << 24)
      | ((static_cast<unsigned int>(s[1]) & 0x3F) << 12)
      | ((static_cast<unsigned int>(s[2]) & 0x3F) << 6)
      |  (static_cast<unsigned int>(s[3]) & 0x3F);
```
Notice the byte shift of 24, while there are just 3x6 bits stored in bytes with lower significance.