### PR TITLE
Update meson build requirement

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project(
     'cpp_std=c++11',
     'warning_level=1'],
   license : 'Public Domain',
-  meson_version : '>= 0.41.1')
+  meson_version : '>= 0.50.0')
 
 jsoncpp_ver_arr = meson.project_version().split('.')
 jsoncpp_major_version = jsoncpp_ver_arr[0]


### PR DESCRIPTION
Currently, we have a build type warning due to listing a requirement for
meson build version that doesn't implement features we use in our build
file. The minimum meson build version required is actually 0.50.0, so
this PR updates our meson.build file to depend on 0.50.0.