### PR TITLE
Implement Value::demand()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,12 +63,12 @@ if(NOT DEFINED CMAKE_BUILD_TYPE)
 endif()
 
 project(JSONCPP
-        VERSION 1.8.4 # <major>[.<minor>[.<patch>[.<tweak>]]]
+        VERSION 1.9.0 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)
 
 set( JSONCPP_VERSION ${JSONCPP_VERSION_MAJOR}.${JSONCPP_VERSION_MINOR}.${JSONCPP_VERSION_PATCH} )
 message(STATUS "JsonCpp Version: ${JSONCPP_VERSION_MAJOR}.${JSONCPP_VERSION_MINOR}.${JSONCPP_VERSION_PATCH}")
-set( JSONCPP_SOVERSION 19 )
+set( JSONCPP_SOVERSION 21 )
 
 option(JSONCPP_WITH_TESTS "Compile and (for jsoncpp_check) run JsonCpp test executables" ON)
 option(JSONCPP_WITH_POST_BUILD_UNITTEST "Automatically run unit-tests as a post build step" ON)

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -524,7 +524,7 @@ Json::Value obj_value(Json::objectValue); // {}
   /// Most general and efficient version of object-mutators.
   /// \note As stated elsewhere, behavior is undefined if (end-begin) >= 2^30
   /// \return non-zero, but JSON_ASSERT if this is neither object nor nullValue.
-  Value const* demand(char const* begin, char const* end);
+  Value* demand(char const* begin, char const* end);
   /// \brief Remove and return the named member.
   ///
   /// Do nothing if it did not exist.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'jsoncpp',
   'cpp',
-  version : '1.8.4',
+  version : '1.9.0',
   default_options : [
     'buildtype=release',
     'cpp_std=c++11',
@@ -62,7 +62,7 @@ jsoncpp_lib = library(
     'src/lib_json/json_reader.cpp',
     'src/lib_json/json_value.cpp',
     'src/lib_json/json_writer.cpp'],
-  soversion : 20,
+  soversion : 21,
   install : true,
   include_directories : jsoncpp_include_directories,
   cpp_args: dll_export_flag)

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1126,6 +1126,12 @@ Value const* Value::find(char const* begin, char const* end) const {
     return nullptr;
   return &(*it).second;
 }
+Value* Value::demand(char const* begin, char const* end) {
+  JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
+                      "in Json::Value::demand(begin, end): requires "
+                      "objectValue or nullValue");
+  return &resolveReference(begin, end);
+}
 const Value& Value::operator[](const char* key) const {
   Value const* found = find(key, key + strlen(key));
   if (!found)

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1115,7 +1115,7 @@ bool Value::isValidIndex(ArrayIndex index) const { return index < size(); }
 
 Value const* Value::find(char const* begin, char const* end) const {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
-                      "in Json::Value::find(key, end, found): requires "
+                      "in Json::Value::find(begin, end): requires "
                       "objectValue or nullValue");
   if (type() == nullValue)
     return nullptr;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -214,6 +214,7 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   const Json::Value* foundUnknownId = object1_.find(unknownIdKey, unknownIdKey + strlen(unknownIdKey));
   JSONTEST_ASSERT_EQUAL(nullptr, foundUnknownId);
 
+  // Access through demand()
   const char yetAnotherIdKey[] = "yet another id";
   const Json::Value* foundYetAnotherId = object1_.find(yetAnotherIdKey, yetAnotherIdKey + strlen(yetAnotherIdKey));
   JSONTEST_ASSERT_EQUAL(nullptr, foundYetAnotherId);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -204,6 +204,16 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), constObject["id"]);
   JSONTEST_ASSERT_EQUAL(Json::Value(), constObject["unknown id"]);
 
+  // Access through find()
+  const char idKey[] = "id";
+  const Json::Value* foundId = object1_.find(idKey, idKey + strlen(idKey));
+  JSONTEST_ASSERT(foundId != nullptr);
+  JSONTEST_ASSERT_EQUAL(Json::Value(1234), *foundId);
+
+  const char unknownIdKey[] = "unknown id";
+  const Json::Value* foundUnknownId = object1_.find(unknownIdKey, unknownIdKey + strlen(unknownIdKey));
+  JSONTEST_ASSERT_EQUAL(nullptr, foundUnknownId);
+
   // Access through non-const reference
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), object1_["id"]);
   JSONTEST_ASSERT_EQUAL(Json::Value(), object1_["unknown id"]);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -214,6 +214,15 @@ JSONTEST_FIXTURE(ValueTest, objects) {
   const Json::Value* foundUnknownId = object1_.find(unknownIdKey, unknownIdKey + strlen(unknownIdKey));
   JSONTEST_ASSERT_EQUAL(nullptr, foundUnknownId);
 
+  const char yetAnotherIdKey[] = "yet another id";
+  const Json::Value* foundYetAnotherId = object1_.find(yetAnotherIdKey, yetAnotherIdKey + strlen(yetAnotherIdKey));
+  JSONTEST_ASSERT_EQUAL(nullptr, foundYetAnotherId);
+  Json::Value* demandedYetAnotherId = object1_.demand(yetAnotherIdKey, yetAnotherIdKey + strlen(yetAnotherIdKey));
+  JSONTEST_ASSERT(demandedYetAnotherId != nullptr);
+  *demandedYetAnotherId = "baz";
+
+  JSONTEST_ASSERT_EQUAL(Json::Value("baz"), object1_["yet another id"]);
+
   // Access through non-const reference
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), object1_["id"]);
   JSONTEST_ASSERT_EQUAL(Json::Value(), object1_["unknown id"]);


### PR DESCRIPTION
There's a declaration of a `Value::demand()` method, but an implementation is nowhere to be found.

It would have some utility, though: it's the only method to create a named key that takes `[begin, end)` arguments. This is useful if you want to use a key stored in a `string_view`.

Note that I also changed the return value of `demand()`:
* I think a non-const pointer is more useful as you can immediately modify the `Value`.
* Leaving it as a pointer keeps some symmetry with `find()`.
* This change doesn't affect compatibility much, as `demand()` wasn't implemented, thus there can't be any user of it.