### PR TITLE
Remove std::swap<Json::Value> in favor of ADL

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -880,14 +880,9 @@ public:
   pointer operator->() const { return &deref(); }
 };
 
+inline void swap(Value& a, Value& b) { a.swap(b); }
+
 } // namespace Json
-
-
-namespace std {
-/// Specialize std::swap() for Json::Value.
-template<>
-inline void swap(Json::Value& a, Json::Value& b) { a.swap(b); }
-}
 
 #pragma pack(pop)
 


### PR DESCRIPTION
Comply with the [Swappable](http://en.cppreference.com/w/cpp/concept/Swappable) concept without opening namespace std.