### PR TITLE
Use fpclassify to convert real number to bool

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -849,7 +849,7 @@ bool Value::asBool() const {
     return value_.uint_ ? true : false;
   case realValue:
     // According to JavaScript language zero or NaN is regarded as false
-    return std::fpclassify(value_.real_) != FP_ZERO && std::fpclassify(value_.real_) != FP_NAN
+      return std::fpclassify(value_.real_) != FP_ZERO && std::fpclassify(value_.real_) != FP_NAN;
   default:
     break;
   }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -847,9 +847,11 @@ bool Value::asBool() const {
     return value_.int_ ? true : false;
   case uintValue:
     return value_.uint_ ? true : false;
-  case realValue:
-    // According to JavaScript language zero or NaN is regarded as false
-      return std::fpclassify(value_.real_) != FP_ZERO && std::fpclassify(value_.real_) != FP_NAN;
+  case realValue: {
+      // According to JavaScript language zero or NaN is regarded as false
+      const auto value_classification = std::fpclassify(value_.real_);
+      return value_classification != FP_ZERO && value_classification != FP_NAN;
+  }
   default:
     break;
   }

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -848,8 +848,8 @@ bool Value::asBool() const {
   case uintValue:
     return value_.uint_ ? true : false;
   case realValue:
-    // This is kind of strange. Not recommended.
-    return (value_.real_ != 0.0) ? true : false;
+    // According to JavaScript language zero or NaN is regarded as false
+    return std::fpclassify(value_.real_) != FP_ZERO && std::fpclassify(value_.real_) != FP_NAN
   default:
     break;
   }


### PR DESCRIPTION
According to JavaScript language, `0.0` and `NaN` are treated as `false`, others are treated as `true`. See 
 [JavaScript Booleans](https://www.w3schools.com/js/js_booleans.asp).

C++11 has already provided a function `fpclassify` to test a real number is zero or NaN. See [std::fpclassify](https://en.cppreference.com/w/cpp/numeric/math/fpclassify), so the unsafe comparison from `0.0f` should change to using this function.