### PR TITLE
Fix #888

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -610,7 +610,7 @@ Json::Value obj_value(Json::objectValue); // {}
   ptrdiff_t getOffsetLimit() const;
 
 private:
-  void setType(ValueType v) { bits_.value_type_ = v; }
+  void setType(ValueType v) { bits_.value_type_ = static_cast<unsigned char> (v); }
   bool isAllocated() const { return bits_.allocated_; }
   void setIsAllocated(bool v) { bits_.allocated_ = v; }
 


### PR DESCRIPTION
gcc recognizes the 8-bit-wide `value_type_` bit field as `unsigned char`, which is nice, I guess.
OTOH, it apparently stores ValueType as `unsigned int`, triggering a warning on the assignment.
As the (legal) ValueType values comfortably fit into an `unsigned char` we can simply cast to that, getting rid of the warning.