### PR TITLE
refactor comments_ into a copyable class

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -659,9 +659,9 @@ private:
   public:
     Comments() = default;
     Comments(const Comments& that);
-    Comments(Comments&&) = default;
+    Comments(Comments&& that);
     Comments& operator=(const Comments& that);
-    Comments& operator=(Comments&&) = default;
+    Comments& operator=(Comments&& that);
     bool has(CommentPlacement slot) const;
     String get(CommentPlacement slot) const;
     void set(CommentPlacement slot, String s);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1440,8 +1440,16 @@ bool Value::isObject() const { return type() == objectValue; }
 Value::Comments::Comments(const Comments& that)
     : ptr_{cloneUnique(that.ptr_)} {}
 
+Value::Comments::Comments(Comments&& that)
+    : ptr_{std::move(that.ptr_)} {}
+
 Value::Comments& Value::Comments::operator=(const Comments& that) {
   ptr_ = cloneUnique(that.ptr_);
+  return *this;
+}
+
+Value::Comments& Value::Comments::operator=(Comments&& that) {
+  ptr_ = std::move(that.ptr_);
   return *this;
 }
 


### PR DESCRIPTION
Preserve the lazy-init semantics, so comments_ only adds 1 pointer to a Value if it's not used.
Switch to `std::unique_ptr` and `std::array` now that we're in C++11.
Use `Json::String` instead of `const char*` with manually-specified special `releaseStringValue` etc stuff.