### PR TITLE
Fix JSON_USE_EXCEPTION=0 use case

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -50,6 +50,7 @@
  */
 namespace Json {
 
+#if JSON_USE_EXCEPTION
 /** Base class for all exceptions we throw.
  *
  * We use nothing but these internally. Of course, STL can throw others.
@@ -85,6 +86,7 @@ class JSON_API LogicError : public Exception {
 public:
   LogicError(String const& msg);
 };
+#endif
 
 /// used internally
 JSONCPP_NORETURN void throwRuntimeError(String const& msg);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -226,6 +226,7 @@ static inline void releaseStringValue(char* value, unsigned) { free(value); }
 
 namespace Json {
 
+#if JSON_USE_EXCEPTION
 Exception::Exception(String msg) : msg_(std::move(msg)) {}
 Exception::~Exception() JSONCPP_NOEXCEPT {}
 char const* Exception::what() const JSONCPP_NOEXCEPT { return msg_.c_str(); }
@@ -237,6 +238,14 @@ JSONCPP_NORETURN void throwRuntimeError(String const& msg) {
 JSONCPP_NORETURN void throwLogicError(String const& msg) {
   throw LogicError(msg);
 }
+# else // !JSON_USE_EXCEPTION
+JSONCPP_NORETURN void throwRuntimeError(String const& msg) {
+  abort();
+}
+JSONCPP_NORETURN void throwLogicError(String const& msg) {
+  abort();
+}
+#endif
 
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This patch fixes the JSON_USE_EXCEPTION flag. Currently, due to the
throwRuntimeError and throwLogicError methods implemented in json_value,
even if JSON_USE_EXCEPTION is set to 0 jsoncpp will still throw. This
breaks integration into projects with -fno-exceptions set, such as
Chromium.