### PR TITLE
pop the root node after readValue()

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1049,6 +1049,7 @@ bool OurReader::parse(const char* beginDoc,
   nodes_.push(&root);
 
   bool successful = readValue();
+  nodes_.pop();
   Token token;
   skipCommentTokens(token);
   if (features_.failIfExtra_) {


### PR DESCRIPTION
We should pop the root node after readValue, although there is no problem when we don't care it, because it's the node at the bottom of the stack,  but in order to maintain consistency, it's better to pop it out.