### PR TITLE
STYLE: Replace integer literals which are cast to bool.

### DIFF
--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2350,14 +2350,14 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     JSONCPP_STRING in;
   };
   const TestData test_data[] = {
-    { __LINE__, 1, "{\"a\":9}" },         { __LINE__, 0, "{\"a\":0Infinity}" },
-    { __LINE__, 0, "{\"a\":1Infinity}" }, { __LINE__, 0, "{\"a\":9Infinity}" },
-    { __LINE__, 0, "{\"a\":0nfinity}" },  { __LINE__, 0, "{\"a\":1nfinity}" },
-    { __LINE__, 0, "{\"a\":9nfinity}" },  { __LINE__, 0, "{\"a\":nfinity}" },
-    { __LINE__, 0, "{\"a\":.nfinity}" },  { __LINE__, 0, "{\"a\":9nfinity}" },
-    { __LINE__, 0, "{\"a\":-nfinity}" },  { __LINE__, 1, "{\"a\":Infinity}" },
-    { __LINE__, 0, "{\"a\":.Infinity}" }, { __LINE__, 0, "{\"a\":_Infinity}" },
-    { __LINE__, 0, "{\"a\":_nfinity}" },  { __LINE__, 1, "{\"a\":-Infinity}" }
+    { __LINE__, true, "{\"a\":9}" },         { __LINE__, false, "{\"a\":0Infinity}" },
+    { __LINE__, false, "{\"a\":1Infinity}" }, { __LINE__, false, "{\"a\":9Infinity}" },
+    { __LINE__, false, "{\"a\":0nfinity}" },  { __LINE__, false, "{\"a\":1nfinity}" },
+    { __LINE__, false, "{\"a\":9nfinity}" },  { __LINE__, false, "{\"a\":nfinity}" },
+    { __LINE__, false, "{\"a\":.nfinity}" },  { __LINE__, false, "{\"a\":9nfinity}" },
+    { __LINE__, false, "{\"a\":-nfinity}" },  { __LINE__, true, "{\"a\":Infinity}" },
+    { __LINE__, false, "{\"a\":.Infinity}" }, { __LINE__, false, "{\"a\":_Infinity}" },
+    { __LINE__, false, "{\"a\":_nfinity}" },  { __LINE__, true, "{\"a\":-Infinity}" }
   };
   for (size_t tdi = 0; tdi < sizeof(test_data) / sizeof(*test_data); ++tdi) {
     const TestData& td = test_data[tdi];


### PR DESCRIPTION
Finds and replaces integer literals which are cast to bool.

SRCDIR=/Users/johnsonhj/src/jsoncpp #My local SRC
BLDDIR=/Users/johnsonhj/src/jsoncpp/cmake-build-debug/ #My local BLD

cd /Users/johnsonhj/src/jsoncpp/cmake-build-debug/
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-bool-literals  -header-filter=.* -fix