### PR TITLE
added cmake config version file for proper cmake delivery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,9 +168,15 @@ if(JSONCPP_WITH_PKGCONFIG_SUPPORT)
 endif()
 
 if(JSONCPP_WITH_CMAKE_PACKAGE)
+        include (CMakePackageConfigHelpers)
         install(EXPORT jsoncpp
                 DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp
                 FILE        jsoncppConfig.cmake)
+        write_basic_package_version_file ("${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfigVersion.cmake"
+                VERSION ${PROJECT_VERSION}
+                COMPATIBILITY SameMajorVersion)
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfigVersion.cmake
+                DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp)
 endif()
 
 if(JSONCPP_WITH_TESTS)


### PR DESCRIPTION
For proper cmake configuration setup, one should also deliver some config-version file. This allows consumers to check for some minimal/required version when importing.

The version compatibility was arbitrarily set to SameMajorVersion, SameMinorVersion or ExactVersion should probably be some smarter choice.

Please let me know if any change is required.