### PR TITLE
Code modernization (empty, for-range, auto)

### DIFF
--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -60,10 +60,10 @@ static JSONCPP_STRING readInputTestFile(const char* path) {
     return JSONCPP_STRING("");
   fseek(file, 0, SEEK_END);
   long const size = ftell(file);
-  unsigned long const usize = static_cast<unsigned long>(size);
+  const auto usize = static_cast<unsigned long>(size);
   fseek(file, 0, SEEK_SET);
   JSONCPP_STRING text;
-  char* buffer = new char[size + 1];
+  auto* buffer = new char[size + 1];
   buffer[size] = 0;
   if (fread(buffer, 1, usize, file) == usize)
     text = buffer;
@@ -118,9 +118,7 @@ static void printValueTree(FILE* fout,
     Json::Value::Members members(value.getMemberNames());
     std::sort(members.begin(), members.end());
     JSONCPP_STRING suffix = *(path.end() - 1) == '.' ? "" : ".";
-    for (Json::Value::Members::iterator it = members.begin();
-         it != members.end(); ++it) {
-      const JSONCPP_STRING name = *it;
+    for (const JSONCPP_STRING& name : members) {
       printValueTree(fout, value[name], path + suffix + name);
     }
   } break;

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm> // sort
 #include <json/json.h>
+#include <fstream>
 #include <sstream>
 #include <stdio.h>
 
@@ -55,20 +56,15 @@ static JSONCPP_STRING normalizeFloatingPointStr(double value) {
 }
 
 static JSONCPP_STRING readInputTestFile(const char* path) {
-  FILE* file = fopen(path, "rb");
+  std::ifstream file(path, std::ios::binary);
   if (!file)
-    return JSONCPP_STRING("");
-  fseek(file, 0, SEEK_END);
-  long const size = ftell(file);
-  const auto usize = static_cast<unsigned long>(size);
-  fseek(file, 0, SEEK_SET);
-  JSONCPP_STRING text;
-  auto* buffer = new char[size + 1];
-  buffer[size] = 0;
-  if (fread(buffer, 1, usize, file) == usize)
-    text = buffer;
-  fclose(file);
-  delete[] buffer;
+    return JSONCPP_STRING();
+  file.seekg(0, file.end);
+  const auto file_size = static_cast<size_t>(file.tellg());
+  file.seekg(0, file.beg);
+  JSONCPP_STRING text(file_size, 0);
+  if (file.read(&text.front(), file_size).gcount() != file_size)
+    return JSONCPP_STRING();
   return text;
 }
 

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -583,7 +583,7 @@ bool Reader::decodeNumber(Token& token, Value& decoded) {
     Char c = *current++;
     if (c < '0' || c > '9')
       return decodeDouble(token, decoded);
-    Value::UInt digit(static_cast<Value::UInt>(c - '0'));
+    auto digit(static_cast<Value::UInt>(c - '0'));
     if (value >= threshold) {
       // We've hit or exceeded the max value divided by 10 (rounded down). If
       // a) we've only just touched the limit, b) this is the last digit, and
@@ -824,9 +824,7 @@ JSONCPP_STRING Reader::getFormatedErrorMessages() const {
 
 JSONCPP_STRING Reader::getFormattedErrorMessages() const {
   JSONCPP_STRING formattedMessage;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end(); ++itError) {
-    const ErrorInfo& error = *itError;
+  for (const ErrorInfo& error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -839,14 +837,13 @@ JSONCPP_STRING Reader::getFormattedErrorMessages() const {
 
 std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   std::vector<Reader::StructuredError> allErrors;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end(); ++itError) {
-    const ErrorInfo& error = *itError;
-    Reader::StructuredError structured;
+  allErrors.reserve(errors_.size());
+  for (const ErrorInfo& error : errors_) {
+    allErrors.emplace_back();
+    Reader::StructuredError& structured = allErrors.back();
     structured.offset_start = error.token_.start_ - begin_;
     structured.offset_limit = error.token_.end_ - begin_;
     structured.message = error.message_;
-    allErrors.push_back(structured);
   }
   return allErrors;
 }
@@ -1579,7 +1576,7 @@ bool OurReader::decodeNumber(Token& token, Value& decoded) {
     Char c = *current++;
     if (c < '0' || c > '9')
       return decodeDouble(token, decoded);
-    Value::UInt digit(static_cast<Value::UInt>(c - '0'));
+    auto digit(static_cast<Value::UInt>(c - '0'));
     if (value >= threshold) {
       // We've hit or exceeded the max value divided by 10 (rounded down). If
       // a) we've only just touched the limit, b) this is the last digit, and
@@ -1621,7 +1618,7 @@ bool OurReader::decodeDouble(Token& token, Value& decoded) {
   if (length < 0) {
     return addError("Unable to parse token length", token);
   }
-  size_t const ulength = static_cast<size_t>(length);
+  const auto ulength = static_cast<size_t>(length);
 
   // Avoid using a string constant for the format control string given to
   // sscanf, as this can cause hard to debug crashes on OS X. See here for more
@@ -1839,9 +1836,7 @@ JSONCPP_STRING OurReader::getLocationLineAndColumn(Location location) const {
 
 JSONCPP_STRING OurReader::getFormattedErrorMessages() const {
   JSONCPP_STRING formattedMessage;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end(); ++itError) {
-    const ErrorInfo& error = *itError;
+  for (const ErrorInfo& error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -1854,14 +1849,13 @@ JSONCPP_STRING OurReader::getFormattedErrorMessages() const {
 
 std::vector<OurReader::StructuredError> OurReader::getStructuredErrors() const {
   std::vector<OurReader::StructuredError> allErrors;
-  for (Errors::const_iterator itError = errors_.begin();
-       itError != errors_.end(); ++itError) {
-    const ErrorInfo& error = *itError;
-    OurReader::StructuredError structured;
+  allErrors.reserve(errors_.size());
+  for (const ErrorInfo& error : errors_) {
+    allErrors.emplace_back();
+    OurReader::StructuredError& structured = allErrors.back();
     structured.offset_start = error.token_.start_ - begin_;
     structured.offset_limit = error.token_.end_ - begin_;
     structured.message = error.message_;
-    allErrors.push_back(structured);
   }
   return allErrors;
 }

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -14,6 +14,7 @@
 #include <cassert>
 #include <cstring>
 #include <istream>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <set>

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -886,7 +886,7 @@ bool Reader::pushError(const Value& value,
   return true;
 }
 
-bool Reader::good() const { return !errors_.size(); }
+bool Reader::good() const { return errors_.empty(); }
 
 // exact copy of Features
 class OurFeatures {
@@ -1901,7 +1901,7 @@ bool OurReader::pushError(const Value& value,
   return true;
 }
 
-bool OurReader::good() const { return !errors_.size(); }
+bool OurReader::good() const { return errors_.empty(); }
 
 class OurCharReader : public CharReader {
   bool const collectComments_;

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -10,6 +10,7 @@
 #include <json/reader.h>
 #include <json/value.h>
 #endif // if !defined(JSON_IS_AMALGAMATION)
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <istream>
@@ -583,7 +584,7 @@ bool Reader::decodeNumber(Token& token, Value& decoded) {
     Char c = *current++;
     if (c < '0' || c > '9')
       return decodeDouble(token, decoded);
-    auto digit(static_cast<Value::UInt>(c - '0'));
+    auto digit = static_cast<Value::UInt>(c - '0');
     if (value >= threshold) {
       // We've hit or exceeded the max value divided by 10 (rounded down). If
       // a) we've only just touched the limit, b) this is the last digit, and
@@ -838,13 +839,11 @@ JSONCPP_STRING Reader::getFormattedErrorMessages() const {
 std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   std::vector<Reader::StructuredError> allErrors;
   allErrors.reserve(errors_.size());
-  for (const ErrorInfo& error : errors_) {
-    allErrors.emplace_back();
-    Reader::StructuredError& structured = allErrors.back();
-    structured.offset_start = error.token_.start_ - begin_;
-    structured.offset_limit = error.token_.end_ - begin_;
-    structured.message = error.message_;
-  }
+  std::transform(
+      errors_.begin(), errors_.end(), std::back_inserter(allErrors),
+      [this](const ErrorInfo& e) -> Reader::StructuredError {
+        return { e.token_.start_ - begin_, e.token_.end_ - begin_, e.message_ };
+      });
   return allErrors;
 }
 
@@ -1576,7 +1575,7 @@ bool OurReader::decodeNumber(Token& token, Value& decoded) {
     Char c = *current++;
     if (c < '0' || c > '9')
       return decodeDouble(token, decoded);
-    auto digit(static_cast<Value::UInt>(c - '0'));
+    auto digit = static_cast<Value::UInt>(c - '0');
     if (value >= threshold) {
       // We've hit or exceeded the max value divided by 10 (rounded down). If
       // a) we've only just touched the limit, b) this is the last digit, and
@@ -1850,13 +1849,11 @@ JSONCPP_STRING OurReader::getFormattedErrorMessages() const {
 std::vector<OurReader::StructuredError> OurReader::getStructuredErrors() const {
   std::vector<OurReader::StructuredError> allErrors;
   allErrors.reserve(errors_.size());
-  for (const ErrorInfo& error : errors_) {
-    allErrors.emplace_back();
-    OurReader::StructuredError& structured = allErrors.back();
-    structured.offset_start = error.token_.start_ - begin_;
-    structured.offset_limit = error.token_.end_ - begin_;
-    structured.message = error.message_;
-  }
+  std::transform(
+      errors_.begin(), errors_.end(), std::back_inserter(allErrors),
+      [this](const ErrorInfo& e) -> OurReader::StructuredError {
+        return { e.token_.start_ - begin_, e.token_.end_ - begin_, e.message_ };
+      });
   return allErrors;
 }
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -107,7 +107,7 @@ static inline char* duplicateStringValue(const char* value, size_t length) {
   if (length >= static_cast<size_t>(Value::maxInt))
     length = Value::maxInt - 1;
 
-  auto* newString = static_cast<char*>(malloc(length + 1));
+  char* newString = static_cast<char*>(malloc(length + 1));
   if (newString == NULL) {
     throwRuntimeError("in Json::Value::duplicateStringValue(): "
                       "Failed to allocate string value buffer");

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -866,8 +866,8 @@ bool Value::isConvertibleTo(ValueType other) const {
     return (isNumeric() && asDouble() == 0.0) ||
            (type_ == booleanValue && value_.bool_ == false) ||
            (type_ == stringValue && asString().empty()) ||
-           (type_ == arrayValue && value_.map_->size() == 0) ||
-           (type_ == objectValue && value_.map_->size() == 0) ||
+           (type_ == arrayValue && value_.map_->empty()) ||
+           (type_ == objectValue && value_.map_->empty()) ||
            type_ == nullValue;
   case intValue:
     return isInt() ||

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -148,7 +148,7 @@ JSONCPP_STRING valueToString(double value,
         (precisionType == PrecisionType::significantDigits) ? "%.*g" : "%.*f",
         precision, value);
     assert(len >= 0);
-    size_t wouldPrint = static_cast<size_t>(len);
+    auto wouldPrint = static_cast<size_t>(len);
     if (wouldPrint >= buffer.size()) {
       buffer.resize(wouldPrint + 1);
       continue;
@@ -410,8 +410,7 @@ void FastWriter::writeValue(const Value& value) {
   case objectValue: {
     Value::Members members(value.getMemberNames());
     document_ += '{';
-    for (Value::Members::iterator it = members.begin(); it != members.end();
-         ++it) {
+    for (auto it = members.begin(); it != members.end(); ++it) {
       const JSONCPP_STRING& name = *it;
       if (it != members.begin())
         document_ += ',';
@@ -480,7 +479,7 @@ void StyledWriter::writeValue(const Value& value) {
     else {
       writeWithIndent("{");
       indent();
-      Value::Members::iterator it = members.begin();
+      auto it = members.begin();
       for (;;) {
         const JSONCPP_STRING& name = *it;
         const Value& childValue = value[name];
@@ -700,7 +699,7 @@ void StyledStreamWriter::writeValue(const Value& value) {
     else {
       writeWithIndent("{");
       indent();
-      Value::Members::iterator it = members.begin();
+      auto it = members.begin();
       for (;;) {
         const JSONCPP_STRING& name = *it;
         const Value& childValue = value[name];
@@ -980,7 +979,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
     else {
       writeWithIndent("{");
       indent();
-      Value::Members::iterator it = members.begin();
+      auto it = members.begin();
       for (;;) {
         JSONCPP_STRING const& name = *it;
         Value const& childValue = value[name];

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -150,9 +150,7 @@ void TestResult::printFailure(bool printTestName) const {
   }
 
   // Print in reverse to display the callstack in the right order
-  Failures::const_iterator itEnd = failures_.end();
-  for (Failures::const_iterator it = failures_.begin(); it != itEnd; ++it) {
-    const Failure& failure = *it;
+  for (const Failure& failure : failures_) {
     JSONCPP_STRING indent(failure.nestingLevel_ * 2, ' ');
     if (failure.file_) {
       printf("%s%s(%u): ", indent.c_str(), failure.file_, failure.line_);
@@ -275,13 +273,12 @@ bool Runner::runAllTest(bool printSummary) const {
     }
     return true;
   } else {
-    for (unsigned int index = 0; index < failures.size(); ++index) {
-      TestResult& result = failures[index];
+    for (const TestResult& result : failures) {
       result.printFailure(count > 1);
     }
 
     if (printSummary) {
-      unsigned int failedCount = static_cast<unsigned int>(failures.size());
+      auto failedCount = static_cast<unsigned int>(failures.size());
       unsigned int passedCount = count - failedCount;
       printf("%u/%u tests passed (%u failure(s))\n", passedCount, count,
              failedCount);

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -273,7 +273,7 @@ bool Runner::runAllTest(bool printSummary) const {
     }
     return true;
   } else {
-    for (const TestResult& result : failures) {
+    for (TestResult& result : failures) {
       result.printFailure(count > 1);
     }
 
@@ -436,16 +436,17 @@ TestResult& checkStringEqual(TestResult& result,
   return result;
 }
 
-void checkStringEmpty(TestResult& result,
-                      const JSONCPP_STRING& actual,
-                      const char* file,
-                      unsigned int line,
-                      const char* expr) {
+TestResult& checkStringEmpty(TestResult& result,
+                             const JSONCPP_STRING& actual,
+                             const char* file,
+                             unsigned int line,
+                             const char* expr) {
   if (!actual.empty()) {
     auto errorString = ToJsonString(expr) + ".empty()";
     result.addFailure(file, line, errorString.c_str());
     result << "Expected " << expr << " to be empty\n"
            << "Actual  : '" << actual << "'";
   }
+  return result;
 }
 } // namespace JsonTest

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -436,4 +436,16 @@ TestResult& checkStringEqual(TestResult& result,
   return result;
 }
 
+void checkStringEmpty(TestResult& result,
+                      const JSONCPP_STRING& actual,
+                      const char* file,
+                      unsigned int line,
+                      const char* expr) {
+  if (!actual.empty()) {
+    auto errorString = ToJsonString(expr) + ".empty()";
+    result.addFailure(file, line, errorString.c_str());
+    result << "Expected " << expr << " to be empty\n"
+           << "Actual  : '" << actual << "'";
+  }
+}
 } // namespace JsonTest

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -203,6 +203,12 @@ TestResult& checkStringEqual(TestResult& result,
                              unsigned int line,
                              const char* expr);
 
+void checkStringEmpty(TestResult& result,
+                      const JSONCPP_STRING& actual,
+                      const char* file,
+                      unsigned int line,
+                      const char* expr);
+
 } // namespace JsonTest
 
 /// \brief Asserts that the given expression is true.
@@ -238,6 +244,10 @@ TestResult& checkStringEqual(TestResult& result,
   JsonTest::checkStringEqual(*result_, JsonTest::ToJsonString(expected),       \
                              JsonTest::ToJsonString(actual), __FILE__,         \
                              __LINE__, #expected " == " #actual)
+
+/// \brief Asserts that string is empty.
+#define JSONTEST_ASSERT_STRING_EMPTY(actual)                                   \
+  JsonTest::checkStringEmpty(*result_, (actual), __FILE__, __LINE__, #actual);
 
 /// \brief Asserts that a given expression throws an exception
 #define JSONTEST_ASSERT_THROWS(expr)                                           \

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -203,11 +203,11 @@ TestResult& checkStringEqual(TestResult& result,
                              unsigned int line,
                              const char* expr);
 
-void checkStringEmpty(TestResult& result,
-                      const JSONCPP_STRING& actual,
-                      const char* file,
-                      unsigned int line,
-                      const char* expr);
+TestResult& checkStringEmpty(TestResult& result,
+                             const JSONCPP_STRING& actual,
+                             const char* file,
+                             unsigned int line,
+                             const char* expr);
 
 } // namespace JsonTest
 
@@ -247,7 +247,7 @@ void checkStringEmpty(TestResult& result,
 
 /// \brief Asserts that string is empty.
 #define JSONTEST_ASSERT_STRING_EMPTY(actual)                                   \
-  JsonTest::checkStringEmpty(*result_, (actual), __FILE__, __LINE__, #actual);
+  JsonTest::checkStringEmpty(*result_, (actual), __FILE__, __LINE__, #actual)
 
 /// \brief Asserts that a given expression throws an exception
 #define JSONTEST_ASSERT_THROWS(expr)                                           \

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -304,7 +304,7 @@ JSONTEST_FIXTURE(ValueTest, null) {
   JSONTEST_ASSERT_EQUAL(Json::LargestUInt(0), null_.asLargestUInt());
   JSONTEST_ASSERT_EQUAL(0.0, null_.asDouble());
   JSONTEST_ASSERT_EQUAL(0.0, null_.asFloat());
-  JSONTEST_ASSERT(null_.asString().empty());
+  JSONTEST_ASSERT_STRING_EMPTY(null_.asString());
 
   JSONTEST_ASSERT_EQUAL(Json::Value::null, null_);
 
@@ -1710,7 +1710,8 @@ JSONTEST_FIXTURE(ValueTest, zeroesInKeys) {
     JSONTEST_ASSERT(!did);
     JSONTEST_ASSERT_STRING_EQUAL("there", removed.asString()); // still
     JSONTEST_ASSERT(!root.isMember(binary));
-    JSONTEST_ASSERT(root.get(binary, Json::Value::nullRef).asString().empty());
+    JSONTEST_ASSERT_STRING_EMPTY(
+        root.get(binary, Json::Value::nullRef).asString());
   }
 }
 
@@ -1811,7 +1812,7 @@ JSONTEST_FIXTURE(StreamWriterTest, dropNullPlaceholders) {
   b.settings_["dropNullPlaceholders"] = false;
   JSONTEST_ASSERT(Json::writeString(b, nullValue) == "null");
   b.settings_["dropNullPlaceholders"] = true;
-  JSONTEST_ASSERT(Json::writeString(b, nullValue).empty());
+  JSONTEST_ASSERT_STRING_EMPTY(Json::writeString(b, nullValue));
 }
 
 JSONTEST_FIXTURE(StreamWriterTest, writeZeroes) {
@@ -1843,8 +1844,8 @@ JSONTEST_FIXTURE(ReaderTest, parseWithNoErrors) {
   Json::Value root;
   bool ok = reader.parse("{ \"property\" : \"value\" }", root);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(reader.getFormattedErrorMessages().empty());
-  JSONTEST_ASSERT(reader.getStructuredErrors().empty());
+  JSONTEST_ASSERT_STRING_EMPTY(reader.getFormattedErrorMessages());
+  JSONTEST_ASSERT_EQUAL(0u, reader.getStructuredErrors().size());
 }
 
 JSONTEST_FIXTURE(ReaderTest, parseWithNoErrorsTestingOffsets) {
@@ -1855,8 +1856,8 @@ JSONTEST_FIXTURE(ReaderTest, parseWithNoErrorsTestingOffsets) {
                          "null, \"false\" : false }",
                          root);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(reader.getFormattedErrorMessages().empty());
-  JSONTEST_ASSERT(reader.getStructuredErrors().empty());
+  JSONTEST_ASSERT_STRING_EMPTY(reader.getFormattedErrorMessages());
+  JSONTEST_ASSERT_EQUAL(0u, reader.getStructuredErrors().size());
   JSONTEST_ASSERT(root["property"].getOffsetStart() == 15);
   JSONTEST_ASSERT(root["property"].getOffsetLimit() == 34);
   JSONTEST_ASSERT(root["property"][0].getOffsetStart() == 16);
@@ -1937,7 +1938,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrors) {
   char const doc[] = "{ \"property\" : \"value\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.empty());
+  JSONTEST_ASSERT_STRING_EMPTY(errs);
   delete reader;
 }
 
@@ -1951,7 +1952,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrorsTestingOffsets) {
                      "null, \"false\" : false }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.empty());
+  JSONTEST_ASSERT_STRING_EMPTY(errs);
   delete reader;
 }
 
@@ -2007,7 +2008,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithStackLimit) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL("value", root["property"]);
     delete reader;
   }
@@ -2054,7 +2055,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue164) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL("property", root);
     delete reader;
   }
@@ -2110,7 +2111,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterObject) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL("value", root["property"]);
     delete reader;
   }
@@ -2124,7 +2125,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterArray) {
   JSONCPP_STRING errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.empty());
+  JSONTEST_ASSERT_STRING_EMPTY(errs);
   JSONTEST_ASSERT_EQUAL("value", root[1u]);
   delete reader;
 }
@@ -2137,7 +2138,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterBool) {
   JSONCPP_STRING errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.empty());
+  JSONTEST_ASSERT_STRING_EMPTY(errs);
   JSONTEST_ASSERT_EQUAL(true, root.asBool());
   delete reader;
 }
@@ -2153,7 +2154,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "{\"a\":,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::nullValue, root.get("a", true));
   }
@@ -2161,7 +2162,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "{\"a\":}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(1u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::nullValue, root.get("a", true));
   }
@@ -2169,7 +2170,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(0u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root);
   }
@@ -2177,70 +2178,70 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(1u, root.size());
   }
   {
     char const doc[] = "[,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(4u, root.size());
   }
   {
     char const doc[] = "[null,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[null,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[,null,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[,,null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[[],,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[0u]);
   }
@@ -2248,7 +2249,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[,[],,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[1u]);
   }
@@ -2256,7 +2257,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[,,,[]]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[3u]);
   }
@@ -2275,7 +2276,7 @@ JSONTEST_FIXTURE(CharReaderAllowSingleQuotesTest, issue182) {
     char const doc[] = "{'a':true,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(true, root.get("a", false));
     JSONTEST_ASSERT_EQUAL(true, root.get("b", false));
@@ -2284,7 +2285,7 @@ JSONTEST_FIXTURE(CharReaderAllowSingleQuotesTest, issue182) {
     char const doc[] = "{'a': 'x', \"b\":'y'}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_STRING_EQUAL("x", root["a"].asString());
     JSONTEST_ASSERT_STRING_EQUAL("y", root["b"].asString());
@@ -2304,7 +2305,7 @@ JSONTEST_FIXTURE(CharReaderAllowZeroesTest, issue176) {
     char const doc[] = "{'a':true,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(true, root.get("a", false));
     JSONTEST_ASSERT_EQUAL(true, root.get("b", false));
@@ -2313,7 +2314,7 @@ JSONTEST_FIXTURE(CharReaderAllowZeroesTest, issue176) {
     char const doc[] = "{'a': 'x', \"b\":'y'}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_STRING_EQUAL("x", root["a"].asString());
     JSONTEST_ASSERT_STRING_EQUAL("y", root["b"].asString());
@@ -2333,7 +2334,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     char const doc[] = "{\"a\":NaN,\"b\":Infinity,\"c\":-Infinity}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(3u, root.size());
     double n = root["a"].asDouble();
     JSONTEST_ASSERT(std::isnan(n));
@@ -2373,7 +2374,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     char const doc[] = "{\"posInf\": Infinity, \"NegInf\": -Infinity}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs.empty());
+    JSONTEST_ASSERT_STRING_EMPTY(errs);
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(std::numeric_limits<double>::infinity(),
                           root["posInf"].asDouble());
@@ -2447,12 +2448,12 @@ JSONTEST_FIXTURE(IteratorTest, indexes) {
   Json::ValueIterator it = json.begin();
   JSONTEST_ASSERT(it != json.end());
   JSONTEST_ASSERT_EQUAL(Json::Value(Json::ArrayIndex(0)), it.key());
-  JSONTEST_ASSERT(it.name().empty());
+  JSONTEST_ASSERT_STRING_EMPTY(it.name());
   JSONTEST_ASSERT_EQUAL(0, it.index());
   ++it;
   JSONTEST_ASSERT(it != json.end());
   JSONTEST_ASSERT_EQUAL(Json::Value(Json::ArrayIndex(1)), it.key());
-  JSONTEST_ASSERT(it.name().empty());
+  JSONTEST_ASSERT_STRING_EMPTY(it.name());
   JSONTEST_ASSERT_EQUAL(1, it.index());
   ++it;
   JSONTEST_ASSERT(it == json.end());

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1030,7 +1030,7 @@ JSONTEST_FIXTURE(ValueTest, integers) {
       normalizeFloatingPointStr(JsonTest::ToJsonString(val.asString())));
 
   // 10^19
-  const Json::UInt64 ten_to_19 = static_cast<Json::UInt64>(1e19);
+  const auto ten_to_19 = static_cast<Json::UInt64>(1e19);
   val = Json::Value(Json::UInt64(ten_to_19));
 
   JSONTEST_ASSERT_EQUAL(Json::uintValue, val.type());
@@ -2358,8 +2358,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     { __LINE__, 0, "{\"a\":.Infinity}" }, { __LINE__, 0, "{\"a\":_Infinity}" },
     { __LINE__, 0, "{\"a\":_nfinity}" },  { __LINE__, 1, "{\"a\":-Infinity}" }
   };
-  for (size_t tdi = 0; tdi < sizeof(test_data) / sizeof(*test_data); ++tdi) {
-    const TestData& td = test_data[tdi];
+  for (const TestData& td : test_data) {
     bool ok = reader->parse(&*td.in.begin(), &*td.in.begin() + td.in.size(),
                             &root, &errs);
     JSONTEST_ASSERT(td.ok == ok) << "line:" << td.line << "\n"

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -304,7 +304,7 @@ JSONTEST_FIXTURE(ValueTest, null) {
   JSONTEST_ASSERT_EQUAL(Json::LargestUInt(0), null_.asLargestUInt());
   JSONTEST_ASSERT_EQUAL(0.0, null_.asDouble());
   JSONTEST_ASSERT_EQUAL(0.0, null_.asFloat());
-  JSONTEST_ASSERT_STRING_EQUAL("", null_.asString());
+  JSONTEST_ASSERT(null_.asString().empty());
 
   JSONTEST_ASSERT_EQUAL(Json::Value::null, null_);
 
@@ -1710,8 +1710,7 @@ JSONTEST_FIXTURE(ValueTest, zeroesInKeys) {
     JSONTEST_ASSERT(!did);
     JSONTEST_ASSERT_STRING_EQUAL("there", removed.asString()); // still
     JSONTEST_ASSERT(!root.isMember(binary));
-    JSONTEST_ASSERT_STRING_EQUAL(
-        "", root.get(binary, Json::Value::nullRef).asString());
+    JSONTEST_ASSERT(root.get(binary, Json::Value::nullRef).asString().empty());
   }
 }
 
@@ -1812,7 +1811,7 @@ JSONTEST_FIXTURE(StreamWriterTest, dropNullPlaceholders) {
   b.settings_["dropNullPlaceholders"] = false;
   JSONTEST_ASSERT(Json::writeString(b, nullValue) == "null");
   b.settings_["dropNullPlaceholders"] = true;
-  JSONTEST_ASSERT(Json::writeString(b, nullValue) == "");
+  JSONTEST_ASSERT(Json::writeString(b, nullValue).empty());
 }
 
 JSONTEST_FIXTURE(StreamWriterTest, writeZeroes) {
@@ -1844,8 +1843,8 @@ JSONTEST_FIXTURE(ReaderTest, parseWithNoErrors) {
   Json::Value root;
   bool ok = reader.parse("{ \"property\" : \"value\" }", root);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(reader.getFormattedErrorMessages().size() == 0);
-  JSONTEST_ASSERT(reader.getStructuredErrors().size() == 0);
+  JSONTEST_ASSERT(reader.getFormattedErrorMessages().empty());
+  JSONTEST_ASSERT(reader.getStructuredErrors().empty());
 }
 
 JSONTEST_FIXTURE(ReaderTest, parseWithNoErrorsTestingOffsets) {
@@ -1856,8 +1855,8 @@ JSONTEST_FIXTURE(ReaderTest, parseWithNoErrorsTestingOffsets) {
                          "null, \"false\" : false }",
                          root);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(reader.getFormattedErrorMessages().size() == 0);
-  JSONTEST_ASSERT(reader.getStructuredErrors().size() == 0);
+  JSONTEST_ASSERT(reader.getFormattedErrorMessages().empty());
+  JSONTEST_ASSERT(reader.getStructuredErrors().empty());
   JSONTEST_ASSERT(root["property"].getOffsetStart() == 15);
   JSONTEST_ASSERT(root["property"].getOffsetLimit() == 34);
   JSONTEST_ASSERT(root["property"][0].getOffsetStart() == 16);
@@ -1938,7 +1937,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrors) {
   char const doc[] = "{ \"property\" : \"value\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.size() == 0);
+  JSONTEST_ASSERT(errs.empty());
   delete reader;
 }
 
@@ -1952,7 +1951,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrorsTestingOffsets) {
                      "null, \"false\" : false }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT(errs.size() == 0);
+  JSONTEST_ASSERT(errs.empty());
   delete reader;
 }
 
@@ -2008,7 +2007,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithStackLimit) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL("value", root["property"]);
     delete reader;
   }
@@ -2055,7 +2054,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue164) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL("property", root);
     delete reader;
   }
@@ -2111,7 +2110,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterObject) {
     JSONCPP_STRING errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL("value", root["property"]);
     delete reader;
   }
@@ -2125,7 +2124,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterArray) {
   JSONCPP_STRING errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT_STRING_EQUAL("", errs);
+  JSONTEST_ASSERT(errs.empty());
   JSONTEST_ASSERT_EQUAL("value", root[1u]);
   delete reader;
 }
@@ -2138,7 +2137,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterBool) {
   JSONCPP_STRING errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
-  JSONTEST_ASSERT_STRING_EQUAL("", errs);
+  JSONTEST_ASSERT(errs.empty());
   JSONTEST_ASSERT_EQUAL(true, root.asBool());
   delete reader;
 }
@@ -2154,7 +2153,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "{\"a\":,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::nullValue, root.get("a", true));
   }
@@ -2162,7 +2161,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "{\"a\":}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(1u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::nullValue, root.get("a", true));
   }
@@ -2170,7 +2169,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(0u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root);
   }
@@ -2178,70 +2177,70 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(1u, root.size());
   }
   {
     char const doc[] = "[,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(4u, root.size());
   }
   {
     char const doc[] = "[null,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
   }
   {
     char const doc[] = "[,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[null,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[,null,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[,,null]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(3u, root.size());
   }
   {
     char const doc[] = "[[],,,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[0u]);
   }
@@ -2249,7 +2248,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[,[],,]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[1u]);
   }
@@ -2257,7 +2256,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
     char const doc[] = "[,,,[]]";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT(errs == "");
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(4u, root.size());
     JSONTEST_ASSERT_EQUAL(Json::arrayValue, root[3u]);
   }
@@ -2276,7 +2275,7 @@ JSONTEST_FIXTURE(CharReaderAllowSingleQuotesTest, issue182) {
     char const doc[] = "{'a':true,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(true, root.get("a", false));
     JSONTEST_ASSERT_EQUAL(true, root.get("b", false));
@@ -2285,7 +2284,7 @@ JSONTEST_FIXTURE(CharReaderAllowSingleQuotesTest, issue182) {
     char const doc[] = "{'a': 'x', \"b\":'y'}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_STRING_EQUAL("x", root["a"].asString());
     JSONTEST_ASSERT_STRING_EQUAL("y", root["b"].asString());
@@ -2305,7 +2304,7 @@ JSONTEST_FIXTURE(CharReaderAllowZeroesTest, issue176) {
     char const doc[] = "{'a':true,\"b\":true}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(true, root.get("a", false));
     JSONTEST_ASSERT_EQUAL(true, root.get("b", false));
@@ -2314,7 +2313,7 @@ JSONTEST_FIXTURE(CharReaderAllowZeroesTest, issue176) {
     char const doc[] = "{'a': 'x', \"b\":'y'}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_STRING_EQUAL("x", root["a"].asString());
     JSONTEST_ASSERT_STRING_EQUAL("y", root["b"].asString());
@@ -2334,7 +2333,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     char const doc[] = "{\"a\":NaN,\"b\":Infinity,\"c\":-Infinity}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(3u, root.size());
     double n = root["a"].asDouble();
     JSONTEST_ASSERT(std::isnan(n));
@@ -2375,7 +2374,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     char const doc[] = "{\"posInf\": Infinity, \"NegInf\": -Infinity}";
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
-    JSONTEST_ASSERT_STRING_EQUAL("", errs);
+    JSONTEST_ASSERT(errs.empty());
     JSONTEST_ASSERT_EQUAL(2u, root.size());
     JSONTEST_ASSERT_EQUAL(std::numeric_limits<double>::infinity(),
                           root["posInf"].asDouble());
@@ -2449,12 +2448,12 @@ JSONTEST_FIXTURE(IteratorTest, indexes) {
   Json::ValueIterator it = json.begin();
   JSONTEST_ASSERT(it != json.end());
   JSONTEST_ASSERT_EQUAL(Json::Value(Json::ArrayIndex(0)), it.key());
-  JSONTEST_ASSERT_STRING_EQUAL("", it.name());
+  JSONTEST_ASSERT(it.name().empty());
   JSONTEST_ASSERT_EQUAL(0, it.index());
   ++it;
   JSONTEST_ASSERT(it != json.end());
   JSONTEST_ASSERT_EQUAL(Json::Value(Json::ArrayIndex(1)), it.key());
-  JSONTEST_ASSERT_STRING_EQUAL("", it.name());
+  JSONTEST_ASSERT(it.name().empty());
   JSONTEST_ASSERT_EQUAL(1, it.index());
   ++it;
   JSONTEST_ASSERT(it == json.end());


### PR DESCRIPTION
Using empty() increases readability.