### PR TITLE
allow out-of-source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,10 +70,10 @@ SET( JSONCPP_USE_SECURE_MEMORY "0" CACHE STRING "-D...=1 to use memory-wiping al
 MESSAGE(STATUS "JsonCpp Version: ${JSONCPP_VERSION_MAJOR}.${JSONCPP_VERSION_MINOR}.${JSONCPP_VERSION_PATCH}")
 # File version.h is only regenerated on CMake configure step
 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/src/lib_json/version.h.in"
-                "${PROJECT_SOURCE_DIR}/include/json/version.h"
+                "${PROJECT_BINARY_DIR}/include/json/version.h"
                 NEWLINE_STYLE UNIX )
 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/version.in"
-                "${PROJECT_SOURCE_DIR}/version"
+                "${PROJECT_BINARY_DIR}/version"
                 NEWLINE_STYLE UNIX )
 
 MACRO(UseCompilationWarningAsError)


### PR DESCRIPTION
allow cmake to build with
set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
set(CMAKE_DISABLE_SOURCE_CHANGES ON)
