### PR TITLE
Explicitly set JSON_API to 'default' visibility on clang & gcc

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -48,6 +48,8 @@
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #define JSON_API __declspec(dllexport)
 #define JSONCPP_DISABLE_DLL_INTERFACE_WARNING
+#elif defined(__GNUC__) || defined(__clang__)
+#define JSON_API __attribute__((visibility("default")))
 #endif // if defined(_MSC_VER)
 #elif defined(JSON_DLL)
 #if defined(_MSC_VER) || defined(__MINGW32__)


### PR DESCRIPTION
This allows building into a shared lib with `-fvisibility=hidden` specified.