### PR TITLE
Add explicit move assignment operator

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -349,7 +349,10 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Deep copy, then swap(other).
   /// \note Over-write existing comments. To preserve comments, use
   /// #swapPayload().
-  Value& operator=(Value other);
+  Value& operator=(const Value& other);
+#if JSON_HAS_RVALUE_REFERENCES
+  Value& operator=(Value&& other);
+#endif
 
   /// Swap everything.
   void swap(Value& other);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -497,10 +497,18 @@ Value::~Value() {
   value_.uint_ = 0;
 }
 
-Value& Value::operator=(Value other) {
+Value& Value::operator=(const Value& other) {
+  Value tmp(other);
+  swap(tmp);
+  return *this;
+}
+
+#if JSON_HAS_RVALUE_REFERENCES
+Value& Value::operator=(Value&& other) {
   swap(other);
   return *this;
 }
+#endif
 
 void Value::swapPayload(Value& other) {
   ValueType temp = type_;


### PR DESCRIPTION
this fixes linking error mentioned in #871 when building chrome/webrtc