### PR TITLE
Fix MSVC 15.9 (2017) warning C4866

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -358,7 +358,7 @@ public:
 
   /** A simple way to update a specific setting.
    */
-  Value& operator[](JSONCPP_STRING key);
+  Value& operator[](const JSONCPP_STRING& key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -132,7 +132,7 @@ public:
   bool validate(Json::Value* invalid) const;
   /** A simple way to update a specific setting.
    */
-  Value& operator[](JSONCPP_STRING key);
+  Value& operator[](const JSONCPP_STRING& key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1969,7 +1969,7 @@ bool CharReaderBuilder::validate(Json::Value* invalid) const {
   }
   return 0u == inv.size();
 }
-Value& CharReaderBuilder::operator[](JSONCPP_STRING key) {
+Value& CharReaderBuilder::operator[](const JSONCPP_STRING& key) {
   return settings_[key];
 }
 // static

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1145,7 +1145,7 @@ const Value& Value::operator[](const char* key) const {
     return nullSingleton();
   return *found;
 }
-Value const& Value::operator[](JSONCPP_STRING const& key) const {
+Value const& Value::operator[](const JSONCPP_STRING& key) const {
   Value const* found = find(key.data(), key.data() + key.length());
   if (!found)
     return nullSingleton();

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1231,7 +1231,7 @@ bool StreamWriterBuilder::validate(Json::Value* invalid) const {
   }
   return 0u == inv.size();
 }
-Value& StreamWriterBuilder::operator[](JSONCPP_STRING key) {
+Value& StreamWriterBuilder::operator[](const JSONCPP_STRING& key) {
   return settings_[key];
 }
 // static


### PR DESCRIPTION
Fixes MSVC 15.9 (2017) warning [C4866](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c4866?view=vs-2017) by changing `operator[]` param type from `JSONCPP_STRING` to `const JSONCPP_STRING&` for `CharReaderBuilder` and `StreamWriterBuilder` (as it is already in `Value`).

C++17 requires that the operands of `operator[]` are evaluated in left-to-right order and when one of them is an object passed by value (`std::string` in this case) MSVC warns that it cannot enforce that evaluation order. In projects where warnings are considered errors, this breaks the build.

Compiling
```cpp
Json::StreamWriterBuilder builder;
builder["indentation"] = "";
```
results in
```
warning C4866: compiler may not enforce left-to-right evaluation order for call to 'Json::StreamWriterBuilder::operator[]'
```