### PR TITLE
Fix macro redefinition warning with clang-cl

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -79,10 +79,6 @@ msvc_pre1900_c99_snprintf(char* outBuf, size_t size, const char* format, ...);
 // Storages, and 64 bits integer support is disabled.
 // #define JSON_NO_INT64 1
 
-#if defined(_MSC_VER) // MSVC
-#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
-#endif // defined(_MSC_VER)
-
 // JSONCPP_OVERRIDE is maintained for backwards compatibility of external tools.
 // C++11 should be used directly in JSONCPP.
 #define JSONCPP_OVERRIDE override
@@ -135,7 +131,9 @@ msvc_pre1900_c99_snprintf(char* outBuf, size_t size, const char* format, ...);
 #elif (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
 #define JSONCPP_DEPRECATED(message) __attribute__((__deprecated__))
 #endif // GNUC version
-#endif // __clang__ || __GNUC__
+#elif defined(_MSC_VER) // MSVC (after clang because clang on Windows emulates MSVC)
+#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+#endif // __clang__ || __GNUC__ || _MSC_VER
 
 #if !defined(JSONCPP_DEPRECATED)
 #define JSONCPP_DEPRECATED(message)


### PR DESCRIPTION
clang-cl defines `_MSC_VER` by default, so `JSONCPP_DEPRECATED` was first
defined for MSVC and then redefined for clang. Integrate the MSVC
definition into the block with clang and GCC's `JSONCPP_DEPRECATED`
definitions to fix this.