### PR TITLE
Add JSON_IS_AMALGAMATION guards around config.h include

### DIFF
--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -6,7 +6,9 @@
 #ifndef LIB_JSONCPP_JSON_TOOL_H_INCLUDED
 #define LIB_JSONCPP_JSON_TOOL_H_INCLUDED
 
+#ifndef JSON_IS_AMALGAMATION
 #include <json/config.h>
+#endif
 
 // Also support old flag NO_LOCALE_SUPPORT
 #ifdef NO_LOCALE_SUPPORT


### PR DESCRIPTION
This include was added a couple of weeks ago, and it looks like it broke the amalgamated build: 

json/jsoncpp.cpp:95:25: fatal error: json/config.h: No such file or directory