### PR TITLE
reader: fix signed overflow when parsing negative value

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1564,7 +1564,7 @@ bool OurReader::decodeNumber(Token& token, Value& decoded) {
   // TODO: Help the compiler do the div and mod at compile time or get rid of
   // them.
   Value::LargestUInt maxIntegerValue =
-      isNegative ? Value::LargestUInt(-Value::minLargestInt)
+      isNegative ? Value::LargestUInt(Value::minLargestInt)
                  : Value::maxLargestUInt;
   Value::LargestUInt threshold = maxIntegerValue / 10;
   Value::LargestUInt value = 0;


### PR DESCRIPTION
Clang's ubsan (-fsanitize=undefined) reports:

    runtime error: negation of -9223372036854775808 cannot be represented in
    type 'Json::Value::LargestInt' (aka 'long'); cast to an unsigned type to
    negate this value to itself

Follow its advice and update the code to remove the explicit negation.