### PR TITLE
COMP: Use nullptr instead of 0 or NULL

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -221,7 +221,7 @@ private:
                                    Location end,
                                    unsigned int& unicode);
   bool
-  addError(const JSONCPP_STRING& message, Token& token, Location extra = 0);
+  addError(const JSONCPP_STRING& message, Token& token, Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
   bool addErrorAndRecover(const JSONCPP_STRING& message,
                           Token& token,

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -137,8 +137,8 @@ bool Reader::parse(const char* beginDoc,
   end_ = endDoc;
   collectComments_ = collectComments;
   current_ = begin_;
-  lastValueEnd_ = 0;
-  lastValue_ = 0;
+  lastValueEnd_ = nullptr;
+  lastValue_ = nullptr;
   commentsBefore_.clear();
   errors_.clear();
   while (!nodes_.empty())
@@ -394,7 +394,7 @@ void Reader::addComment(Location begin,
   assert(collectComments_);
   const JSONCPP_STRING& normalized = normalizeEOL(begin, end);
   if (placement == commentAfterOnSameLine) {
-    assert(lastValue_ != 0);
+    assert(lastValue_ != nullptr);
     lastValue_->setComment(normalized, placement);
   } else {
     commentsBefore_ += normalized;
@@ -862,7 +862,7 @@ bool Reader::pushError(const Value& value, const JSONCPP_STRING& message) {
   ErrorInfo info;
   info.token_ = token;
   info.message_ = message;
-  info.extra_ = 0;
+  info.extra_ = nullptr;
   errors_.push_back(info);
   return true;
 }
@@ -1002,7 +1002,7 @@ private:
                                    Location end,
                                    unsigned int& unicode);
   bool
-  addError(const JSONCPP_STRING& message, Token& token, Location extra = 0);
+  addError(const JSONCPP_STRING& message, Token& token, Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
   bool addErrorAndRecover(const JSONCPP_STRING& message,
                           Token& token,
@@ -1061,8 +1061,8 @@ bool OurReader::parse(const char* beginDoc,
   end_ = endDoc;
   collectComments_ = collectComments;
   current_ = begin_;
-  lastValueEnd_ = 0;
-  lastValue_ = 0;
+  lastValueEnd_ = nullptr;
+  lastValue_ = nullptr;
   commentsBefore_.clear();
   errors_.clear();
   while (!nodes_.empty())
@@ -1368,7 +1368,7 @@ void OurReader::addComment(Location begin,
   assert(collectComments_);
   const JSONCPP_STRING& normalized = normalizeEOL(begin, end);
   if (placement == commentAfterOnSameLine) {
-    assert(lastValue_ != 0);
+    assert(lastValue_ != nullptr);
     lastValue_->setComment(normalized, placement);
   } else {
     commentsBefore_ += normalized;
@@ -1877,7 +1877,7 @@ bool OurReader::pushError(const Value& value, const JSONCPP_STRING& message) {
   ErrorInfo info;
   info.token_ = token;
   info.message_ = message;
-  info.extra_ = 0;
+  info.extra_ = nullptr;
   errors_.push_back(info);
   return true;
 }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -108,7 +108,7 @@ static inline char* duplicateStringValue(const char* value, size_t length) {
     length = Value::maxInt - 1;
 
   char* newString = static_cast<char*>(malloc(length + 1));
-  if (newString == NULL) {
+  if (newString == nullptr) {
     throwRuntimeError("in Json::Value::duplicateStringValue(): "
                       "Failed to allocate string value buffer");
   }
@@ -129,7 +129,7 @@ static inline char* duplicateAndPrefixStringValue(const char* value,
                       "length too big for prefixing");
   unsigned actualLength = length + static_cast<unsigned>(sizeof(unsigned)) + 1U;
   char* newString = static_cast<char*>(malloc(actualLength));
-  if (newString == 0) {
+  if (newString == nullptr) {
     throwRuntimeError("in Json::Value::duplicateAndPrefixStringValue(): "
                       "Failed to allocate string value buffer");
   }
@@ -210,7 +210,7 @@ JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg) {
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 
-Value::CommentInfo::CommentInfo() : comment_(0) {}
+Value::CommentInfo::CommentInfo() : comment_(nullptr) {}
 
 Value::CommentInfo::~CommentInfo() {
   if (comment_)
@@ -220,9 +220,9 @@ Value::CommentInfo::~CommentInfo() {
 void Value::CommentInfo::setComment(const char* text, size_t len) {
   if (comment_) {
     releaseStringValue(comment_, 0u);
-    comment_ = 0;
+    comment_ = nullptr;
   }
-  JSON_ASSERT(text != 0);
+  JSON_ASSERT(text != nullptr);
   JSON_ASSERT_MESSAGE(
       text[0] == '\0' || text[0] == '/',
       "in Json::Value::setComment(): Comments must start with /");
@@ -241,7 +241,7 @@ void Value::CommentInfo::setComment(const char* text, size_t len) {
 // Notes: policy_ indicates if the string was allocated when
 // a string is stored.
 
-Value::CZString::CZString(ArrayIndex index) : cstr_(0), index_(index) {}
+Value::CZString::CZString(ArrayIndex index) : cstr_(nullptr), index_(index) {}
 
 Value::CZString::CZString(char const* str,
                           unsigned length,
@@ -253,7 +253,7 @@ Value::CZString::CZString(char const* str,
 }
 
 Value::CZString::CZString(const CZString& other) {
-  cstr_ = (other.storage_.policy_ != noDuplication && other.cstr_ != 0
+  cstr_ = (other.storage_.policy_ != noDuplication && other.cstr_ != nullptr
                ? duplicateStringValue(other.cstr_, other.storage_.length_)
                : other.cstr_);
   storage_.policy_ =
@@ -413,7 +413,7 @@ Value::Value(double value) {
 
 Value::Value(const char* value) {
   initBasic(stringValue, true);
-  JSON_ASSERT_MESSAGE(value != NULL, "Null Value Passed to Value Constructor");
+  JSON_ASSERT_MESSAGE(value != nullptr, "Null Value Passed to Value Constructor");
   value_.string_ = duplicateAndPrefixStringValue(
       value, static_cast<unsigned>(strlen(value)));
 }
@@ -528,7 +528,7 @@ bool Value::operator<(const Value& other) const {
   case booleanValue:
     return value_.bool_ < other.value_.bool_;
   case stringValue: {
-    if ((value_.string_ == 0) || (other.value_.string_ == 0)) {
+    if ((value_.string_ == nullptr) || (other.value_.string_ == nullptr)) {
       if (other.value_.string_)
         return true;
       else
@@ -590,7 +590,7 @@ bool Value::operator==(const Value& other) const {
   case booleanValue:
     return value_.bool_ == other.value_.bool_;
   case stringValue: {
-    if ((value_.string_ == 0) || (other.value_.string_ == 0)) {
+    if ((value_.string_ == nullptr) || (other.value_.string_ == nullptr)) {
       return (value_.string_ == other.value_.string_);
     }
     unsigned this_len;
@@ -622,8 +622,8 @@ bool Value::operator!=(const Value& other) const { return !(*this == other); }
 const char* Value::asCString() const {
   JSON_ASSERT_MESSAGE(type_ == stringValue,
                       "in Json::Value::asCString(): requires stringValue");
-  if (value_.string_ == 0)
-    return 0;
+  if (value_.string_ == nullptr)
+    return nullptr;
   unsigned this_len;
   char const* this_str;
   decodePrefixedString(this->allocated_, this->value_.string_, &this_len,
@@ -648,7 +648,7 @@ unsigned Value::getCStringLength() const {
 bool Value::getString(char const** begin, char const** end) const {
   if (type_ != stringValue)
     return false;
-  if (value_.string_ == 0)
+  if (value_.string_ == nullptr)
     return false;
   unsigned length;
   decodePrefixedString(this->allocated_, this->value_.string_, &length, begin);
@@ -661,7 +661,7 @@ JSONCPP_STRING Value::asString() const {
   case nullValue:
     return "";
   case stringValue: {
-    if (value_.string_ == 0)
+    if (value_.string_ == nullptr)
       return "";
     unsigned this_len;
     char const* this_str;
@@ -1006,7 +1006,7 @@ const Value& Value::operator[](int index) const {
 void Value::initBasic(ValueType type, bool allocated) {
   type_ = type;
   allocated_ = allocated;
-  comments_ = 0;
+  comments_ = nullptr;
   start_ = 0;
   limit_ = 0;
 }
@@ -1073,7 +1073,7 @@ void Value::dupMeta(const Value& other) {
                                       strlen(otherComment.comment_));
     }
   } else {
-    comments_ = 0;
+    comments_ = nullptr;
   }
   start_ = other.start_;
   limit_ = other.limit_;
@@ -1131,12 +1131,12 @@ Value const* Value::find(char const* begin, char const* end) const {
                       "in Json::Value::find(key, end, found): requires "
                       "objectValue or nullValue");
   if (type_ == nullValue)
-    return NULL;
+    return nullptr;
   CZString actualKey(begin, static_cast<unsigned>(end - begin),
                      CZString::noDuplication);
   ObjectValues::const_iterator it = value_.map_->find(actualKey);
   if (it == value_.map_->end())
-    return NULL;
+    return nullptr;
   return &(*it).second;
 }
 const Value& Value::operator[](const char* key) const {
@@ -1267,7 +1267,7 @@ Value Value::get(const CppTL::ConstString& key,
 
 bool Value::isMember(char const* begin, char const* end) const {
   Value const* value = find(begin, end);
-  return NULL != value;
+  return nullptr != value;
 }
 bool Value::isMember(char const* key) const {
   return isMember(key, key + strlen(key));
@@ -1470,7 +1470,7 @@ void Value::setComment(const JSONCPP_STRING& comment,
 }
 
 bool Value::hasComment(CommentPlacement placement) const {
-  return comments_ != 0 && comments_[placement].comment_ != 0;
+  return comments_ != nullptr && comments_[placement].comment_ != nullptr;
 }
 
 JSONCPP_STRING Value::getComment(CommentPlacement placement) const {

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -108,8 +108,8 @@ char const* ValueIteratorBase::memberName() const {
 char const* ValueIteratorBase::memberName(char const** end) const {
   const char* cname = (*current_).first.data();
   if (!cname) {
-    *end = NULL;
-    return NULL;
+    *end = nullptr;
+    return nullptr;
   }
   *end = cname + (*current_).first.length();
   return cname;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -275,7 +275,7 @@ static JSONCPP_STRING toHex16Bit(unsigned int x) {
 }
 
 static JSONCPP_STRING valueToQuotedStringN(const char* value, unsigned length) {
-  if (value == NULL)
+  if (value == nullptr)
     return "";
 
   if (!isAnyCharRequiredQuoting(value, length))
@@ -646,7 +646,7 @@ bool StyledWriter::hasCommentForValue(const Value& value) {
 // //////////////////////////////////////////////////////////////////
 
 StyledStreamWriter::StyledStreamWriter(const JSONCPP_STRING& indentation)
-    : document_(NULL), rightMargin_(74), indentation_(indentation),
+    : document_(nullptr), rightMargin_(74), indentation_(indentation),
       addChildValues_(), indented_(false) {}
 
 void StyledStreamWriter::write(JSONCPP_OSTREAM& out, const Value& root) {
@@ -661,7 +661,7 @@ void StyledStreamWriter::write(JSONCPP_OSTREAM& out, const Value& root) {
   writeValue(root);
   writeCommentAfterValueOnSameLine(root);
   *document_ << "\n";
-  document_ = NULL; // Forget the stream, for safety.
+  document_ = nullptr; // Forget the stream, for safety.
 }
 
 void StyledStreamWriter::writeValue(const Value& value) {
@@ -940,7 +940,7 @@ int BuiltStyledStreamWriter::write(Value const& root, JSONCPP_OSTREAM* sout) {
   writeValue(root);
   writeCommentAfterValueOnSameLine(root);
   *sout_ << endingLineFeedSymbol_;
-  sout_ = NULL;
+  sout_ = nullptr;
   return 0;
 }
 void BuiltStyledStreamWriter::writeValue(Value const& value) {
@@ -1158,7 +1158,7 @@ bool BuiltStyledStreamWriter::hasCommentForValue(const Value& value) {
 ///////////////
 // StreamWriter
 
-StreamWriter::StreamWriter() : sout_(NULL) {}
+StreamWriter::StreamWriter() : sout_(nullptr) {}
 StreamWriter::~StreamWriter() {}
 StreamWriter::Factory::~Factory() {}
 StreamWriterBuilder::StreamWriterBuilder() { setDefaults(&settings_); }

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -74,10 +74,10 @@ namespace JsonTest {
 // //////////////////////////////////////////////////////////////////
 
 TestResult::TestResult()
-    : predicateId_(1), lastUsedPredicateId_(0), messageTarget_(0) {
+    : predicateId_(1), lastUsedPredicateId_(0), messageTarget_(nullptr) {
   // The root predicate has id 0
   rootPredicateNode_.id_ = 0;
-  rootPredicateNode_.next_ = 0;
+  rootPredicateNode_.next_ = nullptr;
   predicateStackTail_ = &rootPredicateNode_;
 }
 
@@ -89,7 +89,7 @@ TestResult::addFailure(const char* file, unsigned int line, const char* expr) {
   /// added.
   unsigned int nestingLevel = 0;
   PredicateContext* lastNode = rootPredicateNode_.next_;
-  for (; lastNode != 0; lastNode = lastNode->next_) {
+  for (; lastNode != nullptr; lastNode = lastNode->next_) {
     if (lastNode->id_ > lastUsedPredicateId_) // new PredicateContext
     {
       lastUsedPredicateId_ = lastNode->id_;
@@ -124,17 +124,17 @@ void TestResult::addFailureInfo(const char* file,
 
 TestResult& TestResult::popPredicateContext() {
   PredicateContext* lastNode = &rootPredicateNode_;
-  while (lastNode->next_ != 0 && lastNode->next_->next_ != 0) {
+  while (lastNode->next_ != nullptr && lastNode->next_->next_ != nullptr) {
     lastNode = lastNode->next_;
   }
   // Set message target to popped failure
   PredicateContext* tail = lastNode->next_;
-  if (tail != 0 && tail->failure_ != 0) {
+  if (tail != nullptr && tail->failure_ != nullptr) {
     messageTarget_ = tail->failure_;
   }
   // Remove tail from list
   predicateStackTail_ = lastNode;
-  lastNode->next_ = 0;
+  lastNode->next_ = nullptr;
   return *this;
 }
 
@@ -186,7 +186,7 @@ JSONCPP_STRING TestResult::indentText(const JSONCPP_STRING& text,
 }
 
 TestResult& TestResult::addToLastFailure(const JSONCPP_STRING& message) {
-  if (messageTarget_ != 0) {
+  if (messageTarget_ != nullptr) {
     messageTarget_->message_ += message;
   }
   return *this;
@@ -207,7 +207,7 @@ TestResult& TestResult::operator<<(bool value) {
 // class TestCase
 // //////////////////////////////////////////////////////////////////
 
-TestCase::TestCase() : result_(0) {}
+TestCase::TestCase() : result_(nullptr) {}
 
 TestCase::~TestCase() {}
 

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -69,7 +69,7 @@ public:
 
   /// Adds an assertion failure.
   TestResult&
-  addFailure(const char* file, unsigned int line, const char* expr = 0);
+  addFailure(const char* file, unsigned int line, const char* expr = nullptr);
 
   /// Removes the last PredicateContext added to the predicate stack
   /// chained list.


### PR DESCRIPTION
The check converts the usage of null pointer constants (eg. NULL, 0) to
use the new C++11 nullptr keyword.

SRCDIR=/Users/johnsonhj/src/jsoncpp #My local SRC
BLDDIR=/Users/johnsonhj/src/jsoncpp/cmake-build-debug/ #My local BLD

cd /Users/johnsonhj/src/jsoncpp/cmake-build-debug/
run-clang-tidy.py -extra-arg=-D__clang__ -checks=-*,modernize-use-nullptr  -header-filter=.* -fix