### PR TITLE
C++11 clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -29,8 +29,8 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerBindsToType: true
 SpacesBeforeTrailingComments: 1
-Cpp11BracedListStyle: false
-Standard:        Cpp03
+Cpp11BracedListStyle: true
+Standard:        Cpp11
 IndentWidth:     2
 TabWidth:        8
 UseTab:          Never

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -176,9 +176,8 @@ typedef UInt64 LargestUInt;
 template <typename T>
 using Allocator = typename std::conditional<JSONCPP_USING_SECURE_MEMORY,
                                             SecureAllocator<T>,
-                                            std::allocator<T> >::type;
-using String =
-    std::basic_string<char, std::char_traits<char>, Allocator<char> >;
+                                            std::allocator<T>>::type;
+using String = std::basic_string<char, std::char_traits<char>, Allocator<char>>;
 using IStringStream = std::basic_istringstream<String::value_type,
                                                String::traits_type,
                                                String::allocator_type>;

--- a/include/json/features.h
+++ b/include/json/features.h
@@ -41,17 +41,17 @@ public:
   Features();
 
   /// \c true if comments are allowed. Default: \c true.
-  bool allowComments_{ true };
+  bool allowComments_{true};
 
   /// \c true if root must be either an array or an object value. Default: \c
   /// false.
-  bool strictRoot_{ false };
+  bool strictRoot_{false};
 
   /// \c true if dropped null placeholders are allowed. Default: \c false.
-  bool allowDroppedNullPlaceholders_{ false };
+  bool allowDroppedNullPlaceholders_{false};
 
   /// \c true if numeric object key are allowed. Default: \c false.
-  bool allowNumericKeys_{ false };
+  bool allowNumericKeys_{false};
 };
 
 } // namespace Json

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -630,7 +630,7 @@ private:
 
     void setComment(const char* text, size_t len);
 
-    char* comment_{ nullptr };
+    char* comment_{nullptr};
   };
 
   // struct MemberNamesTransform
@@ -679,7 +679,7 @@ private:
   enum Kind { kindNone = 0, kindIndex, kindKey };
   String key_;
   ArrayIndex index_{};
-  Kind kind_{ kindNone };
+  Kind kind_{kindNone};
 };
 
 /** \brief Experimental and untested: represents a "path" to access a node.
@@ -780,7 +780,7 @@ protected:
 private:
   Value::ObjectValues::iterator current_;
   // Indicates that iterator is for a null value.
-  bool isNull_{ true };
+  bool isNull_{true};
 
 public:
   // For some reason, BORLAND needs these at the end, rather

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -189,9 +189,9 @@ private:
   void writeValue(const Value& value);
 
   String document_;
-  bool yamlCompatibilityEnabled_{ false };
-  bool dropNullPlaceholders_{ false };
-  bool omitEndingLineFeed_{ false };
+  bool yamlCompatibilityEnabled_{false};
+  bool dropNullPlaceholders_{false};
+  bool omitEndingLineFeed_{false};
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -257,9 +257,9 @@ private:
   ChildValues childValues_;
   String document_;
   String indentString_;
-  unsigned int rightMargin_{ 74 };
-  unsigned int indentSize_{ 3 };
-  bool addChildValues_{ false };
+  unsigned int rightMargin_{74};
+  unsigned int indentSize_{3};
+  bool addChildValues_{false};
 };
 #if defined(_MSC_VER)
 #pragma warning(pop)
@@ -331,7 +331,7 @@ private:
   ChildValues childValues_;
   OStream* document_;
   String indentString_;
-  unsigned int rightMargin_{ 74 };
+  unsigned int rightMargin_{74};
   String indentation_;
   bool addChildValues_ : 1;
   bool indented_ : 1;

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -22,7 +22,7 @@ struct Options {
   Json::String path;
   Json::Features features;
   bool parseOnly;
-  using writeFuncType = Json::String(*)(Json::Value const&);
+  using writeFuncType = Json::String (*)(Json::Value const&);
   writeFuncType write;
 };
 
@@ -37,10 +37,11 @@ static Json::String normalizeFloatingPointStr(double value) {
         (s[index + 1] == '+' || s[index + 1] == '-') ? 1 : 0;
     Json::String::size_type exponentStartIndex = index + 1 + hasSign;
     Json::String normalized = s.substr(0, exponentStartIndex);
-    Json::String::size_type indexDigit = s.find_first_not_of('0', exponentStartIndex);
+    Json::String::size_type indexDigit =
+        s.find_first_not_of('0', exponentStartIndex);
     Json::String exponent = "0";
     if (indexDigit != Json::String::npos) // There is an exponent different
-                                    // from 0
+                                          // from 0
     {
       exponent = s.substr(indexDigit);
     }
@@ -180,7 +181,8 @@ static int rewriteValueTree(const Json::String& rewritePath,
   return 0;
 }
 
-static Json::String removeSuffix(const Json::String& path, const Json::String& extension) {
+static Json::String removeSuffix(const Json::String& path,
+                                 const Json::String& extension) {
   if (extension.length() >= path.length())
     return Json::String("");
   Json::String suffix = path.substr(path.length() - extension.length());

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -130,8 +130,8 @@ String valueToString(double value,
   // that always has a decimal point because JSON doesn't distinguish the
   // concepts of reals and integers.
   if (!isfinite(value)) {
-    static const char* const reps[2][3] = { { "NaN", "-Infinity", "Infinity" },
-                                            { "null", "-1e+9999", "1e+9999" } };
+    static const char* const reps[2][3] = {{"NaN", "-Infinity", "Infinity"},
+                                           {"null", "-1e+9999", "1e+9999"}};
     return reps[useSpecialFloats ? 0 : 1]
                [isnan(value) ? 0 : (value < 0) ? 1 : 2];
   }

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -166,7 +166,8 @@ void TestResult::printFailure(bool printTestName) const {
   }
 }
 
-Json::String TestResult::indentText(const Json::String& text, const Json::String& indent) {
+Json::String TestResult::indentText(const Json::String& text,
+                                    const Json::String& indent) {
   Json::String reindented;
   Json::String::size_type lastIndex = 0;
   while (lastIndex < text.size()) {
@@ -405,7 +406,9 @@ void Runner::printUsage(const char* appName) {
 // Assertion functions
 // //////////////////////////////////////////////////////////////////
 
-Json::String ToJsonString(const char* toConvert) { return Json::String(toConvert); }
+Json::String ToJsonString(const char* toConvert) {
+  return Json::String(toConvert);
+}
 
 Json::String ToJsonString(Json::String in) { return in; }
 

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -60,7 +60,7 @@ public:
   /// Not encapsulated to prevent step into when debugging failed assertions
   /// Incremented by one on assertion predicate entry, decreased by one
   /// by addPredicateContext().
-  PredicateContext::Id predicateId_{ 1 };
+  PredicateContext::Id predicateId_{1};
 
   /// \internal Implementation detail for predicate macros
   PredicateContext* predicateStackTail_;
@@ -102,15 +102,16 @@ private:
                       unsigned int line,
                       const char* expr,
                       unsigned int nestingLevel);
-  static Json::String indentText(const Json::String& text, const Json::String& indent);
+  static Json::String indentText(const Json::String& text,
+                                 const Json::String& indent);
 
   typedef std::deque<Failure> Failures;
   Failures failures_;
   Json::String name_;
   PredicateContext rootPredicateNode_;
-  PredicateContext::Id lastUsedPredicateId_{ 0 };
+  PredicateContext::Id lastUsedPredicateId_{0};
   /// Failure which is the target of the messages added using operator <<
-  Failure* messageTarget_{ nullptr };
+  Failure* messageTarget_{nullptr};
 };
 
 class TestCase {
@@ -124,7 +125,7 @@ public:
   virtual const char* testName() const = 0;
 
 protected:
-  TestResult* result_{ nullptr };
+  TestResult* result_{nullptr};
 
 private:
   virtual void runTestCase() = 0;
@@ -218,8 +219,7 @@ TestResult& checkStringEqual(TestResult& result,
 #define JSONTEST_ASSERT_PRED(expr)                                             \
   {                                                                            \
     JsonTest::PredicateContext _minitest_Context = {                           \
-      result_->predicateId_, __FILE__, __LINE__, #expr, NULL, NULL             \
-    };                                                                         \
+        result_->predicateId_, __FILE__, __LINE__, #expr, NULL, NULL};         \
     result_->predicateStackTail_->next_ = &_minitest_Context;                  \
     result_->predicateId_ += 1;                                                \
     result_->predicateStackTail_ = &_minitest_Context;                         \

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -82,19 +82,19 @@ struct ValueTest : JsonTest::TestCase {
     /// Initialize all checks to \c false by default.
     IsCheck();
 
-    bool isObject_{ false };
-    bool isArray_{ false };
-    bool isBool_{ false };
-    bool isString_{ false };
-    bool isNull_{ false };
+    bool isObject_{false};
+    bool isArray_{false};
+    bool isBool_{false};
+    bool isString_{false};
+    bool isNull_{false};
 
-    bool isInt_{ false };
-    bool isInt64_{ false };
-    bool isUInt_{ false };
-    bool isUInt64_{ false };
-    bool isIntegral_{ false };
-    bool isDouble_{ false };
-    bool isNumeric_{ false };
+    bool isInt_{false};
+    bool isInt64_{false};
+    bool isUInt_{false};
+    bool isUInt64_{false};
+    bool isIntegral_{false};
+    bool isDouble_{false};
+    bool isNumeric_{false};
   };
 
   void checkConstMemberCount(const Json::Value& value,
@@ -120,10 +120,11 @@ Json::String ValueTest::normalizeFloatingPointStr(const Json::String& s) {
         (s[index + 1] == '+' || s[index + 1] == '-') ? 1 : 0;
     Json::String::size_type exponentStartIndex = index + 1 + hasSign;
     Json::String normalized = s.substr(0, exponentStartIndex);
-    Json::String::size_type indexDigit = s.find_first_not_of('0', exponentStartIndex);
+    Json::String::size_type indexDigit =
+        s.find_first_not_of('0', exponentStartIndex);
     Json::String exponent = "0";
     if (indexDigit != Json::String::npos) // There is an exponent different
-                                    // from 0
+                                          // from 0
     {
       exponent = s.substr(indexDigit);
     }
@@ -2353,22 +2354,22 @@ JSONTEST_FIXTURE(CharReaderAllowSpecialFloatsTest, issue209) {
     Json::String in;
   };
   const TestData test_data[] = {
-    { __LINE__, true, "{\"a\":9}" },          //
-    { __LINE__, false, "{\"a\":0Infinity}" }, //
-    { __LINE__, false, "{\"a\":1Infinity}" }, //
-    { __LINE__, false, "{\"a\":9Infinity}" }, //
-    { __LINE__, false, "{\"a\":0nfinity}" },  //
-    { __LINE__, false, "{\"a\":1nfinity}" },  //
-    { __LINE__, false, "{\"a\":9nfinity}" },  //
-    { __LINE__, false, "{\"a\":nfinity}" },   //
-    { __LINE__, false, "{\"a\":.nfinity}" },  //
-    { __LINE__, false, "{\"a\":9nfinity}" },  //
-    { __LINE__, false, "{\"a\":-nfinity}" },  //
-    { __LINE__, true, "{\"a\":Infinity}" },   //
-    { __LINE__, false, "{\"a\":.Infinity}" }, //
-    { __LINE__, false, "{\"a\":_Infinity}" }, //
-    { __LINE__, false, "{\"a\":_nfinity}" },  //
-    { __LINE__, true, "{\"a\":-Infinity}" }   //
+      {__LINE__, true, "{\"a\":9}"},          //
+      {__LINE__, false, "{\"a\":0Infinity}"}, //
+      {__LINE__, false, "{\"a\":1Infinity}"}, //
+      {__LINE__, false, "{\"a\":9Infinity}"}, //
+      {__LINE__, false, "{\"a\":0nfinity}"},  //
+      {__LINE__, false, "{\"a\":1nfinity}"},  //
+      {__LINE__, false, "{\"a\":9nfinity}"},  //
+      {__LINE__, false, "{\"a\":nfinity}"},   //
+      {__LINE__, false, "{\"a\":.nfinity}"},  //
+      {__LINE__, false, "{\"a\":9nfinity}"},  //
+      {__LINE__, false, "{\"a\":-nfinity}"},  //
+      {__LINE__, true, "{\"a\":Infinity}"},   //
+      {__LINE__, false, "{\"a\":.Infinity}"}, //
+      {__LINE__, false, "{\"a\":_Infinity}"}, //
+      {__LINE__, false, "{\"a\":_nfinity}"},  //
+      {__LINE__, true, "{\"a\":-Infinity}"}   //
   };
   for (const auto& td : test_data) {
     bool ok = reader->parse(&*td.in.begin(), &*td.in.begin() + td.in.size(),


### PR DESCRIPTION
Made changes to .clang-format necessary to support C++11, then applied them.

If we don't set clang-format to `Standard: Cpp11`, it will generate incorrect code sometimes.
In particular, it will misinterpret and break C++11's new raw string literals.
