### PR TITLE
Jsoncpp aliases 2

### DIFF
--- a/include/json/assertions.h
+++ b/include/json/assertions.h
@@ -29,7 +29,7 @@
 
 #define JSON_FAIL_MESSAGE(message)                                             \
   {                                                                            \
-    JSONCPP_OSTRINGSTREAM oss;                                                 \
+    OStringStream oss;                                                         \
     oss << message;                                                            \
     Json::throwLogicError(oss.str());                                          \
     abort();                                                                   \
@@ -43,7 +43,7 @@
 // release builds we abort, for a core-dump or debugger.
 #define JSON_FAIL_MESSAGE(message)                                             \
   {                                                                            \
-    JSONCPP_OSTRINGSTREAM oss;                                                 \
+    OStringStream oss;                                                         \
     oss << message;                                                            \
     assert(false && oss.str().c_str());                                        \
     abort();                                                                   \

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -189,11 +189,13 @@ using IStream = std::istream;
 using OStream = std::ostream;
 } // namespace Json
 
+#if 0  // easily test without these names in place
 // Legacy names (formerly macros).
 using JSONCPP_STRING = Json::String;
 using JSONCPP_ISTRINGSTREAM = Json::IStringStream;
 using JSONCPP_OSTRINGSTREAM = Json::OStringStream;
 using JSONCPP_ISTREAM = Json::IStream;
 using JSONCPP_OSTREAM = Json::OStream;
+#endif
 
 #endif // JSON_CONFIG_H_INCLUDED

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -189,13 +189,11 @@ using IStream = std::istream;
 using OStream = std::ostream;
 } // namespace Json
 
-#if 0  // easily test without these names in place
 // Legacy names (formerly macros).
 using JSONCPP_STRING = Json::String;
 using JSONCPP_ISTRINGSTREAM = Json::IStringStream;
 using JSONCPP_OSTRINGSTREAM = Json::OStringStream;
 using JSONCPP_ISTREAM = Json::IStream;
 using JSONCPP_OSTREAM = Json::OStream;
-#endif
 
 #endif // JSON_CONFIG_H_INCLUDED

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -8,7 +8,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <istream>
+#include <memory>
+#include <istream>
 #include <ostream>
+#include <sstream>
 #include <string>
 #include <type_traits>
 

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <istream>
 #include <memory>
-#include <istream>
 #include <ostream>
 #include <sstream>
 #include <string>

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -46,7 +46,7 @@ public:
   struct StructuredError {
     ptrdiff_t offset_start;
     ptrdiff_t offset_limit;
-    JSONCPP_STRING message;
+    String message;
   };
 
   /** \brief Constructs a Reader allowing all features
@@ -103,7 +103,7 @@ public:
 
   /// \brief Parse from input stream.
   /// \see Json::operator>>(std::istream&, Json::Value&).
-  bool parse(JSONCPP_ISTREAM& is, Value& root, bool collectComments = true);
+  bool parse(IStream& is, Value& root, bool collectComments = true);
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -115,7 +115,7 @@ public:
    * \deprecated Use getFormattedErrorMessages() instead (typo fix).
    */
   JSONCPP_DEPRECATED("Use getFormattedErrorMessages() instead.")
-  JSONCPP_STRING getFormatedErrorMessages() const;
+  String getFormatedErrorMessages() const;
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -125,7 +125,7 @@ public:
    * occurred
    *         during parsing.
    */
-  JSONCPP_STRING getFormattedErrorMessages() const;
+  String getFormattedErrorMessages() const;
 
   /** \brief Returns a vector of structured erros encounted while parsing.
    * \return A (possibly empty) vector of StructuredError objects. Currently
@@ -142,7 +142,7 @@ public:
    * \return \c true if the error was successfully added, \c false if the
    * Value offset exceeds the document size.
    */
-  bool pushError(const Value& value, const JSONCPP_STRING& message);
+  bool pushError(const Value& value, const String& message);
 
   /** \brief Add a semantic error message with extra context.
    * \param value JSON Value location associated with the error
@@ -151,9 +151,7 @@ public:
    * \return \c true if the error was successfully added, \c false if either
    * Value offset exceeds the document size.
    */
-  bool pushError(const Value& value,
-                 const JSONCPP_STRING& message,
-                 const Value& extra);
+  bool pushError(const Value& value, const String& message, const Value& extra);
 
   /** \brief Return whether there are any errors.
    * \return \c true if there are no errors to report \c false if
@@ -189,7 +187,7 @@ private:
   class ErrorInfo {
   public:
     Token token_;
-    JSONCPP_STRING message_;
+    String message_;
     Location extra_;
   };
 
@@ -209,7 +207,7 @@ private:
   bool decodeNumber(Token& token);
   bool decodeNumber(Token& token, Value& decoded);
   bool decodeString(Token& token);
-  bool decodeString(Token& token, JSONCPP_STRING& decoded);
+  bool decodeString(Token& token, String& decoded);
   bool decodeDouble(Token& token);
   bool decodeDouble(Token& token, Value& decoded);
   bool decodeUnicodeCodePoint(Token& token,
@@ -220,11 +218,9 @@ private:
                                    Location& current,
                                    Location end,
                                    unsigned int& unicode);
-  bool addError(const JSONCPP_STRING& message,
-                Token& token,
-                Location extra = nullptr);
+  bool addError(const String& message, Token& token, Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
-  bool addErrorAndRecover(const JSONCPP_STRING& message,
+  bool addErrorAndRecover(const String& message,
                           Token& token,
                           TokenType skipUntilToken);
   void skipUntilSpace();
@@ -232,23 +228,23 @@ private:
   Char getNextChar();
   void
   getLocationLineAndColumn(Location location, int& line, int& column) const;
-  JSONCPP_STRING getLocationLineAndColumn(Location location) const;
+  String getLocationLineAndColumn(Location location) const;
   void addComment(Location begin, Location end, CommentPlacement placement);
   void skipCommentTokens(Token& token);
 
   static bool containsNewLine(Location begin, Location end);
-  static JSONCPP_STRING normalizeEOL(Location begin, Location end);
+  static String normalizeEOL(Location begin, Location end);
 
   typedef std::stack<Value*> Nodes;
   Nodes nodes_;
   Errors errors_;
-  JSONCPP_STRING document_;
+  String document_;
   Location begin_{};
   Location end_{};
   Location current_{};
   Location lastValueEnd_{};
   Value* lastValue_{};
-  JSONCPP_STRING commentsBefore_;
+  String commentsBefore_;
   Features features_;
   bool collectComments_{};
 }; // Reader
@@ -279,7 +275,7 @@ public:
   virtual bool parse(char const* beginDoc,
                      char const* endDoc,
                      Value* root,
-                     JSONCPP_STRING* errs) = 0;
+                     String* errs) = 0;
 
   class JSON_API Factory {
   public:
@@ -299,7 +295,7 @@ Usage:
   CharReaderBuilder builder;
   builder["collectComments"] = false;
   Value value;
-  JSONCPP_STRING errs;
+  String errs;
   bool ok = parseFromStream(builder, std::cin, &value, &errs);
 \endcode
 */
@@ -359,7 +355,7 @@ public:
 
   /** A simple way to update a specific setting.
    */
-  Value& operator[](const JSONCPP_STRING& key);
+  Value& operator[](const String& key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
@@ -380,7 +376,7 @@ public:
  * is convenient.
  */
 bool JSON_API parseFromStream(CharReader::Factory const&,
-                              JSONCPP_ISTREAM&,
+                              IStream&,
                               Value* root,
                               std::string* errs);
 
@@ -408,7 +404,7 @@ bool JSON_API parseFromStream(CharReader::Factory const&,
  \throw std::exception on parse error.
  \see Json::operator<<()
 */
-JSON_API JSONCPP_ISTREAM& operator>>(JSONCPP_ISTREAM&, Value&);
+JSON_API IStream& operator>>(IStream&, Value&);
 
 } // namespace Json
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -54,12 +54,12 @@ namespace Json {
  */
 class JSON_API Exception : public std::exception {
 public:
-  Exception(JSONCPP_STRING msg);
+  Exception(String msg);
   ~Exception() JSONCPP_NOEXCEPT override;
   char const* what() const JSONCPP_NOEXCEPT override;
 
 protected:
-  JSONCPP_STRING msg_;
+  String msg_;
 };
 
 /** Exceptions which the user cannot easily avoid.
@@ -70,7 +70,7 @@ protected:
  */
 class JSON_API RuntimeError : public Exception {
 public:
-  RuntimeError(JSONCPP_STRING const& msg);
+  RuntimeError(String const& msg);
 };
 
 /** Exceptions thrown by JSON_ASSERT/JSON_FAIL macros.
@@ -81,13 +81,13 @@ public:
  */
 class JSON_API LogicError : public Exception {
 public:
-  LogicError(JSONCPP_STRING const& msg);
+  LogicError(String const& msg);
 };
 
 /// used internally
-JSONCPP_NORETURN void throwRuntimeError(JSONCPP_STRING const& msg);
+JSONCPP_NORETURN void throwRuntimeError(String const& msg);
 /// used internally
-JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg);
+JSONCPP_NORETURN void throwLogicError(String const& msg);
 
 /** \brief Type of the value held by a Value object.
  */
@@ -186,7 +186,7 @@ class JSON_API Value {
   friend class ValueIteratorBase;
 
 public:
-  typedef std::vector<JSONCPP_STRING> Members;
+  typedef std::vector<String> Members;
   typedef ValueIterator iterator;
   typedef ValueConstIterator const_iterator;
   typedef Json::UInt UInt;
@@ -332,8 +332,8 @@ Json::Value obj_value(Json::objectValue); // {}
    * \endcode
    */
   Value(const StaticString& value);
-  Value(const JSONCPP_STRING& value); ///< Copy data() til size(). Embedded
-                                      ///< zeroes too.
+  Value(const String& value); ///< Copy data() til size(). Embedded
+                              ///< zeroes too.
 #ifdef JSON_USE_CPPTL
   Value(const CppTL::ConstString& value);
 #endif
@@ -377,7 +377,7 @@ Json::Value obj_value(Json::objectValue); // {}
   unsigned getCStringLength() const; // Allows you to understand the length of
                                      // the CString
 #endif
-  JSONCPP_STRING asString() const; ///< Embedded zeroes are possible.
+  String asString() const; ///< Embedded zeroes are possible.
   /** Get raw char* of string-value.
    *  \return false if !string. (Seg-fault if str or end are NULL.)
    */
@@ -484,11 +484,11 @@ Json::Value obj_value(Json::objectValue); // {}
   const Value& operator[](const char* key) const;
   /// Access an object value by name, create a null member if it does not exist.
   /// \param key may contain embedded nulls.
-  Value& operator[](const JSONCPP_STRING& key);
+  Value& operator[](const String& key);
   /// Access an object value by name, returns null if there is no member with
   /// that name.
   /// \param key may contain embedded nulls.
-  const Value& operator[](const JSONCPP_STRING& key) const;
+  const Value& operator[](const String& key) const;
   /** \brief Access an object value by name, create a null member if it does not
    exist.
 
@@ -521,7 +521,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Return the member named key if it exist, defaultValue otherwise.
   /// \note deep copy
   /// \param key may contain embedded nulls.
-  Value get(const JSONCPP_STRING& key, const Value& defaultValue) const;
+  Value get(const String& key, const Value& defaultValue) const;
 #ifdef JSON_USE_CPPTL
   /// Return the member named key if it exist, defaultValue otherwise.
   /// \note deep copy
@@ -543,7 +543,7 @@ Json::Value obj_value(Json::objectValue); // {}
   void removeMember(const char* key);
   /// Same as removeMember(const char*)
   /// \param key may contain embedded nulls.
-  void removeMember(const JSONCPP_STRING& key);
+  void removeMember(const String& key);
   /// Same as removeMember(const char* begin, const char* end, Value* removed),
   /// but 'key' is null-terminated.
   bool removeMember(const char* key, Value* removed);
@@ -553,8 +553,8 @@ Json::Value obj_value(Json::objectValue); // {}
       \param key may contain embedded nulls.
       \return true iff removed (no exceptions)
   */
-  bool removeMember(JSONCPP_STRING const& key, Value* removed);
-  /// Same as removeMember(JSONCPP_STRING const& key, Value* removed)
+  bool removeMember(String const& key, Value* removed);
+  /// Same as removeMember(String const& key, Value* removed)
   bool removeMember(const char* begin, const char* end, Value* removed);
   /** \brief Remove the indexed array element.
 
@@ -569,8 +569,8 @@ Json::Value obj_value(Json::objectValue); // {}
   bool isMember(const char* key) const;
   /// Return true if the object has a member named key.
   /// \param key may contain embedded nulls.
-  bool isMember(const JSONCPP_STRING& key) const;
-  /// Same as isMember(JSONCPP_STRING const& key)const
+  bool isMember(const String& key) const;
+  /// Same as isMember(String const& key)const
   bool isMember(const char* begin, const char* end) const;
 #ifdef JSON_USE_CPPTL
   /// Return true if the object has a member named key.
@@ -590,17 +590,17 @@ Json::Value obj_value(Json::objectValue); // {}
   //# endif
 
   /// \deprecated Always pass len.
-  JSONCPP_DEPRECATED("Use setComment(JSONCPP_STRING const&) instead.")
+  JSONCPP_DEPRECATED("Use setComment(String const&) instead.")
   void setComment(const char* comment, CommentPlacement placement);
   /// Comments must be //... or /* ... */
   void setComment(const char* comment, size_t len, CommentPlacement placement);
   /// Comments must be //... or /* ... */
-  void setComment(const JSONCPP_STRING& comment, CommentPlacement placement);
+  void setComment(const String& comment, CommentPlacement placement);
   bool hasComment(CommentPlacement placement) const;
   /// Include delimiters and embedded newlines.
-  JSONCPP_STRING getComment(CommentPlacement placement) const;
+  String getComment(CommentPlacement placement) const;
 
-  JSONCPP_STRING toStyledString() const;
+  String toStyledString() const;
 
   const_iterator begin() const;
   const_iterator end() const;
@@ -673,11 +673,11 @@ public:
   PathArgument();
   PathArgument(ArrayIndex index);
   PathArgument(const char* key);
-  PathArgument(const JSONCPP_STRING& key);
+  PathArgument(const String& key);
 
 private:
   enum Kind { kindNone = 0, kindIndex, kindKey };
-  JSONCPP_STRING key_;
+  String key_;
   ArrayIndex index_{};
   Kind kind_{ kindNone };
 };
@@ -695,7 +695,7 @@ private:
  */
 class JSON_API Path {
 public:
-  Path(const JSONCPP_STRING& path,
+  Path(const String& path,
        const PathArgument& a1 = PathArgument(),
        const PathArgument& a2 = PathArgument(),
        const PathArgument& a3 = PathArgument(),
@@ -712,12 +712,12 @@ private:
   typedef std::vector<const PathArgument*> InArgs;
   typedef std::vector<PathArgument> Args;
 
-  void makePath(const JSONCPP_STRING& path, const InArgs& in);
-  void addPathInArg(const JSONCPP_STRING& path,
+  void makePath(const String& path, const InArgs& in);
+  void addPathInArg(const String& path,
                     const InArgs& in,
                     InArgs::const_iterator& itInArg,
                     PathArgument::Kind kind);
-  static void invalidPath(const JSONCPP_STRING& path, int location);
+  static void invalidPath(const String& path, int location);
 
   Args args_;
 };
@@ -751,7 +751,7 @@ public:
   /// Return the member name of the referenced Value, or "" if it is not an
   /// objectValue.
   /// \note Avoid `c_str()` on result, as embedded zeroes are possible.
-  JSONCPP_STRING name() const;
+  String name() const;
 
   /// Return the member name of the referenced Value. "" if it is not an
   /// objectValue.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -41,7 +41,7 @@ Usage:
 */
 class JSON_API StreamWriter {
 protected:
-  JSONCPP_OSTREAM* sout_; // not owned; will not delete
+  OStream* sout_; // not owned; will not delete
 public:
   StreamWriter();
   virtual ~StreamWriter();
@@ -51,7 +51,7 @@ public:
       \return zero on success (For now, we always return zero, so check the
      stream instead.) \throw std::exception possibly, depending on configuration
    */
-  virtual int write(Value const& root, JSONCPP_OSTREAM* sout) = 0;
+  virtual int write(Value const& root, OStream* sout) = 0;
 
   /** \brief A simple abstract factory.
    */
@@ -68,8 +68,8 @@ public:
 /** \brief Write into stringstream, then return string, for convenience.
  * A StreamWriter will be created from the factory, used, and then deleted.
  */
-JSONCPP_STRING JSON_API writeString(StreamWriter::Factory const& factory,
-                                    Value const& root);
+String JSON_API writeString(StreamWriter::Factory const& factory,
+                            Value const& root);
 
 /** \brief Build a StreamWriter implementation.
 
@@ -132,7 +132,7 @@ public:
   bool validate(Json::Value* invalid) const;
   /** A simple way to update a specific setting.
    */
-  Value& operator[](const JSONCPP_STRING& key);
+  Value& operator[](const String& key);
 
   /** Called by ctor, but you can use this to reset settings_.
    * \pre 'settings' != NULL (but Json::null is fine)
@@ -149,7 +149,7 @@ class JSONCPP_DEPRECATED("Use StreamWriter instead") JSON_API Writer {
 public:
   virtual ~Writer();
 
-  virtual JSONCPP_STRING write(const Value& root) = 0;
+  virtual String write(const Value& root) = 0;
 };
 
 /** \brief Outputs a Value in <a HREF="http://www.json.org">JSON</a> format
@@ -183,12 +183,12 @@ public:
   void omitEndingLineFeed();
 
 public: // overridden from Writer
-  JSONCPP_STRING write(const Value& root) override;
+  String write(const Value& root) override;
 
 private:
   void writeValue(const Value& value);
 
-  JSONCPP_STRING document_;
+  String document_;
   bool yamlCompatibilityEnabled_{ false };
   bool dropNullPlaceholders_{ false };
   bool omitEndingLineFeed_{ false };
@@ -236,27 +236,27 @@ public: // overridden from Writer
    * \param root Value to serialize.
    * \return String containing the JSON document that represents the root value.
    */
-  JSONCPP_STRING write(const Value& root) override;
+  String write(const Value& root) override;
 
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
   bool isMultilineArray(const Value& value);
-  void pushValue(const JSONCPP_STRING& value);
+  void pushValue(const String& value);
   void writeIndent();
-  void writeWithIndent(const JSONCPP_STRING& value);
+  void writeWithIndent(const String& value);
   void indent();
   void unindent();
   void writeCommentBeforeValue(const Value& root);
   void writeCommentAfterValueOnSameLine(const Value& root);
   static bool hasCommentForValue(const Value& value);
-  static JSONCPP_STRING normalizeEOL(const JSONCPP_STRING& text);
+  static String normalizeEOL(const String& text);
 
-  typedef std::vector<JSONCPP_STRING> ChildValues;
+  typedef std::vector<String> ChildValues;
 
   ChildValues childValues_;
-  JSONCPP_STRING document_;
-  JSONCPP_STRING indentString_;
+  String document_;
+  String indentString_;
   unsigned int rightMargin_{ 74 };
   unsigned int indentSize_{ 3 };
   bool addChildValues_{ false };
@@ -300,7 +300,7 @@ public:
   /**
    * \param indentation Each level will be indented by this amount extra.
    */
-  StyledStreamWriter(JSONCPP_STRING indentation = "\t");
+  StyledStreamWriter(String indentation = "\t");
   ~StyledStreamWriter() = default;
 
 public:
@@ -310,29 +310,29 @@ public:
    * \note There is no point in deriving from Writer, since write() should not
    * return a value.
    */
-  void write(JSONCPP_OSTREAM& out, const Value& root);
+  void write(OStream& out, const Value& root);
 
 private:
   void writeValue(const Value& value);
   void writeArrayValue(const Value& value);
   bool isMultilineArray(const Value& value);
-  void pushValue(const JSONCPP_STRING& value);
+  void pushValue(const String& value);
   void writeIndent();
-  void writeWithIndent(const JSONCPP_STRING& value);
+  void writeWithIndent(const String& value);
   void indent();
   void unindent();
   void writeCommentBeforeValue(const Value& root);
   void writeCommentAfterValueOnSameLine(const Value& root);
   static bool hasCommentForValue(const Value& value);
-  static JSONCPP_STRING normalizeEOL(const JSONCPP_STRING& text);
+  static String normalizeEOL(const String& text);
 
-  typedef std::vector<JSONCPP_STRING> ChildValues;
+  typedef std::vector<String> ChildValues;
 
   ChildValues childValues_;
-  JSONCPP_OSTREAM* document_;
-  JSONCPP_STRING indentString_;
+  OStream* document_;
+  String indentString_;
   unsigned int rightMargin_{ 74 };
-  JSONCPP_STRING indentation_;
+  String indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
 };
@@ -341,21 +341,21 @@ private:
 #endif
 
 #if defined(JSON_HAS_INT64)
-JSONCPP_STRING JSON_API valueToString(Int value);
-JSONCPP_STRING JSON_API valueToString(UInt value);
+String JSON_API valueToString(Int value);
+String JSON_API valueToString(UInt value);
 #endif // if defined(JSON_HAS_INT64)
-JSONCPP_STRING JSON_API valueToString(LargestInt value);
-JSONCPP_STRING JSON_API valueToString(LargestUInt value);
-JSONCPP_STRING JSON_API
+String JSON_API valueToString(LargestInt value);
+String JSON_API valueToString(LargestUInt value);
+String JSON_API
 valueToString(double value,
               unsigned int precision = Value::defaultRealPrecision,
               PrecisionType precisionType = PrecisionType::significantDigits);
-JSONCPP_STRING JSON_API valueToString(bool value);
-JSONCPP_STRING JSON_API valueToQuotedString(const char* value);
+String JSON_API valueToString(bool value);
+String JSON_API valueToQuotedString(const char* value);
 
 /// \brief Output using the StyledStreamWriter.
 /// \see Json::operator>>()
-JSON_API JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM&, const Value& root);
+JSON_API OStream& operator<<(OStream&, const Value& root);
 
 } // namespace Json
 

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -36,8 +36,8 @@ static inline char getDecimalPoint() {
 }
 
 /// Converts a unicode code-point to UTF-8.
-static inline JSONCPP_STRING codePointToUTF8(unsigned int cp) {
-  JSONCPP_STRING result;
+static inline String codePointToUTF8(unsigned int cp) {
+  String result;
 
   // based on description from http://en.wikipedia.org/wiki/UTF-8
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -217,15 +217,15 @@ static inline void releaseStringValue(char* value, unsigned) { free(value); }
 
 namespace Json {
 
-Exception::Exception(JSONCPP_STRING msg) : msg_(std::move(msg)) {}
+Exception::Exception(String msg) : msg_(std::move(msg)) {}
 Exception::~Exception() JSONCPP_NOEXCEPT {}
 char const* Exception::what() const JSONCPP_NOEXCEPT { return msg_.c_str(); }
-RuntimeError::RuntimeError(JSONCPP_STRING const& msg) : Exception(msg) {}
-LogicError::LogicError(JSONCPP_STRING const& msg) : Exception(msg) {}
-JSONCPP_NORETURN void throwRuntimeError(JSONCPP_STRING const& msg) {
+RuntimeError::RuntimeError(String const& msg) : Exception(msg) {}
+LogicError::LogicError(String const& msg) : Exception(msg) {}
+JSONCPP_NORETURN void throwRuntimeError(String const& msg) {
   throw RuntimeError(msg);
 }
-JSONCPP_NORETURN void throwLogicError(JSONCPP_STRING const& msg) {
+JSONCPP_NORETURN void throwLogicError(String const& msg) {
   throw LogicError(msg);
 }
 
@@ -452,7 +452,7 @@ Value::Value(const char* begin, const char* end) {
       duplicateAndPrefixStringValue(begin, static_cast<unsigned>(end - begin));
 }
 
-Value::Value(const JSONCPP_STRING& value) {
+Value::Value(const String& value) {
   initBasic(stringValue, true);
   value_.string_ = duplicateAndPrefixStringValue(
       value.data(), static_cast<unsigned>(value.length()));
@@ -684,7 +684,7 @@ bool Value::getString(char const** begin, char const** end) const {
   return true;
 }
 
-JSONCPP_STRING Value::asString() const {
+String Value::asString() const {
   switch (type_) {
   case nullValue:
     return "";
@@ -695,7 +695,7 @@ JSONCPP_STRING Value::asString() const {
     char const* this_str;
     decodePrefixedString(this->allocated_, this->value_.string_, &this_len,
                          &this_str);
-    return JSONCPP_STRING(this_str, this_len);
+    return String(this_str, this_len);
   }
   case booleanValue:
     return value_.bool_ ? "true" : "false";
@@ -1172,7 +1172,7 @@ const Value& Value::operator[](const char* key) const {
     return nullSingleton();
   return *found;
 }
-Value const& Value::operator[](const JSONCPP_STRING& key) const {
+Value const& Value::operator[](const String& key) const {
   Value const* found = find(key.data(), key.data() + key.length());
   if (!found)
     return nullSingleton();
@@ -1183,7 +1183,7 @@ Value& Value::operator[](const char* key) {
   return resolveReference(key, key + strlen(key));
 }
 
-Value& Value::operator[](const JSONCPP_STRING& key) {
+Value& Value::operator[](const String& key) {
   return resolveReference(key.data(), key.data() + key.length());
 }
 
@@ -1220,7 +1220,7 @@ Value Value::get(char const* begin,
 Value Value::get(char const* key, Value const& defaultValue) const {
   return get(key, key + strlen(key), defaultValue);
 }
-Value Value::get(JSONCPP_STRING const& key, Value const& defaultValue) const {
+Value Value::get(String const& key, Value const& defaultValue) const {
   return get(key.data(), key.data() + key.length(), defaultValue);
 }
 
@@ -1245,7 +1245,7 @@ bool Value::removeMember(const char* begin, const char* end, Value* removed) {
 bool Value::removeMember(const char* key, Value* removed) {
   return removeMember(key, key + strlen(key), removed);
 }
-bool Value::removeMember(JSONCPP_STRING const& key, Value* removed) {
+bool Value::removeMember(String const& key, Value* removed) {
   return removeMember(key.data(), key.data() + key.length(), removed);
 }
 void Value::removeMember(const char* key) {
@@ -1257,9 +1257,7 @@ void Value::removeMember(const char* key) {
   CZString actualKey(key, unsigned(strlen(key)), CZString::noDuplication);
   value_.map_->erase(actualKey);
 }
-void Value::removeMember(const JSONCPP_STRING& key) {
-  removeMember(key.c_str());
-}
+void Value::removeMember(const String& key) { removeMember(key.c_str()); }
 
 bool Value::removeIndex(ArrayIndex index, Value* removed) {
   if (type_ != arrayValue) {
@@ -1299,7 +1297,7 @@ bool Value::isMember(char const* begin, char const* end) const {
 bool Value::isMember(char const* key) const {
   return isMember(key, key + strlen(key));
 }
-bool Value::isMember(JSONCPP_STRING const& key) const {
+bool Value::isMember(String const& key) const {
   return isMember(key.data(), key.data() + key.length());
 }
 
@@ -1320,7 +1318,7 @@ Value::Members Value::getMemberNames() const {
   ObjectValues::const_iterator it = value_.map_->begin();
   ObjectValues::const_iterator itEnd = value_.map_->end();
   for (; it != itEnd; ++it) {
-    members.push_back(JSONCPP_STRING((*it).first.data(), (*it).first.length()));
+    members.push_back(String((*it).first.data(), (*it).first.length()));
   }
   return members;
 }
@@ -1491,8 +1489,7 @@ void Value::setComment(const char* comment, CommentPlacement placement) {
   setComment(comment, strlen(comment), placement);
 }
 
-void Value::setComment(const JSONCPP_STRING& comment,
-                       CommentPlacement placement) {
+void Value::setComment(const String& comment, CommentPlacement placement) {
   setComment(comment.c_str(), comment.length(), placement);
 }
 
@@ -1500,7 +1497,7 @@ bool Value::hasComment(CommentPlacement placement) const {
   return comments_ != nullptr && comments_[placement].comment_ != nullptr;
 }
 
-JSONCPP_STRING Value::getComment(CommentPlacement placement) const {
+String Value::getComment(CommentPlacement placement) const {
   if (hasComment(placement))
     return comments_[placement].comment_;
   return "";
@@ -1514,10 +1511,10 @@ ptrdiff_t Value::getOffsetStart() const { return start_; }
 
 ptrdiff_t Value::getOffsetLimit() const { return limit_; }
 
-JSONCPP_STRING Value::toStyledString() const {
+String Value::toStyledString() const {
   StreamWriterBuilder builder;
 
-  JSONCPP_STRING out = this->hasComment(commentBefore) ? "\n" : "";
+  String out = this->hasComment(commentBefore) ? "\n" : "";
   out += Json::writeString(builder, *this);
   out += '\n';
 
@@ -1587,13 +1584,13 @@ PathArgument::PathArgument(ArrayIndex index)
 PathArgument::PathArgument(const char* key)
     : key_(key), index_(), kind_(kindKey) {}
 
-PathArgument::PathArgument(const JSONCPP_STRING& key)
+PathArgument::PathArgument(const String& key)
     : key_(key.c_str()), index_(), kind_(kindKey) {}
 
 // class Path
 // //////////////////////////////////////////////////////////////////
 
-Path::Path(const JSONCPP_STRING& path,
+Path::Path(const String& path,
            const PathArgument& a1,
            const PathArgument& a2,
            const PathArgument& a3,
@@ -1609,7 +1606,7 @@ Path::Path(const JSONCPP_STRING& path,
   makePath(path, in);
 }
 
-void Path::makePath(const JSONCPP_STRING& path, const InArgs& in) {
+void Path::makePath(const String& path, const InArgs& in) {
   const char* current = path.c_str();
   const char* end = current + path.length();
   auto itInArg = in.begin();
@@ -1635,12 +1632,12 @@ void Path::makePath(const JSONCPP_STRING& path, const InArgs& in) {
       const char* beginName = current;
       while (current != end && !strchr("[.", *current))
         ++current;
-      args_.push_back(JSONCPP_STRING(beginName, current));
+      args_.push_back(String(beginName, current));
     }
   }
 }
 
-void Path::addPathInArg(const JSONCPP_STRING& /*path*/,
+void Path::addPathInArg(const String& /*path*/,
                         const InArgs& in,
                         InArgs::const_iterator& itInArg,
                         PathArgument::Kind kind) {
@@ -1653,7 +1650,7 @@ void Path::addPathInArg(const JSONCPP_STRING& /*path*/,
   }
 }
 
-void Path::invalidPath(const JSONCPP_STRING& /*path*/, int /*location*/) {
+void Path::invalidPath(const String& /*path*/, int /*location*/) {
   // Error: invalid path.
 }
 

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -84,13 +84,13 @@ UInt ValueIteratorBase::index() const {
   return Value::UInt(-1);
 }
 
-JSONCPP_STRING ValueIteratorBase::name() const {
+String ValueIteratorBase::name() const {
   char const* keey;
   char const* end;
   keey = memberName(&end);
   if (!keey)
-    return JSONCPP_STRING();
-  return JSONCPP_STRING(keey, end);
+    return String();
+  return String(keey, end);
 }
 
 char const* ValueIteratorBase::memberName() const {

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -89,7 +89,7 @@ typedef std::unique_ptr<StreamWriter> StreamWriterPtr;
 typedef std::auto_ptr<StreamWriter> StreamWriterPtr;
 #endif
 
-JSONCPP_STRING valueToString(LargestInt value) {
+String valueToString(LargestInt value) {
   UIntToStringBuffer buffer;
   char* current = buffer + sizeof(buffer);
   if (value == Value::minLargestInt) {
@@ -105,7 +105,7 @@ JSONCPP_STRING valueToString(LargestInt value) {
   return current;
 }
 
-JSONCPP_STRING valueToString(LargestUInt value) {
+String valueToString(LargestUInt value) {
   UIntToStringBuffer buffer;
   char* current = buffer + sizeof(buffer);
   uintToString(value, current);
@@ -115,21 +115,17 @@ JSONCPP_STRING valueToString(LargestUInt value) {
 
 #if defined(JSON_HAS_INT64)
 
-JSONCPP_STRING valueToString(Int value) {
-  return valueToString(LargestInt(value));
-}
+String valueToString(Int value) { return valueToString(LargestInt(value)); }
 
-JSONCPP_STRING valueToString(UInt value) {
-  return valueToString(LargestUInt(value));
-}
+String valueToString(UInt value) { return valueToString(LargestUInt(value)); }
 
 #endif // # if defined(JSON_HAS_INT64)
 
 namespace {
-JSONCPP_STRING valueToString(double value,
-                             bool useSpecialFloats,
-                             unsigned int precision,
-                             PrecisionType precisionType) {
+String valueToString(double value,
+                     bool useSpecialFloats,
+                     unsigned int precision,
+                     PrecisionType precisionType) {
   // Print into the buffer. We need not request the alternative representation
   // that always has a decimal point because JSON doesn't distinguish the
   // concepts of reals and integers.
@@ -140,7 +136,7 @@ JSONCPP_STRING valueToString(double value,
                [isnan(value) ? 0 : (value < 0) ? 1 : 2];
   }
 
-  JSONCPP_STRING buffer(size_t(36), '\0');
+  String buffer(size_t(36), '\0');
   while (true) {
     int len = jsoncpp_snprintf(
         &*buffer.begin(), buffer.size(),
@@ -172,13 +168,13 @@ JSONCPP_STRING valueToString(double value,
 }
 } // namespace
 
-JSONCPP_STRING valueToString(double value,
-                             unsigned int precision,
-                             PrecisionType precisionType) {
+String valueToString(double value,
+                     unsigned int precision,
+                     PrecisionType precisionType) {
   return valueToString(value, false, precision, precisionType);
 }
 
-JSONCPP_STRING valueToString(bool value) { return value ? "true" : "false"; }
+String valueToString(bool value) { return value ? "true" : "false"; }
 
 static bool isAnyCharRequiredQuoting(char const* s, size_t n) {
   assert(s || !n);
@@ -260,10 +256,10 @@ static const char hex2[] = "000102030405060708090a0b0c0d0e0f"
                            "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
                            "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
 
-static JSONCPP_STRING toHex16Bit(unsigned int x) {
+static String toHex16Bit(unsigned int x) {
   const unsigned int hi = (x >> 8) & 0xff;
   const unsigned int lo = x & 0xff;
-  JSONCPP_STRING result(4, ' ');
+  String result(4, ' ');
   result[0] = hex2[2 * hi];
   result[1] = hex2[2 * hi + 1];
   result[2] = hex2[2 * lo];
@@ -271,17 +267,17 @@ static JSONCPP_STRING toHex16Bit(unsigned int x) {
   return result;
 }
 
-static JSONCPP_STRING valueToQuotedStringN(const char* value, unsigned length) {
+static String valueToQuotedStringN(const char* value, unsigned length) {
   if (value == nullptr)
     return "";
 
   if (!isAnyCharRequiredQuoting(value, length))
-    return JSONCPP_STRING("\"") + value + "\"";
+    return String("\"") + value + "\"";
   // We have to walk value and escape any special characters.
-  // Appending to JSONCPP_STRING is not efficient, but this should be rare.
+  // Appending to String is not efficient, but this should be rare.
   // (Note: forward slashes are *not* rare, but I am not escaping them.)
-  JSONCPP_STRING::size_type maxsize = length * 2 + 3; // allescaped+quotes+NULL
-  JSONCPP_STRING result;
+  String::size_type maxsize = length * 2 + 3; // allescaped+quotes+NULL
+  String result;
   result.reserve(maxsize); // to avoid lots of mallocs
   result += "\"";
   char const* end = value + length;
@@ -340,7 +336,7 @@ static JSONCPP_STRING valueToQuotedStringN(const char* value, unsigned length) {
   return result;
 }
 
-JSONCPP_STRING valueToQuotedString(const char* value) {
+String valueToQuotedString(const char* value) {
   return valueToQuotedStringN(value, static_cast<unsigned int>(strlen(value)));
 }
 
@@ -361,7 +357,7 @@ void FastWriter::dropNullPlaceholders() { dropNullPlaceholders_ = true; }
 
 void FastWriter::omitEndingLineFeed() { omitEndingLineFeed_ = true; }
 
-JSONCPP_STRING FastWriter::write(const Value& root) {
+String FastWriter::write(const Value& root) {
   document_.clear();
   writeValue(root);
   if (!omitEndingLineFeed_)
@@ -410,7 +406,7 @@ void FastWriter::writeValue(const Value& value) {
     Value::Members members(value.getMemberNames());
     document_ += '{';
     for (auto it = members.begin(); it != members.end(); ++it) {
-      const JSONCPP_STRING& name = *it;
+      const String& name = *it;
       if (it != members.begin())
         document_ += ',';
       document_ += valueToQuotedStringN(name.data(),
@@ -428,7 +424,7 @@ void FastWriter::writeValue(const Value& value) {
 
 StyledWriter::StyledWriter() = default;
 
-JSONCPP_STRING StyledWriter::write(const Value& root) {
+String StyledWriter::write(const Value& root) {
   document_.clear();
   addChildValues_ = false;
   indentString_.clear();
@@ -479,7 +475,7 @@ void StyledWriter::writeValue(const Value& value) {
       indent();
       auto it = members.begin();
       for (;;) {
-        const JSONCPP_STRING& name = *it;
+        const String& name = *it;
         const Value& childValue = value[name];
         writeCommentBeforeValue(childValue);
         writeWithIndent(valueToQuotedString(name.c_str()));
@@ -569,7 +565,7 @@ bool StyledWriter::isMultilineArray(const Value& value) {
   return isMultiLine;
 }
 
-void StyledWriter::pushValue(const JSONCPP_STRING& value) {
+void StyledWriter::pushValue(const String& value) {
   if (addChildValues_)
     childValues_.push_back(value);
   else
@@ -587,14 +583,12 @@ void StyledWriter::writeIndent() {
   document_ += indentString_;
 }
 
-void StyledWriter::writeWithIndent(const JSONCPP_STRING& value) {
+void StyledWriter::writeWithIndent(const String& value) {
   writeIndent();
   document_ += value;
 }
 
-void StyledWriter::indent() {
-  indentString_ += JSONCPP_STRING(indentSize_, ' ');
-}
+void StyledWriter::indent() { indentString_ += String(indentSize_, ' '); }
 
 void StyledWriter::unindent() {
   assert(indentString_.size() >= indentSize_);
@@ -607,8 +601,8 @@ void StyledWriter::writeCommentBeforeValue(const Value& root) {
 
   document_ += '\n';
   writeIndent();
-  const JSONCPP_STRING& comment = root.getComment(commentBefore);
-  JSONCPP_STRING::const_iterator iter = comment.begin();
+  const String& comment = root.getComment(commentBefore);
+  String::const_iterator iter = comment.begin();
   while (iter != comment.end()) {
     document_ += *iter;
     if (*iter == '\n' && ((iter + 1) != comment.end() && *(iter + 1) == '/'))
@@ -640,11 +634,11 @@ bool StyledWriter::hasCommentForValue(const Value& value) {
 // Class StyledStreamWriter
 // //////////////////////////////////////////////////////////////////
 
-StyledStreamWriter::StyledStreamWriter(JSONCPP_STRING indentation)
+StyledStreamWriter::StyledStreamWriter(String indentation)
     : document_(nullptr), indentation_(std::move(indentation)),
       addChildValues_(), indented_(false) {}
 
-void StyledStreamWriter::write(JSONCPP_OSTREAM& out, const Value& root) {
+void StyledStreamWriter::write(OStream& out, const Value& root) {
   document_ = &out;
   addChildValues_ = false;
   indentString_.clear();
@@ -699,7 +693,7 @@ void StyledStreamWriter::writeValue(const Value& value) {
       indent();
       auto it = members.begin();
       for (;;) {
-        const JSONCPP_STRING& name = *it;
+        const String& name = *it;
         const Value& childValue = value[name];
         writeCommentBeforeValue(childValue);
         writeWithIndent(valueToQuotedString(name.c_str()));
@@ -792,7 +786,7 @@ bool StyledStreamWriter::isMultilineArray(const Value& value) {
   return isMultiLine;
 }
 
-void StyledStreamWriter::pushValue(const JSONCPP_STRING& value) {
+void StyledStreamWriter::pushValue(const String& value) {
   if (addChildValues_)
     childValues_.push_back(value);
   else
@@ -807,7 +801,7 @@ void StyledStreamWriter::writeIndent() {
   *document_ << '\n' << indentString_;
 }
 
-void StyledStreamWriter::writeWithIndent(const JSONCPP_STRING& value) {
+void StyledStreamWriter::writeWithIndent(const String& value) {
   if (!indented_)
     writeIndent();
   *document_ << value;
@@ -827,8 +821,8 @@ void StyledStreamWriter::writeCommentBeforeValue(const Value& root) {
 
   if (!indented_)
     writeIndent();
-  const JSONCPP_STRING& comment = root.getComment(commentBefore);
-  JSONCPP_STRING::const_iterator iter = comment.begin();
+  const String& comment = root.getComment(commentBefore);
+  String::const_iterator iter = comment.begin();
   while (iter != comment.end()) {
     *document_ << *iter;
     if (*iter == '\n' && ((iter + 1) != comment.end() && *(iter + 1) == '/'))
@@ -870,61 +864,60 @@ struct CommentStyle {
 };
 
 struct BuiltStyledStreamWriter : public StreamWriter {
-  BuiltStyledStreamWriter(JSONCPP_STRING indentation,
+  BuiltStyledStreamWriter(String indentation,
                           CommentStyle::Enum cs,
-                          JSONCPP_STRING colonSymbol,
-                          JSONCPP_STRING nullSymbol,
-                          JSONCPP_STRING endingLineFeedSymbol,
+                          String colonSymbol,
+                          String nullSymbol,
+                          String endingLineFeedSymbol,
                           bool useSpecialFloats,
                           unsigned int precision,
                           PrecisionType precisionType);
-  int write(Value const& root, JSONCPP_OSTREAM* sout) override;
+  int write(Value const& root, OStream* sout) override;
 
 private:
   void writeValue(Value const& value);
   void writeArrayValue(Value const& value);
   bool isMultilineArray(Value const& value);
-  void pushValue(JSONCPP_STRING const& value);
+  void pushValue(String const& value);
   void writeIndent();
-  void writeWithIndent(JSONCPP_STRING const& value);
+  void writeWithIndent(String const& value);
   void indent();
   void unindent();
   void writeCommentBeforeValue(Value const& root);
   void writeCommentAfterValueOnSameLine(Value const& root);
   static bool hasCommentForValue(const Value& value);
 
-  typedef std::vector<JSONCPP_STRING> ChildValues;
+  typedef std::vector<String> ChildValues;
 
   ChildValues childValues_;
-  JSONCPP_STRING indentString_;
+  String indentString_;
   unsigned int rightMargin_;
-  JSONCPP_STRING indentation_;
+  String indentation_;
   CommentStyle::Enum cs_;
-  JSONCPP_STRING colonSymbol_;
-  JSONCPP_STRING nullSymbol_;
-  JSONCPP_STRING endingLineFeedSymbol_;
+  String colonSymbol_;
+  String nullSymbol_;
+  String endingLineFeedSymbol_;
   bool addChildValues_ : 1;
   bool indented_ : 1;
   bool useSpecialFloats_ : 1;
   unsigned int precision_;
   PrecisionType precisionType_;
 };
-BuiltStyledStreamWriter::BuiltStyledStreamWriter(
-    JSONCPP_STRING indentation,
-    CommentStyle::Enum cs,
-    JSONCPP_STRING colonSymbol,
-    JSONCPP_STRING nullSymbol,
-    JSONCPP_STRING endingLineFeedSymbol,
-    bool useSpecialFloats,
-    unsigned int precision,
-    PrecisionType precisionType)
+BuiltStyledStreamWriter::BuiltStyledStreamWriter(String indentation,
+                                                 CommentStyle::Enum cs,
+                                                 String colonSymbol,
+                                                 String nullSymbol,
+                                                 String endingLineFeedSymbol,
+                                                 bool useSpecialFloats,
+                                                 unsigned int precision,
+                                                 PrecisionType precisionType)
     : rightMargin_(74), indentation_(std::move(indentation)), cs_(cs),
       colonSymbol_(std::move(colonSymbol)), nullSymbol_(std::move(nullSymbol)),
       endingLineFeedSymbol_(std::move(endingLineFeedSymbol)),
       addChildValues_(false), indented_(false),
       useSpecialFloats_(useSpecialFloats), precision_(precision),
       precisionType_(precisionType) {}
-int BuiltStyledStreamWriter::write(Value const& root, JSONCPP_OSTREAM* sout) {
+int BuiltStyledStreamWriter::write(Value const& root, OStream* sout) {
   sout_ = sout;
   addChildValues_ = false;
   indented_ = true;
@@ -980,7 +973,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
       indent();
       auto it = members.begin();
       for (;;) {
-        JSONCPP_STRING const& name = *it;
+        String const& name = *it;
         Value const& childValue = value[name];
         writeCommentBeforeValue(childValue);
         writeWithIndent(valueToQuotedStringN(
@@ -1078,7 +1071,7 @@ bool BuiltStyledStreamWriter::isMultilineArray(Value const& value) {
   return isMultiLine;
 }
 
-void BuiltStyledStreamWriter::pushValue(JSONCPP_STRING const& value) {
+void BuiltStyledStreamWriter::pushValue(String const& value) {
   if (addChildValues_)
     childValues_.push_back(value);
   else
@@ -1097,7 +1090,7 @@ void BuiltStyledStreamWriter::writeIndent() {
   }
 }
 
-void BuiltStyledStreamWriter::writeWithIndent(JSONCPP_STRING const& value) {
+void BuiltStyledStreamWriter::writeWithIndent(String const& value) {
   if (!indented_)
     writeIndent();
   *sout_ << value;
@@ -1119,8 +1112,8 @@ void BuiltStyledStreamWriter::writeCommentBeforeValue(Value const& root) {
 
   if (!indented_)
     writeIndent();
-  const JSONCPP_STRING& comment = root.getComment(commentBefore);
-  JSONCPP_STRING::const_iterator iter = comment.begin();
+  const String& comment = root.getComment(commentBefore);
+  String::const_iterator iter = comment.begin();
   while (iter != comment.end()) {
     *sout_ << *iter;
     if (*iter == '\n' && ((iter + 1) != comment.end() && *(iter + 1) == '/'))
@@ -1160,9 +1153,9 @@ StreamWriter::Factory::~Factory() = default;
 StreamWriterBuilder::StreamWriterBuilder() { setDefaults(&settings_); }
 StreamWriterBuilder::~StreamWriterBuilder() = default;
 StreamWriter* StreamWriterBuilder::newStreamWriter() const {
-  JSONCPP_STRING indentation = settings_["indentation"].asString();
-  JSONCPP_STRING cs_str = settings_["commentStyle"].asString();
-  JSONCPP_STRING pt_str = settings_["precisionType"].asString();
+  String indentation = settings_["indentation"].asString();
+  String cs_str = settings_["commentStyle"].asString();
+  String pt_str = settings_["precisionType"].asString();
   bool eyc = settings_["enableYAMLCompatibility"].asBool();
   bool dnp = settings_["dropNullPlaceholders"].asBool();
   bool usf = settings_["useSpecialFloats"].asBool();
@@ -1183,24 +1176,24 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const {
   } else {
     throwRuntimeError("precisionType must be 'significant' or 'decimal'");
   }
-  JSONCPP_STRING colonSymbol = " : ";
+  String colonSymbol = " : ";
   if (eyc) {
     colonSymbol = ": ";
   } else if (indentation.empty()) {
     colonSymbol = ":";
   }
-  JSONCPP_STRING nullSymbol = "null";
+  String nullSymbol = "null";
   if (dnp) {
     nullSymbol.clear();
   }
   if (pre > 17)
     pre = 17;
-  JSONCPP_STRING endingLineFeedSymbol;
+  String endingLineFeedSymbol;
   return new BuiltStyledStreamWriter(indentation, cs, colonSymbol, nullSymbol,
                                      endingLineFeedSymbol, usf, pre,
                                      precisionType);
 }
-static void getValidWriterKeys(std::set<JSONCPP_STRING>* valid_keys) {
+static void getValidWriterKeys(std::set<String>* valid_keys) {
   valid_keys->clear();
   valid_keys->insert("indentation");
   valid_keys->insert("commentStyle");
@@ -1215,19 +1208,19 @@ bool StreamWriterBuilder::validate(Json::Value* invalid) const {
   if (!invalid)
     invalid = &my_invalid; // so we do not need to test for NULL
   Json::Value& inv = *invalid;
-  std::set<JSONCPP_STRING> valid_keys;
+  std::set<String> valid_keys;
   getValidWriterKeys(&valid_keys);
   Value::Members keys = settings_.getMemberNames();
   size_t n = keys.size();
   for (size_t i = 0; i < n; ++i) {
-    JSONCPP_STRING const& key = keys[i];
+    String const& key = keys[i];
     if (valid_keys.find(key) == valid_keys.end()) {
       inv[key] = settings_[key];
     }
   }
   return inv.empty();
 }
-Value& StreamWriterBuilder::operator[](const JSONCPP_STRING& key) {
+Value& StreamWriterBuilder::operator[](const String& key) {
   return settings_[key];
 }
 // static
@@ -1243,15 +1236,14 @@ void StreamWriterBuilder::setDefaults(Json::Value* settings) {
   //! [StreamWriterBuilderDefaults]
 }
 
-JSONCPP_STRING writeString(StreamWriter::Factory const& factory,
-                           Value const& root) {
-  JSONCPP_OSTRINGSTREAM sout;
+String writeString(StreamWriter::Factory const& factory, Value const& root) {
+  OStringStream sout;
   StreamWriterPtr const writer(factory.newStreamWriter());
   writer->write(root, &sout);
   return sout.str();
 }
 
-JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM& sout, Value const& root) {
+OStream& operator<<(OStream& sout, Value const& root) {
   StreamWriterBuilder builder;
   StreamWriterPtr const writer(builder.newStreamWriter());
   writer->write(root, &sout);

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -80,7 +80,7 @@ TestResult::TestResult() {
   predicateStackTail_ = &rootPredicateNode_;
 }
 
-void TestResult::setTestName(const JSONCPP_STRING& name) { name_ = name; }
+void TestResult::setTestName(const Json::String& name) { name_ = name; }
 
 TestResult&
 TestResult::addFailure(const char* file, unsigned int line, const char* expr) {
@@ -150,7 +150,7 @@ void TestResult::printFailure(bool printTestName) const {
 
   // Print in reverse to display the callstack in the right order
   for (const auto& failure : failures_) {
-    JSONCPP_STRING indent(failure.nestingLevel_ * 2, ' ');
+    Json::String indent(failure.nestingLevel_ * 2, ' ');
     if (failure.file_) {
       printf("%s%s(%u): ", indent.c_str(), failure.file_, failure.line_);
     }
@@ -160,19 +160,18 @@ void TestResult::printFailure(bool printTestName) const {
       printf("\n");
     }
     if (!failure.message_.empty()) {
-      JSONCPP_STRING reindented = indentText(failure.message_, indent + "  ");
+      Json::String reindented = indentText(failure.message_, indent + "  ");
       printf("%s\n", reindented.c_str());
     }
   }
 }
 
-JSONCPP_STRING TestResult::indentText(const JSONCPP_STRING& text,
-                                      const JSONCPP_STRING& indent) {
-  JSONCPP_STRING reindented;
-  JSONCPP_STRING::size_type lastIndex = 0;
+Json::String TestResult::indentText(const Json::String& text, const Json::String& indent) {
+  Json::String reindented;
+  Json::String::size_type lastIndex = 0;
   while (lastIndex < text.size()) {
-    JSONCPP_STRING::size_type nextIndex = text.find('\n', lastIndex);
-    if (nextIndex == JSONCPP_STRING::npos) {
+    Json::String::size_type nextIndex = text.find('\n', lastIndex);
+    if (nextIndex == Json::String::npos) {
       nextIndex = text.size() - 1;
     }
     reindented += indent;
@@ -182,7 +181,7 @@ JSONCPP_STRING TestResult::indentText(const JSONCPP_STRING& text,
   return reindented;
 }
 
-TestResult& TestResult::addToLastFailure(const JSONCPP_STRING& message) {
+TestResult& TestResult::addToLastFailure(const Json::String& message) {
   if (messageTarget_ != nullptr) {
     messageTarget_->message_ += message;
   }
@@ -225,9 +224,9 @@ Runner& Runner::add(TestCaseFactory factory) {
 
 size_t Runner::testCount() const { return tests_.size(); }
 
-JSONCPP_STRING Runner::testNameAt(size_t index) const {
+Json::String Runner::testNameAt(size_t index) const {
   TestCase* test = tests_[index]();
-  JSONCPP_STRING name = test->testName();
+  Json::String name = test->testName();
   delete test;
   return name;
 }
@@ -284,7 +283,7 @@ bool Runner::runAllTest(bool printSummary) const {
   }
 }
 
-bool Runner::testIndex(const JSONCPP_STRING& testName, size_t& indexOut) const {
+bool Runner::testIndex(const Json::String& testName, size_t& indexOut) const {
   const size_t count = testCount();
   for (size_t index = 0; index < count; ++index) {
     if (testNameAt(index) == testName) {
@@ -303,10 +302,10 @@ void Runner::listTests() const {
 }
 
 int Runner::runCommandLine(int argc, const char* argv[]) const {
-  // typedef std::deque<JSONCPP_STRING> TestNames;
+  // typedef std::deque<String> TestNames;
   Runner subrunner;
   for (int index = 1; index < argc; ++index) {
-    JSONCPP_STRING opt = argv[index];
+    Json::String opt = argv[index];
     if (opt == "--list-tests") {
       listTests();
       return 0;
@@ -406,21 +405,19 @@ void Runner::printUsage(const char* appName) {
 // Assertion functions
 // //////////////////////////////////////////////////////////////////
 
-JSONCPP_STRING ToJsonString(const char* toConvert) {
-  return JSONCPP_STRING(toConvert);
-}
+Json::String ToJsonString(const char* toConvert) { return Json::String(toConvert); }
 
-JSONCPP_STRING ToJsonString(JSONCPP_STRING in) { return in; }
+Json::String ToJsonString(Json::String in) { return in; }
 
 #if JSONCPP_USING_SECURE_MEMORY
-JSONCPP_STRING ToJsonString(std::string in) {
-  return JSONCPP_STRING(in.data(), in.data() + in.length());
+Json::String ToJsonString(std::string in) {
+  return Json::String(in.data(), in.data() + in.length());
 }
 #endif
 
 TestResult& checkStringEqual(TestResult& result,
-                             const JSONCPP_STRING& expected,
-                             const JSONCPP_STRING& actual,
+                             const Json::String& expected,
+                             const Json::String& actual,
                              const char* file,
                              unsigned int line,
                              const char* expr) {

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -32,8 +32,8 @@ class Failure {
 public:
   const char* file_;
   unsigned int line_;
-  JSONCPP_STRING expr_;
-  JSONCPP_STRING message_;
+  Json::String expr_;
+  Json::String message_;
   unsigned int nestingLevel_;
 };
 
@@ -65,7 +65,7 @@ public:
   /// \internal Implementation detail for predicate macros
   PredicateContext* predicateStackTail_;
 
-  void setTestName(const JSONCPP_STRING& name);
+  void setTestName(const Json::String& name);
 
   /// Adds an assertion failure.
   TestResult&
@@ -82,7 +82,7 @@ public:
 
   // Generic operator that will work with anything ostream can deal with.
   template <typename T> TestResult& operator<<(const T& value) {
-    JSONCPP_OSTRINGSTREAM oss;
+    Json::OStringStream oss;
     oss.precision(16);
     oss.setf(std::ios_base::floatfield);
     oss << value;
@@ -96,18 +96,17 @@ public:
   TestResult& operator<<(Json::UInt64 value);
 
 private:
-  TestResult& addToLastFailure(const JSONCPP_STRING& message);
+  TestResult& addToLastFailure(const Json::String& message);
   /// Adds a failure or a predicate context
   void addFailureInfo(const char* file,
                       unsigned int line,
                       const char* expr,
                       unsigned int nestingLevel);
-  static JSONCPP_STRING indentText(const JSONCPP_STRING& text,
-                                   const JSONCPP_STRING& indent);
+  static Json::String indentText(const Json::String& text, const Json::String& indent);
 
   typedef std::deque<Failure> Failures;
   Failures failures_;
-  JSONCPP_STRING name_;
+  Json::String name_;
   PredicateContext rootPredicateNode_;
   PredicateContext::Id lastUsedPredicateId_{ 0 };
   /// Failure which is the target of the messages added using operator <<
@@ -154,7 +153,7 @@ public:
   size_t testCount() const;
 
   /// Returns the name of the test case at the specified index
-  JSONCPP_STRING testNameAt(size_t index) const;
+  Json::String testNameAt(size_t index) const;
 
   /// Runs the test case at the specified index using the specified TestResult
   void runTestAt(size_t index, TestResult& result) const;
@@ -167,7 +166,7 @@ private: // prevents copy construction and assignment
 
 private:
   void listTests() const;
-  bool testIndex(const JSONCPP_STRING& testName, size_t& indexOut) const;
+  bool testIndex(const Json::String& testName, size_t& indexOut) const;
   static void preventDialogOnCrash();
 
 private:
@@ -190,15 +189,15 @@ TestResult& checkEqual(TestResult& result,
   return result;
 }
 
-JSONCPP_STRING ToJsonString(const char* toConvert);
-JSONCPP_STRING ToJsonString(JSONCPP_STRING in);
+Json::String ToJsonString(const char* toConvert);
+Json::String ToJsonString(Json::String in);
 #if JSONCPP_USING_SECURE_MEMORY
-JSONCPP_STRING ToJsonString(std::string in);
+Json::String ToJsonString(std::string in);
 #endif
 
 TestResult& checkStringEqual(TestResult& result,
-                             const JSONCPP_STRING& expected,
-                             const JSONCPP_STRING& actual,
+                             const Json::String& expected,
+                             const Json::String& actual,
                              const char* file,
                              unsigned int line,
                              const char* expr);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -110,21 +110,20 @@ struct ValueTest : JsonTest::TestCase {
 
   /// Normalize the representation of floating-point number by stripped leading
   /// 0 in exponent.
-  static JSONCPP_STRING normalizeFloatingPointStr(const JSONCPP_STRING& s);
+  static Json::String normalizeFloatingPointStr(const Json::String& s);
 };
 
-JSONCPP_STRING ValueTest::normalizeFloatingPointStr(const JSONCPP_STRING& s) {
-  JSONCPP_STRING::size_type index = s.find_last_of("eE");
-  if (index != JSONCPP_STRING::npos) {
-    JSONCPP_STRING::size_type hasSign =
+Json::String ValueTest::normalizeFloatingPointStr(const Json::String& s) {
+  Json::String::size_type index = s.find_last_of("eE");
+  if (index != Json::String::npos) {
+    Json::String::size_type hasSign =
         (s[index + 1] == '+' || s[index + 1] == '-') ? 1 : 0;
-    JSONCPP_STRING::size_type exponentStartIndex = index + 1 + hasSign;
-    JSONCPP_STRING normalized = s.substr(0, exponentStartIndex);
-    JSONCPP_STRING::size_type indexDigit =
-        s.find_first_not_of('0', exponentStartIndex);
-    JSONCPP_STRING exponent = "0";
-    if (indexDigit != JSONCPP_STRING::npos) // There is an exponent different
-                                            // from 0
+    Json::String::size_type exponentStartIndex = index + 1 + hasSign;
+    Json::String normalized = s.substr(0, exponentStartIndex);
+    Json::String::size_type indexDigit = s.find_first_not_of('0', exponentStartIndex);
+    Json::String exponent = "0";
+    if (indexDigit != Json::String::npos) // There is an exponent different
+                                    // from 0
     {
       exponent = s.substr(indexDigit);
     }
@@ -1601,7 +1600,7 @@ JSONTEST_FIXTURE(ValueTest, offsetAccessors) {
 JSONTEST_FIXTURE(ValueTest, StaticString) {
   char mutant[] = "hello";
   Json::StaticString ss(mutant);
-  JSONCPP_STRING regular(mutant);
+  Json::String regular(mutant);
   mutant[1] = 'a';
   JSONTEST_ASSERT_STRING_EQUAL("hallo", ss.c_str());
   JSONTEST_ASSERT_STRING_EQUAL("hello", regular.c_str());
@@ -1623,16 +1622,16 @@ JSONTEST_FIXTURE(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE(ValueTest, CommentBefore) {
   Json::Value val; // fill val
-  val.setComment(JSONCPP_STRING("// this comment should appear before"),
+  val.setComment(Json::String("// this comment should appear before"),
                  Json::commentBefore);
   Json::StreamWriterBuilder wbuilder;
   wbuilder.settings_["commentStyle"] = "All";
   {
     char const expected[] = "// this comment should appear before\nnull";
-    JSONCPP_STRING result = Json::writeString(wbuilder, val);
+    Json::String result = Json::writeString(wbuilder, val);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
-    JSONCPP_STRING res2 = val.toStyledString();
-    JSONCPP_STRING exp2 = "\n";
+    Json::String res2 = val.toStyledString();
+    Json::String exp2 = "\n";
     exp2 += expected;
     exp2 += "\n";
     JSONTEST_ASSERT_STRING_EQUAL(exp2, res2);
@@ -1641,10 +1640,10 @@ JSONTEST_FIXTURE(ValueTest, CommentBefore) {
   val.swapPayload(other);
   {
     char const expected[] = "// this comment should appear before\n\"hello\"";
-    JSONCPP_STRING result = Json::writeString(wbuilder, val);
+    Json::String result = Json::writeString(wbuilder, val);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
-    JSONCPP_STRING res2 = val.toStyledString();
-    JSONCPP_STRING exp2 = "\n";
+    Json::String res2 = val.toStyledString();
+    Json::String exp2 = "\n";
     exp2 += expected;
     exp2 += "\n";
     JSONTEST_ASSERT_STRING_EQUAL(exp2, res2);
@@ -1655,10 +1654,10 @@ JSONTEST_FIXTURE(ValueTest, CommentBefore) {
   // Json::CommentPlacement::commentBefore); Assignment over-writes comments.
   {
     char const expected[] = "\"hello\"";
-    JSONCPP_STRING result = Json::writeString(wbuilder, val);
+    Json::String result = Json::writeString(wbuilder, val);
     JSONTEST_ASSERT_STRING_EQUAL(expected, result);
-    JSONCPP_STRING res2 = val.toStyledString();
-    JSONCPP_STRING exp2 = "";
+    Json::String res2 = val.toStyledString();
+    Json::String exp2 = "";
     exp2 += expected;
     exp2 += "\n";
     JSONTEST_ASSERT_STRING_EQUAL(exp2, res2);
@@ -1667,7 +1666,7 @@ JSONTEST_FIXTURE(ValueTest, CommentBefore) {
 
 JSONTEST_FIXTURE(ValueTest, zeroes) {
   char const cstr[] = "h\0i";
-  JSONCPP_STRING binary(cstr, sizeof(cstr)); // include trailing 0
+  Json::String binary(cstr, sizeof(cstr)); // include trailing 0
   JSONTEST_ASSERT_EQUAL(4U, binary.length());
   Json::StreamWriterBuilder b;
   {
@@ -1693,7 +1692,7 @@ JSONTEST_FIXTURE(ValueTest, zeroes) {
 
 JSONTEST_FIXTURE(ValueTest, zeroesInKeys) {
   char const cstr[] = "h\0i";
-  JSONCPP_STRING binary(cstr, sizeof(cstr)); // include trailing 0
+  Json::String binary(cstr, sizeof(cstr)); // include trailing 0
   JSONTEST_ASSERT_EQUAL(4U, binary.length());
   {
     Json::Value root;
@@ -1724,8 +1723,8 @@ JSONTEST_FIXTURE(ValueTest, specialFloats) {
   b.settings_["useSpecialFloats"] = true;
 
   Json::Value v = std::numeric_limits<double>::quiet_NaN();
-  JSONCPP_STRING expected = "NaN";
-  JSONCPP_STRING result = Json::writeString(b, v);
+  Json::String expected = "NaN";
+  Json::String result = Json::writeString(b, v);
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
   v = std::numeric_limits<double>::infinity();
@@ -1744,8 +1743,8 @@ JSONTEST_FIXTURE(ValueTest, precision) {
   b.settings_["precision"] = 5;
 
   Json::Value v = 100.0 / 3;
-  JSONCPP_STRING expected = "33.333";
-  JSONCPP_STRING result = Json::writeString(b, v);
+  Json::String expected = "33.333";
+  Json::String result = Json::writeString(b, v);
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
   v = 0.25000000;
@@ -1820,15 +1819,15 @@ JSONTEST_FIXTURE(StreamWriterTest, dropNullPlaceholders) {
 }
 
 JSONTEST_FIXTURE(StreamWriterTest, writeZeroes) {
-  JSONCPP_STRING binary("hi", 3); // include trailing 0
+  Json::String binary("hi", 3); // include trailing 0
   JSONTEST_ASSERT_EQUAL(3, binary.length());
-  JSONCPP_STRING expected("\"hi\\u0000\""); // unicoded zero
+  Json::String expected("\"hi\\u0000\""); // unicoded zero
   Json::StreamWriterBuilder b;
   {
     Json::Value root;
     root = binary;
     JSONTEST_ASSERT_STRING_EQUAL(binary, root.asString());
-    JSONCPP_STRING out = Json::writeString(b, root);
+    Json::String out = Json::writeString(b, root);
     JSONTEST_ASSERT_EQUAL(expected.size(), out.size());
     JSONTEST_ASSERT_STRING_EQUAL(expected, out);
   }
@@ -1836,7 +1835,7 @@ JSONTEST_FIXTURE(StreamWriterTest, writeZeroes) {
     Json::Value root;
     root["top"] = binary;
     JSONTEST_ASSERT_STRING_EQUAL(binary, root["top"].asString());
-    JSONCPP_STRING out = Json::writeString(b, root["top"]);
+    Json::String out = Json::writeString(b, root["top"]);
     JSONTEST_ASSERT_STRING_EQUAL(expected, out);
   }
 }
@@ -1937,7 +1936,7 @@ struct CharReaderTest : JsonTest::TestCase {};
 JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrors) {
   Json::CharReaderBuilder b;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::Value root;
   char const doc[] = "{ \"property\" : \"value\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
@@ -1949,7 +1948,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrors) {
 JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrorsTestingOffsets) {
   Json::CharReaderBuilder b;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::Value root;
   char const doc[] = "{ \"property\" : [\"value\", \"value2\"], \"obj\" : "
                      "{ \"nested\" : 123, \"bool\" : true}, \"null\" : "
@@ -1963,7 +1962,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithNoErrorsTestingOffsets) {
 JSONTEST_FIXTURE(CharReaderTest, parseWithOneError) {
   Json::CharReaderBuilder b;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::Value root;
   char const doc[] = "{ \"property\" :: \"value\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
@@ -1977,7 +1976,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithOneError) {
 JSONTEST_FIXTURE(CharReaderTest, parseChineseWithOneError) {
   Json::CharReaderBuilder b;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::Value root;
   char const doc[] = "{ \"pr佐藤erty\" :: \"value\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
@@ -1991,7 +1990,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseChineseWithOneError) {
 JSONTEST_FIXTURE(CharReaderTest, parseWithDetailError) {
   Json::CharReaderBuilder b;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::Value root;
   char const doc[] = "{ \"property\" : \"v\\alue\" }";
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
@@ -2009,7 +2008,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithStackLimit) {
   {
     b.settings_["stackLimit"] = 2;
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
@@ -2019,7 +2018,7 @@ JSONTEST_FIXTURE(CharReaderTest, parseWithStackLimit) {
   {
     b.settings_["stackLimit"] = 1;
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     JSONTEST_ASSERT_THROWS(
         reader->parse(doc, doc + std::strlen(doc), &root, &errs));
     delete reader;
@@ -2036,7 +2035,7 @@ JSONTEST_FIXTURE(CharReaderStrictModeTest, dupKeys) {
   {
     b.strictMode(&b.settings_);
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(!ok);
     JSONTEST_ASSERT_STRING_EQUAL("* Line 1, Column 41\n"
@@ -2056,7 +2055,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue164) {
   {
     b.settings_["failIfExtra"] = false;
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
@@ -2066,7 +2065,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue164) {
   {
     b.settings_["failIfExtra"] = true;
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(!ok);
     JSONTEST_ASSERT_STRING_EQUAL(errs,
@@ -2079,7 +2078,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue164) {
     b.settings_["failIfExtra"] = false;
     b.strictMode(&b.settings_);
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(!ok);
     JSONTEST_ASSERT_STRING_EQUAL(errs,
@@ -2096,7 +2095,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, issue107) {
   char const doc[] = "1:2:3";
   b.settings_["failIfExtra"] = true;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(!ok);
   JSONTEST_ASSERT_STRING_EQUAL("* Line 1, Column 2\n"
@@ -2112,7 +2111,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterObject) {
     char const doc[] = "{ \"property\" : \"value\" } //trailing\n//comment\n";
     b.settings_["failIfExtra"] = true;
     Json::CharReader* reader(b.newCharReader());
-    JSONCPP_STRING errs;
+    Json::String errs;
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT_STRING_EQUAL("", errs);
@@ -2126,7 +2125,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterArray) {
   char const doc[] = "[ \"property\" , \"value\" ] //trailing\n//comment\n";
   b.settings_["failIfExtra"] = true;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
   JSONTEST_ASSERT_STRING_EQUAL("", errs);
@@ -2139,7 +2138,7 @@ JSONTEST_FIXTURE(CharReaderFailIfExtraTest, commentAfterBool) {
   char const doc[] = " true /*trailing\ncomment*/";
   b.settings_["failIfExtra"] = true;
   Json::CharReader* reader(b.newCharReader());
-  JSONCPP_STRING errs;
+  Json::String errs;
   bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
   JSONTEST_ASSERT(ok);
   JSONTEST_ASSERT_STRING_EQUAL("", errs);
@@ -2152,7 +2151,7 @@ JSONTEST_FIXTURE(CharReaderAllowDropNullTest, issue178) {
   Json::CharReaderBuilder b;
   b.settings_["allowDroppedNullPlaceholders"] = true;
   Json::Value root;
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::CharReader* reader(b.newCharReader());
   {
     char const doc[] = "{\"a\":,\"b\":true}";
@@ -2274,7 +2273,7 @@ JSONTEST_FIXTURE(CharReaderAllowSingleQuotesTest, issue182) {
   Json::CharReaderBuilder b;
   b.settings_["allowSingleQuotes"] = true;
   Json::Value root;
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::CharReader* reader(b.newCharReader());
   {
     char const doc[] = "{'a':true,\"b\":true}";
@@ -2303,7 +2302,7 @@ JSONTEST_FIXTURE(CharReaderAllowZeroesTest, issue176) {
   Json::CharReaderBuilder b;
   b.settings_["allowSingleQuotes"] = true;
   Json::Value root;
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::CharReader* reader(b.newCharReader());
   {
     char const doc[] = "{'a':true,\"b\":true}";
@@ -2332,7 +2331,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
   Json::CharReaderBuilder b;
   b.settings_["allowSpecialFloats"] = true;
   Json::Value root;
-  JSONCPP_STRING errs;
+  Json::String errs;
   Json::CharReader* reader(b.newCharReader());
   {
     char const doc[] = "{\"a\":NaN,\"b\":Infinity,\"c\":-Infinity}";
@@ -2351,7 +2350,7 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
   struct TestData {
     int line;
     bool ok;
-    JSONCPP_STRING in;
+    Json::String in;
   };
   const TestData test_data[] = {
     { __LINE__, true, "{\"a\":9}" },          //
@@ -2426,7 +2425,7 @@ JSONTEST_FIXTURE(IteratorTest, distance) {
   json["k1"] = "a";
   json["k2"] = "b";
   int dist = 0;
-  JSONCPP_STRING str;
+  Json::String str;
   for (Json::ValueIterator it = json.begin(); it != json.end(); ++it) {
     dist = it - json.begin();
     str = it->asString().c_str();
@@ -2480,19 +2479,19 @@ JSONTEST_FIXTURE(IteratorTest, const) {
   Json::Value value;
 
   for (int i = 9; i < 12; ++i) {
-    JSONCPP_OSTRINGSTREAM out;
+    Json::OStringStream out;
     out << std::setw(2) << i;
-    JSONCPP_STRING str = out.str();
+    Json::String str = out.str();
     value[str] = str;
   }
 
-  JSONCPP_OSTRINGSTREAM out;
+  Json::OStringStream out;
   // in old code, this will get a compile error
   Json::Value::const_iterator iter = value.begin();
   for (; iter != value.end(); ++iter) {
     out << *iter << ',';
   }
-  JSONCPP_STRING expected = "\" 9\",\"10\",\"11\",";
+  Json::String expected = "\" 9\",\"10\",\"11\",";
   JSONTEST_ASSERT_STRING_EQUAL(expected, out.str());
 }
 


### PR DESCRIPTION

There's no reason for those JSONCPP_STRING etc to be macros.
Let's use real typedefs so the compiler can see them for what they are, and they can have proper namespacing, etc.