### PR TITLE
repair a typo error

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -840,7 +840,7 @@ bool Reader::pushError(const Value& value, const String& message) {
   Token token;
   token.type_ = tokenError;
   token.start_ = begin_ + value.getOffsetStart();
-  token.end_ = end_ + value.getOffsetLimit();
+  token.end_ = begin_ + value.getOffsetLimit();
   ErrorInfo info;
   info.token_ = token;
   info.message_ = message;
@@ -1845,7 +1845,7 @@ bool OurReader::pushError(const Value& value, const String& message) {
   Token token;
   token.type_ = tokenError;
   token.start_ = begin_ + value.getOffsetStart();
-  token.end_ = end_ + value.getOffsetLimit();
+  token.end_ = begin_ + value.getOffsetLimit();
   ErrorInfo info;
   info.token_ = token;
   info.message_ = message;


### PR DESCRIPTION
As the issue #812 mentioned before, I'm sure there are some typo error in the `Reader::pushError()` funtion,
there should be a consisency with other functions like :
```c++
620 bool Reader::decodeString(Token& token) { 
621   String decoded_string; 
622   if (!decodeString(token, decoded_string)) 
623     return false; 
624   Value decoded(decoded_string); 
625   currentValue().swapPayload(decoded); 
626   currentValue().setOffsetStart(token.start_ - begin_); 
627   currentValue().setOffsetLimit(token.end_ - begin_); 
628   return true; 
629 } 
``` 
