### PR TITLE
Reapply clang-format.

### DIFF
--- a/include/json/assertions.h
+++ b/include/json/assertions.h
@@ -6,8 +6,8 @@
 #ifndef CPPTL_JSON_ASSERTIONS_H_INCLUDED
 #define CPPTL_JSON_ASSERTIONS_H_INCLUDED
 
-#include <sstream>
 #include <cstdlib>
+#include <sstream>
 
 #if !defined(JSON_IS_AMALGAMATION)
 #include "config.h"

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -7,7 +7,7 @@
 #define JSON_CONFIG_H_INCLUDED
 #include <cstddef>
 #include <cstdint> //typedef int64_t, uint64_t
-#include <string>   //typedef String
+#include <string>  //typedef String
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1
@@ -55,15 +55,18 @@
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1800
-  #error "ERROR:  Visual Studio 12 (2013) with _MSC_VER=1800 is the oldest supported compiler with sufficient C++11 capabilities"
+#error                                                                         \
+    "ERROR:  Visual Studio 12 (2013) with _MSC_VER=1800 is the oldest supported compiler with sufficient C++11 capabilities"
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER < 1900
-// As recommended at https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
-   extern JSON_API int msvc_pre1900_c99_snprintf(char *outBuf, size_t size, const char *format, ...);
-#  define jsoncpp_snprintf msvc_pre1900_c99_snprintf
+// As recommended at
+// https://stackoverflow.com/questions/2915672/snprintf-and-visual-studio-2010
+extern JSON_API int
+msvc_pre1900_c99_snprintf(char* outBuf, size_t size, const char* format, ...);
+#define jsoncpp_snprintf msvc_pre1900_c99_snprintf
 #else
-#  define jsoncpp_snprintf std::snprintf
+#define jsoncpp_snprintf std::snprintf
 #endif
 
 // If JSON_NO_INT64 is defined, then Json only support C++ "int" type for
@@ -75,10 +78,10 @@
 #define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
 #endif // defined(_MSC_VER)
 
-// In c++11 the override keyword allows you to explicitly define that a function
-// is intended to override the base-class version.  This makes the code more
-// manageable and fixes a set of common hard-to-find bugs.
-#define JSONCPP_OVERRIDE override    // Define maintained for backwards compatibility of external tools.  C++11 should be used directly in JSONCPP
+// JSONCPP_OVERRIDE is maintained for backwards compatibility of external tools.
+// C++11 should be used directly in JSONCPP.
+#define JSONCPP_OVERRIDE override
+
 #if __cplusplus >= 201103L
 #define JSONCPP_NOEXCEPT noexcept
 #define JSONCPP_OP_EXPLICIT explicit

--- a/include/json/features.h
+++ b/include/json/features.h
@@ -41,17 +41,17 @@ public:
   Features();
 
   /// \c true if comments are allowed. Default: \c true.
-  bool allowComments_{true};
+  bool allowComments_{ true };
 
   /// \c true if root must be either an array or an object value. Default: \c
   /// false.
-  bool strictRoot_{false};
+  bool strictRoot_{ false };
 
   /// \c true if dropped null placeholders are allowed. Default: \c false.
-  bool allowDroppedNullPlaceholders_{false};
+  bool allowDroppedNullPlaceholders_{ false };
 
   /// \c true if numeric object key are allowed. Default: \c false.
-  bool allowNumericKeys_{false};
+  bool allowNumericKeys_{ false };
 };
 
 } // namespace Json

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -220,8 +220,9 @@ private:
                                    Location& current,
                                    Location end,
                                    unsigned int& unicode);
-  bool
-  addError(const JSONCPP_STRING& message, Token& token, Location extra = nullptr);
+  bool addError(const JSONCPP_STRING& message,
+                Token& token,
+                Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
   bool addErrorAndRecover(const JSONCPP_STRING& message,
                           Token& token,

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -630,7 +630,7 @@ private:
 
     void setComment(const char* text, size_t len);
 
-    char* comment_{nullptr};
+    char* comment_{ nullptr };
   };
 
   // struct MemberNamesTransform
@@ -679,7 +679,7 @@ private:
   enum Kind { kindNone = 0, kindIndex, kindKey };
   JSONCPP_STRING key_;
   ArrayIndex index_{};
-  Kind kind_{kindNone};
+  Kind kind_{ kindNone };
 };
 
 /** \brief Experimental and untested: represents a "path" to access a node.
@@ -780,7 +780,7 @@ protected:
 private:
   Value::ObjectValues::iterator current_;
   // Indicates that iterator is for a null value.
-  bool isNull_{true};
+  bool isNull_{ true };
 
 public:
   // For some reason, BORLAND needs these at the end, rather

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -189,9 +189,9 @@ private:
   void writeValue(const Value& value);
 
   JSONCPP_STRING document_;
-  bool yamlCompatibilityEnabled_{false};
-  bool dropNullPlaceholders_{false};
-  bool omitEndingLineFeed_{false};
+  bool yamlCompatibilityEnabled_{ false };
+  bool dropNullPlaceholders_{ false };
+  bool omitEndingLineFeed_{ false };
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -257,9 +257,9 @@ private:
   ChildValues childValues_;
   JSONCPP_STRING document_;
   JSONCPP_STRING indentString_;
-  unsigned int rightMargin_{74};
-  unsigned int indentSize_{3};
-  bool addChildValues_{false};
+  unsigned int rightMargin_{ 74 };
+  unsigned int indentSize_{ 3 };
+  bool addChildValues_{ false };
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -331,7 +331,7 @@ private:
   ChildValues childValues_;
   JSONCPP_OSTREAM* document_;
   JSONCPP_STRING indentString_;
-  unsigned int rightMargin_{74};
+  unsigned int rightMargin_{ 74 };
   JSONCPP_STRING indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -14,9 +14,9 @@
  */
 
 #include <algorithm> // sort
+#include <cstdio>
 #include <json/json.h>
 #include <sstream>
-#include <cstdio>
 
 struct Options {
   JSONCPP_STRING path;

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -31,8 +31,8 @@
 #if defined(_MSC_VER)
 #if !defined(_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES)
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
-#endif  //_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
-#endif  //_MSC_VER
+#endif //_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
+#endif //_MSC_VER
 
 #if defined(_MSC_VER)
 // Disable warning about strdup being deprecated.
@@ -59,8 +59,7 @@ typedef std::auto_ptr<CharReader> CharReaderPtr;
 // Implementation of class Features
 // ////////////////////////////////
 
-Features::Features()
-     = default;
+Features::Features() = default;
 
 Features Features::all() { return {}; }
 
@@ -87,8 +86,7 @@ bool Reader::containsNewLine(Reader::Location begin, Reader::Location end) {
 // //////////////////////////////////////////////////////////////////
 
 Reader::Reader()
-    : errors_(), document_(), commentsBefore_(), features_(Features::all())
-      {}
+    : errors_(), document_(), commentsBefore_(), features_(Features::all()) {}
 
 Reader::Reader(const Features& features)
     : errors_(), document_(), begin_(), end_(), current_(), lastValueEnd_(),
@@ -816,7 +814,7 @@ JSONCPP_STRING Reader::getFormatedErrorMessages() const {
 
 JSONCPP_STRING Reader::getFormattedErrorMessages() const {
   JSONCPP_STRING formattedMessage;
-  for (const auto & error : errors_) {
+  for (const auto& error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -829,7 +827,7 @@ JSONCPP_STRING Reader::getFormattedErrorMessages() const {
 
 std::vector<Reader::StructuredError> Reader::getStructuredErrors() const {
   std::vector<Reader::StructuredError> allErrors;
-  for (const auto & error : errors_) {
+  for (const auto& error : errors_) {
     Reader::StructuredError structured;
     structured.offset_start = error.token_.start_ - begin_;
     structured.offset_limit = error.token_.end_ - begin_;
@@ -989,8 +987,9 @@ private:
                                    Location& current,
                                    Location end,
                                    unsigned int& unicode);
-  bool
-  addError(const JSONCPP_STRING& message, Token& token, Location extra = nullptr);
+  bool addError(const JSONCPP_STRING& message,
+                Token& token,
+                Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
   bool addErrorAndRecover(const JSONCPP_STRING& message,
                           Token& token,
@@ -1827,7 +1826,7 @@ JSONCPP_STRING OurReader::getLocationLineAndColumn(Location location) const {
 
 JSONCPP_STRING OurReader::getFormattedErrorMessages() const {
   JSONCPP_STRING formattedMessage;
-  for (const auto & error : errors_) {
+  for (const auto& error : errors_) {
     formattedMessage +=
         "* " + getLocationLineAndColumn(error.token_.start_) + "\n";
     formattedMessage += "  " + error.message_ + "\n";
@@ -1840,7 +1839,7 @@ JSONCPP_STRING OurReader::getFormattedErrorMessages() const {
 
 std::vector<OurReader::StructuredError> OurReader::getStructuredErrors() const {
   std::vector<OurReader::StructuredError> allErrors;
-  for (const auto & error : errors_) {
+  for (const auto& error : errors_) {
     OurReader::StructuredError structured;
     structured.offset_start = error.token_.start_ - begin_;
     structured.offset_limit = error.token_.end_ - begin_;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -9,8 +9,8 @@
 #include <json/writer.h>
 #endif // if !defined(JSON_IS_AMALGAMATION)
 #include <cassert>
-#include <cstring>
 #include <cmath>
+#include <cstring>
 #include <sstream>
 #include <utility>
 #ifdef JSON_USE_CPPTL
@@ -21,24 +21,28 @@
 
 // Provide implementation equivalent of std::snprintf for older _MSC compilers
 #if defined(_MSC_VER) && _MSC_VER < 1900
-#include <stdarg.h>  
-static int msvc_pre1900_c99_vsnprintf(char *outBuf, size_t size, const char *format, va_list ap)
-{
-    int count = -1;
-    if (size != 0)
-        count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
-    if (count == -1)
-        count = _vscprintf(format, ap);
-    return count;
+#include <stdarg.h>
+static int msvc_pre1900_c99_vsnprintf(char* outBuf,
+                                      size_t size,
+                                      const char* format,
+                                      va_list ap) {
+  int count = -1;
+  if (size != 0)
+    count = _vsnprintf_s(outBuf, size, _TRUNCATE, format, ap);
+  if (count == -1)
+    count = _vscprintf(format, ap);
+  return count;
 }
 
-int JSON_API msvc_pre1900_c99_snprintf(char *outBuf, size_t size, const char *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    const int count = msvc_pre1900_c99_vsnprintf(outBuf, size, format, ap);
-    va_end(ap);
-    return count;
+int JSON_API msvc_pre1900_c99_snprintf(char* outBuf,
+                                       size_t size,
+                                       const char* format,
+                                       ...) {
+  va_list ap;
+  va_start(ap, format);
+  const int count = msvc_pre1900_c99_vsnprintf(outBuf, size, format, ap);
+  va_end(ap);
+  return count;
 }
 #endif
 
@@ -213,7 +217,7 @@ static inline void releaseStringValue(char* value, unsigned) { free(value); }
 
 namespace Json {
 
-Exception::Exception(JSONCPP_STRING  msg) : msg_(std::move(msg)) {}
+Exception::Exception(JSONCPP_STRING msg) : msg_(std::move(msg)) {}
 Exception::~Exception() JSONCPP_NOEXCEPT {}
 char const* Exception::what() const JSONCPP_NOEXCEPT { return msg_.c_str(); }
 RuntimeError::RuntimeError(JSONCPP_STRING const& msg) : Exception(msg) {}
@@ -233,7 +237,7 @@ JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg) {
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 
-Value::CommentInfo::CommentInfo()  = default;
+Value::CommentInfo::CommentInfo() = default;
 
 Value::CommentInfo::~CommentInfo() {
   if (comment_)
@@ -436,7 +440,8 @@ Value::Value(double value) {
 
 Value::Value(const char* value) {
   initBasic(stringValue, true);
-  JSON_ASSERT_MESSAGE(value != nullptr, "Null Value Passed to Value Constructor");
+  JSON_ASSERT_MESSAGE(value != nullptr,
+                      "Null Value Passed to Value Constructor");
   value_.string_ = duplicateAndPrefixStringValue(
       value, static_cast<unsigned>(strlen(value)));
 }
@@ -890,8 +895,7 @@ bool Value::isConvertibleTo(ValueType other) const {
            (type_ == booleanValue && value_.bool_ == false) ||
            (type_ == stringValue && asString().empty()) ||
            (type_ == arrayValue && value_.map_->empty()) ||
-           (type_ == objectValue && value_.map_->empty()) ||
-           type_ == nullValue;
+           (type_ == objectValue && value_.map_->empty()) || type_ == nullValue;
   case intValue:
     return isInt() ||
            (type_ == realValue && InRange(value_.real_, minInt, maxInt)) ||
@@ -1655,7 +1659,7 @@ void Path::invalidPath(const JSONCPP_STRING& /*path*/, int /*location*/) {
 
 const Value& Path::resolve(const Value& root) const {
   const Value* node = &root;
-  for (const auto & arg : args_) {
+  for (const auto& arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray() || !node->isValidIndex(arg.index_)) {
         // Error: unable to resolve path (array value expected at position...
@@ -1680,7 +1684,7 @@ const Value& Path::resolve(const Value& root) const {
 
 Value Path::resolve(const Value& root, const Value& defaultValue) const {
   const Value* node = &root;
-  for (const auto & arg : args_) {
+  for (const auto& arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray() || !node->isValidIndex(arg.index_))
         return defaultValue;
@@ -1698,7 +1702,7 @@ Value Path::resolve(const Value& root, const Value& defaultValue) const {
 
 Value& Path::make(Value& root) const {
   Value* node = &root;
-  for (const auto & arg : args_) {
+  for (const auto& arg : args_) {
     if (arg.kind_ == PathArgument::kindIndex) {
       if (!node->isArray()) {
         // Error: node is not an array at position ...

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -15,25 +15,17 @@ namespace Json {
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 
-ValueIteratorBase::ValueIteratorBase()
-    : current_() {
-}
+ValueIteratorBase::ValueIteratorBase() : current_() {}
 
 ValueIteratorBase::ValueIteratorBase(
     const Value::ObjectValues::iterator& current)
     : current_(current), isNull_(false) {}
 
-Value& ValueIteratorBase::deref() const {
-  return current_->second;
-}
+Value& ValueIteratorBase::deref() const { return current_->second; }
 
-void ValueIteratorBase::increment() {
-  ++current_;
-}
+void ValueIteratorBase::increment() { ++current_; }
 
-void ValueIteratorBase::decrement() {
-  --current_;
-}
+void ValueIteratorBase::decrement() { --current_; }
 
 ValueIteratorBase::difference_type
 ValueIteratorBase::computeDistance(const SelfType& other) const {
@@ -96,7 +88,8 @@ JSONCPP_STRING ValueIteratorBase::name() const {
   char const* keey;
   char const* end;
   keey = memberName(&end);
-  if (!keey) return JSONCPP_STRING();
+  if (!keey)
+    return JSONCPP_STRING();
   return JSONCPP_STRING(keey, end);
 }
 
@@ -156,8 +149,7 @@ ValueIterator::ValueIterator(const ValueConstIterator& other)
   throwRuntimeError("ConstIterator to Iterator should never be allowed.");
 }
 
-ValueIterator::ValueIterator(const ValueIterator& other)
-     = default;
+ValueIterator::ValueIterator(const ValueIterator& other) = default;
 
 ValueIterator& ValueIterator::operator=(const SelfType& other) {
   copy(other);

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -44,7 +44,7 @@
 
 #if !defined(_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES)
 #define _CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES 1
-#endif  //_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
+#endif //_CRT_SECURE_CPP_OVERLOAD_STANDARD_NAMES
 
 #endif //_MSC_VER
 
@@ -352,8 +352,8 @@ Writer::~Writer() = default;
 // //////////////////////////////////////////////////////////////////
 
 FastWriter::FastWriter()
-    
-      = default;
+
+    = default;
 
 void FastWriter::enableYAMLCompatibility() { yamlCompatibilityEnabled_ = true; }
 
@@ -409,8 +409,7 @@ void FastWriter::writeValue(const Value& value) {
   case objectValue: {
     Value::Members members(value.getMemberNames());
     document_ += '{';
-    for (auto it = members.begin(); it != members.end();
-         ++it) {
+    for (auto it = members.begin(); it != members.end(); ++it) {
       const JSONCPP_STRING& name = *it;
       if (it != members.begin())
         document_ += ',';
@@ -427,8 +426,7 @@ void FastWriter::writeValue(const Value& value) {
 // Class StyledWriter
 // //////////////////////////////////////////////////////////////////
 
-StyledWriter::StyledWriter()
-     = default;
+StyledWriter::StyledWriter() = default;
 
 JSONCPP_STRING StyledWriter::write(const Value& root) {
   document_.clear();
@@ -922,9 +920,10 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
     PrecisionType precisionType)
     : rightMargin_(74), indentation_(std::move(indentation)), cs_(cs),
       colonSymbol_(std::move(colonSymbol)), nullSymbol_(std::move(nullSymbol)),
-      endingLineFeedSymbol_(std::move(endingLineFeedSymbol)), addChildValues_(false),
-      indented_(false), useSpecialFloats_(useSpecialFloats),
-      precision_(precision), precisionType_(precisionType) {}
+      endingLineFeedSymbol_(std::move(endingLineFeedSymbol)),
+      addChildValues_(false), indented_(false),
+      useSpecialFloats_(useSpecialFloats), precision_(precision),
+      precisionType_(precisionType) {}
 int BuiltStyledStreamWriter::write(Value const& root, JSONCPP_OSTREAM* sout) {
   sout_ = sout;
   addChildValues_ = false;

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -73,8 +73,7 @@ namespace JsonTest {
 // class TestResult
 // //////////////////////////////////////////////////////////////////
 
-TestResult::TestResult()
-     {
+TestResult::TestResult() {
   // The root predicate has id 0
   rootPredicateNode_.id_ = 0;
   rootPredicateNode_.next_ = nullptr;
@@ -150,7 +149,7 @@ void TestResult::printFailure(bool printTestName) const {
   }
 
   // Print in reverse to display the callstack in the right order
-  for (const auto & failure : failures_ ) {
+  for (const auto& failure : failures_) {
     JSONCPP_STRING indent(failure.nestingLevel_ * 2, ' ');
     if (failure.file_) {
       printf("%s%s(%u): ", indent.c_str(), failure.file_, failure.line_);
@@ -205,7 +204,7 @@ TestResult& TestResult::operator<<(bool value) {
 // class TestCase
 // //////////////////////////////////////////////////////////////////
 
-TestCase::TestCase()  = default;
+TestCase::TestCase() = default;
 
 TestCase::~TestCase() = default;
 
@@ -224,9 +223,7 @@ Runner& Runner::add(TestCaseFactory factory) {
   return *this;
 }
 
-size_t Runner::testCount() const {
-  return tests_.size();
-}
+size_t Runner::testCount() const { return tests_.size(); }
 
 JSONCPP_STRING Runner::testNameAt(size_t index) const {
   TestCase* test = tests_[index]();
@@ -273,22 +270,21 @@ bool Runner::runAllTest(bool printSummary) const {
     }
     return true;
   } else {
-    for (auto & result : failures) {
+    for (auto& result : failures) {
       result.printFailure(count > 1);
     }
 
     if (printSummary) {
       size_t const failedCount = failures.size();
       size_t const passedCount = count - failedCount;
-      printf("%zu/%zu tests passed (%zu failure(s))\n",
-             passedCount, count, failedCount);
+      printf("%zu/%zu tests passed (%zu failure(s))\n", passedCount, count,
+             failedCount);
     }
     return false;
   }
 }
 
-bool Runner::testIndex(const JSONCPP_STRING& testName,
-                       size_t& indexOut) const {
+bool Runner::testIndex(const JSONCPP_STRING& testName, size_t& indexOut) const {
   const size_t count = testCount();
   for (size_t index = 0; index < count; ++index) {
     if (testNameAt(index) == testName) {

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -6,12 +6,12 @@
 #ifndef JSONTEST_H_INCLUDED
 #define JSONTEST_H_INCLUDED
 
+#include <cstdio>
 #include <deque>
 #include <json/config.h>
 #include <json/value.h>
 #include <json/writer.h>
 #include <sstream>
-#include <cstdio>
 #include <string>
 
 // //////////////////////////////////////////////////////////////////
@@ -60,7 +60,7 @@ public:
   /// Not encapsulated to prevent step into when debugging failed assertions
   /// Incremented by one on assertion predicate entry, decreased by one
   /// by addPredicateContext().
-  PredicateContext::Id predicateId_{1};
+  PredicateContext::Id predicateId_{ 1 };
 
   /// \internal Implementation detail for predicate macros
   PredicateContext* predicateStackTail_;
@@ -109,9 +109,9 @@ private:
   Failures failures_;
   JSONCPP_STRING name_;
   PredicateContext rootPredicateNode_;
-  PredicateContext::Id lastUsedPredicateId_{0};
+  PredicateContext::Id lastUsedPredicateId_{ 0 };
   /// Failure which is the target of the messages added using operator <<
-  Failure* messageTarget_{nullptr};
+  Failure* messageTarget_{ nullptr };
 };
 
 class TestCase {
@@ -125,7 +125,7 @@ public:
   virtual const char* testName() const = 0;
 
 protected:
-  TestResult* result_{nullptr};
+  TestResult* result_{ nullptr };
 
 private:
   virtual void runTestCase() = 0;
@@ -262,9 +262,7 @@ TestResult& checkStringEqual(TestResult& result,
     }                                                                          \
                                                                                \
   public: /* overridden from TestCase */                                       \
-    const char* testName() const override {                                    \
-      return #FixtureType "/" #name;                                           \
-    }                                                                          \
+    const char* testName() const override { return #FixtureType "/" #name; }   \
     void runTestCase() override;                                               \
   };                                                                           \
                                                                                \

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -82,19 +82,19 @@ struct ValueTest : JsonTest::TestCase {
     /// Initialize all checks to \c false by default.
     IsCheck();
 
-    bool isObject_{false};
-    bool isArray_{false};
-    bool isBool_{false};
-    bool isString_{false};
-    bool isNull_{false};
+    bool isObject_{ false };
+    bool isArray_{ false };
+    bool isBool_{ false };
+    bool isString_{ false };
+    bool isNull_{ false };
 
-    bool isInt_{false};
-    bool isInt64_{false};
-    bool isUInt_{false};
-    bool isUInt64_{false};
-    bool isIntegral_{false};
-    bool isDouble_{false};
-    bool isNumeric_{false};
+    bool isInt_{ false };
+    bool isInt64_{ false };
+    bool isUInt_{ false };
+    bool isUInt64_{ false };
+    bool isIntegral_{ false };
+    bool isDouble_{ false };
+    bool isNumeric_{ false };
   };
 
   void checkConstMemberCount(const Json::Value& value,
@@ -1331,8 +1331,8 @@ void ValueTest::checkMemberCount(Json::Value& value,
 }
 
 ValueTest::IsCheck::IsCheck()
-    
-      = default;
+
+    = default;
 
 void ValueTest::checkIs(const Json::Value& value, const IsCheck& check) {
   JSONTEST_ASSERT_EQUAL(check.isObject_, value.isObject());
@@ -2354,14 +2354,22 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     JSONCPP_STRING in;
   };
   const TestData test_data[] = {
-    { __LINE__, true, "{\"a\":9}" },         { __LINE__, false, "{\"a\":0Infinity}" },
-    { __LINE__, false, "{\"a\":1Infinity}" }, { __LINE__, false, "{\"a\":9Infinity}" },
-    { __LINE__, false, "{\"a\":0nfinity}" },  { __LINE__, false, "{\"a\":1nfinity}" },
-    { __LINE__, false, "{\"a\":9nfinity}" },  { __LINE__, false, "{\"a\":nfinity}" },
-    { __LINE__, false, "{\"a\":.nfinity}" },  { __LINE__, false, "{\"a\":9nfinity}" },
-    { __LINE__, false, "{\"a\":-nfinity}" },  { __LINE__, true, "{\"a\":Infinity}" },
-    { __LINE__, false, "{\"a\":.Infinity}" }, { __LINE__, false, "{\"a\":_Infinity}" },
-    { __LINE__, false, "{\"a\":_nfinity}" },  { __LINE__, true, "{\"a\":-Infinity}" }
+    { __LINE__, true, "{\"a\":9}" },          //
+    { __LINE__, false, "{\"a\":0Infinity}" }, //
+    { __LINE__, false, "{\"a\":1Infinity}" }, //
+    { __LINE__, false, "{\"a\":9Infinity}" }, //
+    { __LINE__, false, "{\"a\":0nfinity}" },  //
+    { __LINE__, false, "{\"a\":1nfinity}" },  //
+    { __LINE__, false, "{\"a\":9nfinity}" },  //
+    { __LINE__, false, "{\"a\":nfinity}" },   //
+    { __LINE__, false, "{\"a\":.nfinity}" },  //
+    { __LINE__, false, "{\"a\":9nfinity}" },  //
+    { __LINE__, false, "{\"a\":-nfinity}" },  //
+    { __LINE__, true, "{\"a\":Infinity}" },   //
+    { __LINE__, false, "{\"a\":.Infinity}" }, //
+    { __LINE__, false, "{\"a\":_Infinity}" }, //
+    { __LINE__, false, "{\"a\":_nfinity}" },  //
+    { __LINE__, true, "{\"a\":-Infinity}" }   //
   };
   for (const auto& td : test_data) {
     bool ok = reader->parse(&*td.in.begin(), &*td.in.begin() + td.in.size(),


### PR DESCRIPTION
```
  $ clang-format -i -style=file \
        $(find  . | egrep '.*\.(h|cpp|inl)$')

```

Also did some manual commenting to keep test data lines from joining up,
since they rely on `__LINE__` to be meaningful.