### PR TITLE
(-) Fix JSON-CPP #801

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -120,9 +120,10 @@ bool Reader::parse(std::istream& is, Value& root, bool collectComments) {
 
   // Since JSONCPP_STRING is reference-counted, this at least does not
   // create an extra copy.
-  std::getline(is, document_, (char)EOF);
+  JSONCPP_STRING doc;
+  std::getline(is, doc, (char)EOF);
 
-  return parse(document_.data(), document_.data() + document_.size(), root, collectComments);
+  return parse(doc, root, collectComments);
 }
 
 bool Reader::parse(const char* beginDoc,

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -120,9 +120,9 @@ bool Reader::parse(std::istream& is, Value& root, bool collectComments) {
 
   // Since JSONCPP_STRING is reference-counted, this at least does not
   // create an extra copy.
-  JSONCPP_STRING doc;
-  std::getline(is, doc, (char)EOF);
-  return parse(doc.data(), doc.data() + doc.size(), root, collectComments);
+  std::getline(is, document_, (char)EOF);
+
+  return parse(document_.data(), document_.data() + document_.size(), root, collectComments);
 }
 
 bool Reader::parse(const char* beginDoc,

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2499,6 +2499,17 @@ JSONTEST_FIXTURE(RValueTest, moveConstruction) {
 #endif
 }
 
+struct ErrorTest : JsonTest::TestCase {};
+JSONTEST_FIXTURE(ErrorTest, getErrorWorksFineWithStreams)
+{
+  const char TEST_VALUE[] = R"__({"X":3, "Y":oops})__";
+  JSONCPP_ISTRINGSTREAM ss(TEST_VALUE);
+  Json::Reader reader;
+  Json::Value result;
+  JSONTEST_ASSERT(!reader.parse(ss, result));
+  JSONTEST_ASSERT(reader.getFormattedErrorMessages().size());
+}
+
 int main(int argc, const char* argv[]) {
   JsonTest::Runner runner;
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, checkNormalizeFloatingPointStr);
@@ -2577,6 +2588,7 @@ int main(int argc, const char* argv[]) {
   JSONTEST_REGISTER_FIXTURE(runner, IteratorTest, const);
 
   JSONTEST_REGISTER_FIXTURE(runner, RValueTest, moveConstruction);
+  JSONTEST_REGISTER_FIXTURE(runner, ErrorTest, getErrorWorksFineWithStreams);
 
   return runner.runCommandLine(argc, argv);
 }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2507,7 +2507,8 @@ JSONTEST_FIXTURE(ErrorTest, getErrorWorksFineWithStreams)
   Json::Reader reader;
   Json::Value result;
   JSONTEST_ASSERT(!reader.parse(ss, result));
-  JSONTEST_ASSERT(reader.getFormattedErrorMessages().size());
+  JSONTEST_ASSERT(!reader.getFormattedErrorMessages().empty());
+  JSONTEST_ASSERT_STRING_EQUAL("* Line 1, Column 13\n  Syntax error: value, object or array expected.\n", reader.getFormattedErrorMessages().c_str());
 }
 
 int main(int argc, const char* argv[]) {


### PR DESCRIPTION
Read stream to readers document_ instead of stack-located dangling
variable