### PR TITLE
fiexd “Cannot take the address of a bit field.”

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -394,7 +394,7 @@ void FastWriter::writeValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledWriter::StyledWriter()
-    : rightMargin_(74), indentSize_(3), addChildValues_() {}
+    : rightMargin_(74), indentSize_(3), addChildValues_(false) {}
 
 JSONCPP_STRING StyledWriter::write(const Value& root) {
   document_ = "";


### PR DESCRIPTION
```c++
 #include <iostream>

class TestBool
{
public:
    TestBool():addChildValues_(){}
    TestBool(int):addChildValues_(false){}
    bool addChildValues_ : 1;
    bool indented_ : 1;
};


int main()
{
    std::cout << "\n TestBool () addChildValues_ = " << TestBool().addChildValues_;
    std::cout << "\n TestBool false addChildValues_ = " << TestBool(3).addChildValues_;
    return 0;
}
```

```text
root@osssvr-1 # /opt/SUNWspro/prod/bin/CC  testbool.cpp -o testbool   
Error: Cannot take the address of a bit field.
1 Error(s) detected.
```