### PR TITLE
Disable warning "C4702" when compiling json cpp using vs2013 and above

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -19,6 +19,11 @@
 #include <cstddef> // size_t
 #include <algorithm> // min()
 
+// Disable warning C4702 : unreachable code
+#if defined(_MSC_VER) && _MSC_VER >= 1800 // VC++ 12.0 and above
+#pragma warning(disable:4702)
+#endif
+
 #define JSON_ASSERT_UNREACHABLE assert(false)
 
 namespace Json {


### PR DESCRIPTION
I want to fix the issue: #759.

Jsoncpp project will generate many warnings in vs2017. In my environment, all of the warnings are C4702: unreachable code.

Add few lines to suppress this warning.

Tested in local environment, compiling jsoncpp lib in vs2017 and no warning is  generated.