### PR TITLE
Add new "asEnum" template method

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -296,14 +296,14 @@ public:
     To create an empty array, pass arrayValue.
     To create an empty object, pass objectValue.
     Another Value can then be set to this one by assignment.
-This is useful since clear() and resize() will not alter types.
+    This is useful since clear() and resize() will not alter types.
 
     Examples:
-\code
-Json::Value null_value; // null
-Json::Value arr_value(Json::arrayValue); // []
-Json::Value obj_value(Json::objectValue); // {}
-\endcode
+        \code
+        Json::Value null_value; // null
+        Json::Value arr_value(Json::arrayValue); // []
+        Json::Value obj_value(Json::objectValue); // {}
+        \endcode
   */
   Value(ValueType type = nullValue);
   Value(Int value);
@@ -391,6 +391,19 @@ Json::Value obj_value(Json::objectValue); // {}
   float asFloat() const;
   double asDouble() const;
   bool asBool() const;
+
+  template <typename T,
+            typename std::enable_if<std::is_enum<T>::value>::type* = nullptr>
+  T asEnum() {
+    switch (type()) {
+    case intValue:
+      return static_cast<T>(asLargestInt());
+    case uintValue:
+      return static_cast<T>(asLargestUInt());
+    default:
+      throwRuntimeError("Invalid cast to enum value");
+    }
+  }
 
   bool isNull() const;
   bool isBool() const;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1844,6 +1844,37 @@ JSONTEST_FIXTURE(ValueTest, precision) {
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 }
 
+JSONTEST_FIXTURE(ValueTest, convertToEnum) {
+  enum class Foo : Json::Int64 {
+    A = -10,
+    B = 20,
+  };
+
+  enum class Bar : Json::UInt64 {
+    C = 30,
+    D = 40,
+  };
+
+  enum Baz {
+    E = -500,
+    F = 600,
+  };
+
+  Json::Value a = -10;
+  Json::Value b = 20;
+  Json::Value c = 30;
+  Json::Value d = 40;
+  Json::Value e = -500;
+  Json::Value f = 600;
+
+  JSONTEST_ASSERT(a.asEnum<Foo>() == Foo::A);
+  JSONTEST_ASSERT(b.asEnum<Foo>() == Foo::B);
+  JSONTEST_ASSERT(c.asEnum<Bar>() == Bar::C);
+  JSONTEST_ASSERT(d.asEnum<Bar>() == Bar::D);
+  JSONTEST_ASSERT(e.asEnum<Baz>() == Baz::E);
+  JSONTEST_ASSERT(f.asEnum<Baz>() == Baz::F);
+}
+
 struct WriterTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE(WriterTest, dropNullPlaceholders) {
@@ -2594,11 +2625,11 @@ int main(int argc, const char* argv[]) {
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, StaticString);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, WideString);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, CommentBefore);
-  // JSONTEST_REGISTER_FIXTURE(runner, ValueTest, nulls);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, zeroes);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, zeroesInKeys);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, specialFloats);
   JSONTEST_REGISTER_FIXTURE(runner, ValueTest, precision);
+  JSONTEST_REGISTER_FIXTURE(runner, ValueTest, convertToEnum);
 
   JSONTEST_REGISTER_FIXTURE(runner, WriterTest, dropNullPlaceholders);
   JSONTEST_REGISTER_FIXTURE(runner, StreamWriterTest, dropNullPlaceholders);


### PR DESCRIPTION
This patch is a solution to #487, as request to add an "asEnum" template
helper for integral type Json::Value instances. Includes tests.

Issue: #487