### PR TITLE
Add setting precision for json writers and also add decimal places precision type.

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -109,6 +109,13 @@ enum CommentPlacement {
   numberOfCommentPlacement
 };
 
+/** \brief Type of precision for formatting of real values.
+ */
+enum PrecisionType {
+  significantDigits = 0, ///< we set max number of significant digits in string
+  decimalPlaces          ///< we set max number of digits after "." in string
+};
+
 //# ifdef JSON_USE_CPPTL
 //   typedef CppTL::AnyEnumerator<const char *> EnumMemberNames;
 //   typedef CppTL::AnyEnumerator<const Value &> EnumValues;

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -111,7 +111,7 @@ enum CommentPlacement {
 
 /** \brief Type of precision for formatting of real values.
  */
-enum FloatFormat {
+enum PrecisionType {
   significantDigits = 0, ///< we set max number of significant digits in string
   decimalPlaces          ///< we set max number of digits after "." in string
 };

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -111,7 +111,7 @@ enum CommentPlacement {
 
 /** \brief Type of precision for formatting of real values.
  */
-enum PrecisionType {
+enum FloatFormat {
   significantDigits = 0, ///< we set max number of significant digits in string
   decimalPlaces          ///< we set max number of digits after "." in string
 };

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -220,6 +220,9 @@ public:
   static const UInt64 maxUInt64;
 #endif // defined(JSON_HAS_INT64)
 
+  /// Default precision for real value for string representation.
+  static const UInt defaultRealPrecision;
+
 // Workaround for bug in the NVIDIAs CUDA 9.1 nvcc compiler
 // when using gcc and clang backend compilers.  CZString
 // cannot be defined as private.  See issue #486

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -106,6 +106,10 @@ public:
       - If true, outputs non-finite floating point values in the following way:
         NaN values as "NaN", positive infinity as "Infinity", and negative infinity
         as "-Infinity".
+    - "precision": int
+      - Number of precision digits for formatting of real values.
+    - "precisionType": "significant"(default) or "decimal"
+      - Type of precision for formatting of real values.
 
     You can examine 'settings_` yourself
     to see the defaults. You can also write and read them just like any
@@ -177,9 +181,6 @@ public:
 
   void omitEndingLineFeed();
 
-  void setPrecision(unsigned int precision);
-  void setPrecisionType(PrecisionType precisionType);
-
 public: // overridden from Writer
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
@@ -190,8 +191,6 @@ private:
   bool yamlCompatibilityEnabled_;
   bool dropNullPlaceholders_;
   bool omitEndingLineFeed_;
-  UInt precision_;
-  PrecisionType precisionType_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -237,9 +236,6 @@ public: // overridden from Writer
    */
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
-  void setPrecision(unsigned int precision);
-  void setPrecisionType(PrecisionType precisionType);
-
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
@@ -262,8 +258,6 @@ private:
   unsigned int rightMargin_;
   unsigned int indentSize_;
   bool addChildValues_;
-  UInt precision_;
-  PrecisionType precisionType_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -315,9 +309,6 @@ public:
    */
   void write(JSONCPP_OSTREAM& out, const Value& root);
 
-  void setPrecision(unsigned int precision);
-  void setPrecisionType(PrecisionType precisionType);
-
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
@@ -338,8 +329,6 @@ private:
   JSONCPP_OSTREAM* document_;
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
-  UInt precision_;
-  PrecisionType precisionType_;
   JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
@@ -354,7 +343,8 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision, PrecisionType precisionType);
+JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision,
+                                      PrecisionType precisionType = PrecisionType::significantDigits);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -176,7 +176,8 @@ public:
 
   void omitEndingLineFeed();
 
-  void setRealPrecision(unsigned int realPrecision);
+  void setPrecision(unsigned int precision);
+  void setPrecisionType(PrecisionType precisionType);
 
 public: // overridden from Writer
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
@@ -188,8 +189,8 @@ private:
   bool yamlCompatibilityEnabled_;
   bool dropNullPlaceholders_;
   bool omitEndingLineFeed_;
-  UInt realPrecision_;
-  bool isCustomRealPrecision_;
+  UInt precision_;
+  PrecisionType precisionType_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -235,7 +236,8 @@ public: // overridden from Writer
    */
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
-  void setRealPrecision(unsigned int realPrecision);
+  void setPrecision(unsigned int precision);
+  void setPrecisionType(PrecisionType precisionType);
 
 private:
   void writeValue(const Value& value);
@@ -258,9 +260,9 @@ private:
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
   unsigned int indentSize_;
-  unsigned int realPrecision_;
   bool addChildValues_;
-  bool isCustomRealPrecision_;
+  UInt precision_;
+  PrecisionType precisionType_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -312,7 +314,8 @@ public:
    */
   void write(JSONCPP_OSTREAM& out, const Value& root);
 
-  void setRealPrecision(unsigned int realPrecision);
+  void setPrecision(unsigned int precision);
+  void setPrecisionType(PrecisionType precisionType);
 
 private:
   void writeValue(const Value& value);
@@ -334,8 +337,8 @@ private:
   JSONCPP_OSTREAM* document_;
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
-  unsigned int realPrecision_;
-  bool isCustomRealPrecision_;
+  UInt precision_;
+  PrecisionType precisionType_;
   JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
@@ -350,7 +353,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision, bool isCustomPrecision);
+JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision, PrecisionType precisionType);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -343,7 +343,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision,
+JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision = Value::defaultRealPrecision,
                                       PrecisionType precisionType = PrecisionType::significantDigits);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -176,6 +176,8 @@ public:
 
   void omitEndingLineFeed();
 
+  void setRealPrecision(unsigned int realPrecision);
+
 public: // overridden from Writer
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
@@ -186,6 +188,7 @@ private:
   bool yamlCompatibilityEnabled_;
   bool dropNullPlaceholders_;
   bool omitEndingLineFeed_;
+  UInt realPrecision_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -231,6 +234,8 @@ public: // overridden from Writer
    */
   JSONCPP_STRING write(const Value& root) JSONCPP_OVERRIDE;
 
+  void setRealPrecision(unsigned int realPrecision);
+
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
@@ -252,6 +257,7 @@ private:
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
   unsigned int indentSize_;
+  unsigned int realPrecision_;
   bool addChildValues_;
 };
 #if defined(_MSC_VER)
@@ -304,6 +310,8 @@ public:
    */
   void write(JSONCPP_OSTREAM& out, const Value& root);
 
+  void setRealPrecision(unsigned int realPrecision);
+
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
@@ -324,6 +332,7 @@ private:
   JSONCPP_OSTREAM* document_;
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
+  unsigned int realPrecision_;
   JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
@@ -338,7 +347,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API valueToString(double value);
+JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -106,9 +106,9 @@ public:
       - If true, outputs non-finite floating point values in the following way:
         NaN values as "NaN", positive infinity as "Infinity", and negative infinity
         as "-Infinity".
-    - "precision": int
+    - "floatPrecision": int
       - Number of precision digits for formatting of real values.
-    - "precisionType": "significant"(default) or "decimal"
+    - "floatFormat": "significant"(default) or "decimal"
       - Type of precision for formatting of real values.
 
     You can examine 'settings_` yourself
@@ -344,7 +344,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
 JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision = Value::defaultRealPrecision,
-                                      PrecisionType precisionType = PrecisionType::significantDigits);
+                                      FloatFormat floatFormat = FloatFormat::significantDigits);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -106,9 +106,9 @@ public:
       - If true, outputs non-finite floating point values in the following way:
         NaN values as "NaN", positive infinity as "Infinity", and negative infinity
         as "-Infinity".
-    - "floatPrecision": int
+    - "precision": int
       - Number of precision digits for formatting of real values.
-    - "floatFormat": "significant"(default) or "decimal"
+    - "precisionType": "significant"(default) or "decimal"
       - Type of precision for formatting of real values.
 
     You can examine 'settings_` yourself
@@ -344,7 +344,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
 JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision = Value::defaultRealPrecision,
-                                      FloatFormat floatFormat = FloatFormat::significantDigits);
+                                      PrecisionType precisionType = PrecisionType::significantDigits);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -189,6 +189,7 @@ private:
   bool dropNullPlaceholders_;
   bool omitEndingLineFeed_;
   UInt realPrecision_;
+  bool isCustomRealPrecision_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -259,6 +260,7 @@ private:
   unsigned int indentSize_;
   unsigned int realPrecision_;
   bool addChildValues_;
+  bool isCustomRealPrecision_;
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -333,6 +335,7 @@ private:
   JSONCPP_STRING indentString_;
   unsigned int rightMargin_;
   unsigned int realPrecision_;
+  bool isCustomRealPrecision_;
   JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
@@ -347,7 +350,7 @@ JSONCPP_STRING JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
 JSONCPP_STRING JSON_API valueToString(LargestInt value);
 JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision);
+JSONCPP_STRING JSON_API valueToString(double value, unsigned int precision, bool isCustomPrecision);
 JSONCPP_STRING JSON_API valueToString(bool value);
 JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
 

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -109,6 +109,20 @@ static inline void fixNumericLocaleInput(char* begin, char* end) {
   }
 }
 
+/**
+ * Delete zeros in the end of string, if it isn't last zero before '.' character.
+ */
+static inline void fixZerosInTheEnd(char* begin, char* end) {
+  end--;
+  while ((begin < end) && (*end == '0')) {
+    // don't delete last zero before point.
+    if (*(end - 1) != '.') {
+      *end = '\0';
+    }
+    end--;
+  }
+}
+
 } // namespace Json {
 
 #endif // LIB_JSONCPP_JSON_TOOL_H_INCLUDED

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -64,7 +64,7 @@ const LargestInt Value::minLargestInt = LargestInt(~(LargestUInt(-1) / 2));
 const LargestInt Value::maxLargestInt = LargestInt(LargestUInt(-1) / 2);
 const LargestUInt Value::maxLargestUInt = LargestUInt(-1);
 
-const UInt Value::defaultRealPrecision = 15;
+const UInt Value::defaultRealPrecision = 17;
 
 #if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
 template <typename T, typename U>
@@ -657,7 +657,7 @@ JSONCPP_STRING Value::asString() const {
   case uintValue:
     return valueToString(value_.uint_);
   case realValue:
-    return valueToString(value_.real_, Value::defaultRealPrecision);
+    return valueToString(value_.real_, Value::defaultRealPrecision, false);
   default:
     JSON_FAIL_MESSAGE("Type is not convertible to string");
   }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -64,6 +64,8 @@ const LargestInt Value::minLargestInt = LargestInt(~(LargestUInt(-1) / 2));
 const LargestInt Value::maxLargestInt = LargestInt(LargestUInt(-1) / 2);
 const LargestUInt Value::maxLargestUInt = LargestUInt(-1);
 
+const UInt Value::defaultRealPrecision = 15;
+
 #if !defined(JSON_USE_INT64_DOUBLE_CONVERSION)
 template <typename T, typename U>
 static inline bool InRange(double d, T min, U max) {
@@ -655,7 +657,7 @@ JSONCPP_STRING Value::asString() const {
   case uintValue:
     return valueToString(value_.uint_);
   case realValue:
-    return valueToString(value_.real_);
+    return valueToString(value_.real_, Value::defaultRealPrecision);
   default:
     JSON_FAIL_MESSAGE("Type is not convertible to string");
   }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -657,7 +657,7 @@ JSONCPP_STRING Value::asString() const {
   case uintValue:
     return valueToString(value_.uint_);
   case realValue:
-    return valueToString(value_.real_, Value::defaultRealPrecision, PrecisionType::significantDigits);
+    return valueToString(value_.real_);
   default:
     JSON_FAIL_MESSAGE("Type is not convertible to string");
   }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -657,7 +657,7 @@ JSONCPP_STRING Value::asString() const {
   case uintValue:
     return valueToString(value_.uint_);
   case realValue:
-    return valueToString(value_.real_, Value::defaultRealPrecision, false);
+    return valueToString(value_.real_, Value::defaultRealPrecision, PrecisionType::significantDigits);
   default:
     JSON_FAIL_MESSAGE("Type is not convertible to string");
   }

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -154,7 +154,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
 }
 }
 
-JSONCPP_STRING valueToString(double value) { return valueToString(value, false, 17); }
+JSONCPP_STRING valueToString(double value) { return valueToString(value, false, 15); }
 
 JSONCPP_STRING valueToString(bool value) { return value ? "true" : "false"; }
 

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -118,14 +118,14 @@ JSONCPP_STRING valueToString(UInt value) {
 #endif // # if defined(JSON_HAS_INT64)
 
 namespace {
-JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int precision, FloatFormat floatFormat) {
+JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int precision, PrecisionType precisionType) {
   // Allocate a buffer that is more than large enough to store the 16 digits of
   // precision requested below.
   char buffer[36];
   int len = -1;
 
   char formatString[15];
-  if (floatFormat == FloatFormat::significantDigits) {
+  if (precisionType == PrecisionType::significantDigits) {
     snprintf(formatString, sizeof(formatString), "%%.%ug", precision);
   } else {
     snprintf(formatString, sizeof(formatString), "%%.%uf", precision);
@@ -138,7 +138,7 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
     len = snprintf(buffer, sizeof(buffer), formatString, value);
     fixNumericLocale(buffer, buffer + len);
     // to delete use-less too much zeros in the end of string
-    if (floatFormat == FloatFormat::decimalPlaces) {
+    if (precisionType == PrecisionType::decimalPlaces) {
       fixZerosInTheEnd(buffer, buffer + len);
     }
 
@@ -162,8 +162,8 @@ JSONCPP_STRING valueToString(double value, bool useSpecialFloats, unsigned int p
 }
 }
 
-JSONCPP_STRING valueToString(double value, unsigned int precision, FloatFormat floatFormat) {
-  return valueToString(value, false, precision, floatFormat);
+JSONCPP_STRING valueToString(double value, unsigned int precision, PrecisionType precisionType) {
+  return valueToString(value, false, precision, precisionType);
 }
 
 JSONCPP_STRING valueToString(bool value) { return value ? "true" : "false"; }
@@ -867,7 +867,7 @@ struct BuiltStyledStreamWriter : public StreamWriter
       JSONCPP_STRING const& endingLineFeedSymbol,
       bool useSpecialFloats,
       unsigned int precision,
-      FloatFormat floatFormat);
+      PrecisionType precisionType);
   int write(Value const& root, JSONCPP_OSTREAM* sout) JSONCPP_OVERRIDE;
 private:
   void writeValue(Value const& value);
@@ -895,8 +895,8 @@ private:
   bool addChildValues_ : 1;
   bool indented_ : 1;
   bool useSpecialFloats_ : 1;
-  unsigned int floatPrecision_;
-  FloatFormat floatFormat_;
+  unsigned int precision_;
+  PrecisionType precisionType_;
 };
 BuiltStyledStreamWriter::BuiltStyledStreamWriter(
       JSONCPP_STRING const& indentation,
@@ -905,8 +905,8 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
       JSONCPP_STRING const& nullSymbol,
       JSONCPP_STRING const& endingLineFeedSymbol,
       bool useSpecialFloats,
-      unsigned int floatPrecision,
-      FloatFormat floatFormat)
+      unsigned int precision,
+      PrecisionType precisionType)
   : rightMargin_(74)
   , indentation_(indentation)
   , cs_(cs)
@@ -916,8 +916,8 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
   , addChildValues_(false)
   , indented_(false)
   , useSpecialFloats_(useSpecialFloats)
-  , floatPrecision_(floatPrecision)
-  , floatFormat_(floatFormat)
+  , precision_(precision)
+  , precisionType_(precisionType)
 {
 }
 int BuiltStyledStreamWriter::write(Value const& root, JSONCPP_OSTREAM* sout)
@@ -947,7 +947,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), useSpecialFloats_, floatPrecision_, floatFormat_));
+    pushValue(valueToString(value.asDouble(), useSpecialFloats_, precision_, precisionType_));
     break;
   case stringValue:
   {
@@ -1159,11 +1159,11 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const
 {
   JSONCPP_STRING indentation = settings_["indentation"].asString();
   JSONCPP_STRING cs_str = settings_["commentStyle"].asString();
-  JSONCPP_STRING ff_str = settings_["floatFormat"].asString();
+  JSONCPP_STRING pt_str = settings_["precisionType"].asString();
   bool eyc = settings_["enableYAMLCompatibility"].asBool();
   bool dnp = settings_["dropNullPlaceholders"].asBool();
   bool usf = settings_["useSpecialFloats"].asBool(); 
-  unsigned int pre = settings_["floatPrecision"].asUInt();
+  unsigned int pre = settings_["precision"].asUInt();
   CommentStyle::Enum cs = CommentStyle::All;
   if (cs_str == "All") {
     cs = CommentStyle::All;
@@ -1172,13 +1172,13 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const
   } else {
     throwRuntimeError("commentStyle must be 'All' or 'None'");
   }
-  FloatFormat floatFormat(significantDigits);
-  if (ff_str == "significant") {
-    floatFormat = FloatFormat::significantDigits;
-  } else if (ff_str == "decimal") {
-    floatFormat = FloatFormat::decimalPlaces;
+  PrecisionType precisionType(significantDigits);
+  if (pt_str == "significant") {
+    precisionType = PrecisionType::significantDigits;
+  } else if (pt_str == "decimal") {
+    precisionType = PrecisionType::decimalPlaces;
   } else {
-    throwRuntimeError("floatFormat must be 'significant' or 'decimal'");
+    throwRuntimeError("precisionType must be 'significant' or 'decimal'");
   }
   JSONCPP_STRING colonSymbol = " : ";
   if (eyc) {
@@ -1194,7 +1194,7 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const
   JSONCPP_STRING endingLineFeedSymbol;
   return new BuiltStyledStreamWriter(
       indentation, cs,
-      colonSymbol, nullSymbol, endingLineFeedSymbol, usf, pre, floatFormat);
+      colonSymbol, nullSymbol, endingLineFeedSymbol, usf, pre, precisionType);
 }
 static void getValidWriterKeys(std::set<JSONCPP_STRING>* valid_keys)
 {
@@ -1204,8 +1204,8 @@ static void getValidWriterKeys(std::set<JSONCPP_STRING>* valid_keys)
   valid_keys->insert("enableYAMLCompatibility");
   valid_keys->insert("dropNullPlaceholders");
   valid_keys->insert("useSpecialFloats");
-  valid_keys->insert("floatPrecision");
-  valid_keys->insert("floatFormat");
+  valid_keys->insert("precision");
+  valid_keys->insert("precisionType");
 }
 bool StreamWriterBuilder::validate(Json::Value* invalid) const
 {
@@ -1237,8 +1237,8 @@ void StreamWriterBuilder::setDefaults(Json::Value* settings)
   (*settings)["enableYAMLCompatibility"] = false;
   (*settings)["dropNullPlaceholders"] = false;
   (*settings)["useSpecialFloats"] = false;
-  (*settings)["floatPrecision"] = 17;
-  (*settings)["floatFormat"] = "significant";
+  (*settings)["precision"] = 17;
+  (*settings)["precisionType"] = "significant";
   //! [StreamWriterBuilderDefaults]
 }
 

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -374,7 +374,7 @@ void FastWriter::writeValue(const Value& value) {
     document_ += valueToString(value.asLargestUInt());
     break;
   case realValue:
-    document_ += valueToString(value.asDouble(), Value::defaultRealPrecision);
+    document_ += valueToString(value.asDouble());
     break;
   case stringValue:
   {
@@ -444,7 +444,7 @@ void StyledWriter::writeValue(const Value& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), Value::defaultRealPrecision));
+    pushValue(valueToString(value.asDouble()));
     break;
   case stringValue:
   {
@@ -632,7 +632,9 @@ bool StyledWriter::hasCommentForValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledStreamWriter::StyledStreamWriter(JSONCPP_STRING indentation)
-    : document_(NULL), rightMargin_(74), indentation_(indentation), addChildValues_(), indented_(false) {}
+    : document_(NULL), rightMargin_(74), indentation_(indentation),
+      addChildValues_(), indented_(false)
+{}
 
 void StyledStreamWriter::write(JSONCPP_OSTREAM& out, const Value& root) {
   document_ = &out;
@@ -660,7 +662,7 @@ void StyledStreamWriter::writeValue(const Value& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), Value::defaultRealPrecision));
+    pushValue(valueToString(value.asDouble()));
     break;
   case stringValue:
   {

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -345,19 +345,13 @@ Writer::~Writer() {}
 
 FastWriter::FastWriter()
     : yamlCompatibilityEnabled_(false), dropNullPlaceholders_(false),
-      omitEndingLineFeed_(false),
-      precision_(Value::defaultRealPrecision),
-      precisionType_(PrecisionType::significantDigits) {}
+      omitEndingLineFeed_(false) {}
 
 void FastWriter::enableYAMLCompatibility() { yamlCompatibilityEnabled_ = true; }
 
 void FastWriter::dropNullPlaceholders() { dropNullPlaceholders_ = true; }
 
 void FastWriter::omitEndingLineFeed() { omitEndingLineFeed_ = true; }
-
-void FastWriter::setPrecision(unsigned int precision) { precision_ = precision; }
-
-void FastWriter::setPrecisionType(PrecisionType precisionType) { precisionType_ = precisionType; }
 
 JSONCPP_STRING FastWriter::write(const Value& root) {
   document_.clear();
@@ -380,7 +374,7 @@ void FastWriter::writeValue(const Value& value) {
     document_ += valueToString(value.asLargestUInt());
     break;
   case realValue:
-    document_ += valueToString(value.asDouble(), precision_, precisionType_);
+    document_ += valueToString(value.asDouble(), Value::defaultRealPrecision);
     break;
   case stringValue:
   {
@@ -425,12 +419,7 @@ void FastWriter::writeValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledWriter::StyledWriter()
-    : rightMargin_(74), indentSize_(3), addChildValues_(), precision_(Value::defaultRealPrecision),
-      precisionType_(PrecisionType::significantDigits) {}
-
-void StyledWriter::setPrecision(unsigned int precision) { precision_ = precision; }
-
-void StyledWriter::setPrecisionType(PrecisionType precisionType) { precisionType_ = precisionType; }
+    : rightMargin_(74), indentSize_(3), addChildValues_() {}
 
 JSONCPP_STRING StyledWriter::write(const Value& root) {
   document_.clear();
@@ -455,7 +444,7 @@ void StyledWriter::writeValue(const Value& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), precision_, precisionType_));
+    pushValue(valueToString(value.asDouble(), Value::defaultRealPrecision));
     break;
   case stringValue:
   {
@@ -643,13 +632,7 @@ bool StyledWriter::hasCommentForValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledStreamWriter::StyledStreamWriter(JSONCPP_STRING indentation)
-    : document_(NULL), rightMargin_(74), precision_(Value::defaultRealPrecision),
-      precisionType_(PrecisionType::significantDigits), indentation_(indentation),
-      addChildValues_(), indented_(false) {}
-
-void StyledStreamWriter::setPrecision(unsigned int precision) { precision_ = precision; }
-
-void StyledStreamWriter::setPrecisionType(PrecisionType precisionType) { precisionType_ = precisionType; }
+    : document_(NULL), rightMargin_(74), indentation_(indentation), addChildValues_(), indented_(false) {}
 
 void StyledStreamWriter::write(JSONCPP_OSTREAM& out, const Value& root) {
   document_ = &out;
@@ -677,7 +660,7 @@ void StyledStreamWriter::writeValue(const Value& value) {
     pushValue(valueToString(value.asLargestUInt()));
     break;
   case realValue:
-    pushValue(valueToString(value.asDouble(), precision_, precisionType_));
+    pushValue(valueToString(value.asDouble(), Value::defaultRealPrecision));
     break;
   case stringValue:
   {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1724,7 +1724,7 @@ JSONTEST_FIXTURE(ValueTest, specialFloats) {
 
 JSONTEST_FIXTURE(ValueTest, precision) {
     Json::StreamWriterBuilder b;
-    b.settings_["precision"] = 5;
+    b.settings_["floatPrecision"] = 5;
 
     Json::Value v = 100.0/3;
     JSONCPP_STRING expected = "33.333";
@@ -1741,39 +1741,39 @@ JSONTEST_FIXTURE(ValueTest, precision) {
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 1;
+    b.settings_["floatPrecision"] = 1;
     expected = "0.3";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 17;
+    b.settings_["floatPrecision"] = 17;
     v = 1234857476305.256345694873740545068;
     expected = "1234857476305.2563";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 24;
+    b.settings_["floatPrecision"] = 24;
     v = 0.256345694873740545068;
     expected = "0.25634569487374054";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 5;
-    b.settings_["precisionType"] = "decimal";
+    b.settings_["floatPrecision"] = 5;
+    b.settings_["floatFormat"] = "decimal";
     v = 0.256345694873740545068;
     expected = "0.25635";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 1;
-    b.settings_["precisionType"] = "decimal";
+    b.settings_["floatPrecision"] = 1;
+    b.settings_["floatFormat"] = "decimal";
     v = 0.256345694873740545068;
     expected = "0.3";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["precision"] = 10;
-    b.settings_["precisionType"] = "decimal";
+    b.settings_["floatPrecision"] = 10;
+    b.settings_["floatFormat"] = "decimal";
     v = 0.23300000;
     expected = "0.233";
     result = Json::writeString(b, v);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1757,6 +1757,27 @@ JSONTEST_FIXTURE(ValueTest, precision) {
     expected = "0.25634569487374054";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 5;
+    b.settings_["precisionType"] = "decimal";
+    v = 0.256345694873740545068;
+    expected = "0.25635";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 1;
+    b.settings_["precisionType"] = "decimal";
+    v = 0.256345694873740545068;
+    expected = "0.3";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+    b.settings_["precision"] = 10;
+    b.settings_["precisionType"] = "decimal";
+    v = 0.23300000;
+    expected = "0.233";
+    result = Json::writeString(b, v);
+    JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 }
 
 struct WriterTest : JsonTest::TestCase {};

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1724,7 +1724,7 @@ JSONTEST_FIXTURE(ValueTest, specialFloats) {
 
 JSONTEST_FIXTURE(ValueTest, precision) {
     Json::StreamWriterBuilder b;
-    b.settings_["floatPrecision"] = 5;
+    b.settings_["precision"] = 5;
 
     Json::Value v = 100.0/3;
     JSONCPP_STRING expected = "33.333";
@@ -1741,39 +1741,39 @@ JSONTEST_FIXTURE(ValueTest, precision) {
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 1;
+    b.settings_["precision"] = 1;
     expected = "0.3";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 17;
+    b.settings_["precision"] = 17;
     v = 1234857476305.256345694873740545068;
     expected = "1234857476305.2563";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 24;
+    b.settings_["precision"] = 24;
     v = 0.256345694873740545068;
     expected = "0.25634569487374054";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 5;
-    b.settings_["floatFormat"] = "decimal";
+    b.settings_["precision"] = 5;
+    b.settings_["precisionType"] = "decimal";
     v = 0.256345694873740545068;
     expected = "0.25635";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 1;
-    b.settings_["floatFormat"] = "decimal";
+    b.settings_["precision"] = 1;
+    b.settings_["precisionType"] = "decimal";
     v = 0.256345694873740545068;
     expected = "0.3";
     result = Json::writeString(b, v);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-    b.settings_["floatPrecision"] = 10;
-    b.settings_["floatFormat"] = "decimal";
+    b.settings_["precision"] = 10;
+    b.settings_["precisionType"] = "decimal";
     v = 0.23300000;
     expected = "0.233";
     result = Json::writeString(b, v);


### PR DESCRIPTION
In thread of issue https://github.com/open-source-parsers/jsoncpp/pull/648 was an idea to make precision settable. So, this PR do that and also add decimal places precision setting.