### PR TITLE
[CMake] Generate CMake config files by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ OPTION(JSONCPP_WITH_POST_BUILD_UNITTEST "Automatically run unit-tests as a post 
 OPTION(JSONCPP_WITH_WARNING_AS_ERROR "Force compilation to fail if a warning occurs" OFF)
 OPTION(JSONCPP_WITH_STRICT_ISO "Issue all the warnings demanded by strict ISO C and ISO C++" ON)
 OPTION(JSONCPP_WITH_PKGCONFIG_SUPPORT "Generate and install .pc files" ON)
-OPTION(JSONCPP_WITH_CMAKE_PACKAGE "Generate and install cmake package files" OFF)
+OPTION(JSONCPP_WITH_CMAKE_PACKAGE "Generate and install cmake package files" ON)
 OPTION(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." OFF)
 OPTION(BUILD_STATIC_LIBS "Build jsoncpp_lib static library." ON)
 


### PR DESCRIPTION
It seems like the right thing to do here is to always provide the CMake Config files, unless they are undesirable for some reason. This makes it more likely that people will use the provided CMake Config files as opposed to rolling their own `FindJsonCpp.cmake` script because they don't know the library can provide it.