### PR TITLE
Change to throw macro, fix JSON_USE_EXCEPTION=0

### DIFF
--- a/include/json/assertions.h
+++ b/include/json/assertions.h
@@ -23,7 +23,7 @@
 #define JSON_ASSERT(condition)                                                 \
   {                                                                            \
     if (!(condition)) {                                                        \
-      Json::throwLogicError("assert json failed");                             \
+      THROW_LOGIC_ERROR("assert json failed");                                 \
     }                                                                          \
   }
 
@@ -31,7 +31,7 @@
   {                                                                            \
     OStringStream oss;                                                         \
     oss << message;                                                            \
-    Json::throwLogicError(oss.str());                                          \
+    THROW_LOGIC_ERROR(oss.str());                                              \
     abort();                                                                   \
   }
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -24,19 +24,6 @@
 #include <cpptl/forwards.h>
 #endif
 
-// Conditional NORETURN attribute on the throw functions would:
-// a) suppress false positives from static code analysis
-// b) possibly improve optimization opportunities.
-#if !defined(JSONCPP_NORETURN)
-#if defined(_MSC_VER)
-#define JSONCPP_NORETURN __declspec(noreturn)
-#elif defined(__GNUC__)
-#define JSONCPP_NORETURN __attribute__((__noreturn__))
-#else
-#define JSONCPP_NORETURN
-#endif
-#endif
-
 // Disable warning C4251: <data member>: <type> needs to have dll-interface to
 // be used by...
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
@@ -89,9 +76,17 @@ public:
 #endif
 
 /// used internally
-JSONCPP_NORETURN void throwRuntimeError(String const& msg);
-/// used internally
-JSONCPP_NORETURN void throwLogicError(String const& msg);
+#if JSON_USE_EXCEPTION
+#define THROW_RUNTIME_ERROR(msg_ref)                                           \
+  { throw RuntimeError(msg_ref); }
+#define THROW_LOGIC_ERROR(msg_ref)                                             \
+  { throw LogicError(msg_ref); }
+#else
+#define THROW_RUNTIME_ERROR(msg_ref)                                           \
+  { return {}; }
+#define THROW_LOGIC_ERROR(msg_ref)                                             \
+  { return {}; }
+#endif
 
 /** \brief Type of the value held by a Value object.
  */

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -161,8 +161,9 @@ bool Reader::readValue() {
   // These methods execute nodes_.push() just before and nodes_.pop)() just
   // after calling readValue(). parse() executes one nodes_.push(), so > instead
   // of >=.
-  if (nodes_.size() > stackLimit_g)
-    throwRuntimeError("Exceeded stackLimit in readValue().");
+  if (nodes_.size() > stackLimit_g) {
+    THROW_RUNTIME_ERROR("Exceeded stackLimit in readValue().");
+  }
 
   Token token;
   skipCommentTokens(token);
@@ -1077,8 +1078,10 @@ bool OurReader::parse(const char* beginDoc,
 
 bool OurReader::readValue() {
   //  To preserve the old behaviour we cast size_t to int.
-  if (nodes_.size() > features_.stackLimit_)
-    throwRuntimeError("Exceeded stackLimit in readValue().");
+  if (nodes_.size() > features_.stackLimit_) {
+    THROW_RUNTIME_ERROR("Exceeded stackLimit in readValue().");
+  }
+
   Token token;
   skipCommentTokens(token);
   bool successful = true;
@@ -1454,8 +1457,11 @@ bool OurReader::readObject(Token& token) {
     } else {
       break;
     }
-    if (name.length() >= (1U << 30))
-      throwRuntimeError("keylength >= 2^30");
+
+    if (name.length() >= (1U << 30)) {
+      THROW_RUNTIME_ERROR("keylength >= 2^30");
+    }
+
     if (features_.rejectDupKeys_ && currentValue().isMember(name)) {
       String msg = "Duplicate key: '" + name + "'";
       return addErrorAndRecover(msg, tokenName, tokenObjectEnd);
@@ -2006,10 +2012,11 @@ bool parseFromStream(CharReader::Factory const& fact,
 IStream& operator>>(IStream& sin, Value& root) {
   CharReaderBuilder b;
   String errs;
-  bool ok = parseFromStream(b, sin, &root, &errs);
+  const bool ok = parseFromStream(b, sin, &root, &errs);
   if (!ok) {
-    throwRuntimeError(errs);
+    THROW_RUNTIME_ERROR(errs);
   }
+
   return sin;
 }
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -145,9 +145,10 @@ static inline char* duplicateStringValue(const char* value, size_t length) {
 
   char* newString = static_cast<char*>(malloc(length + 1));
   if (newString == nullptr) {
-    throwRuntimeError("in Json::Value::duplicateStringValue(): "
-                      "Failed to allocate string value buffer");
+    THROW_RUNTIME_ERROR("in Json::Value::duplicateStringValue(): "
+                        "Failed to allocate string value buffer");
   }
+
   memcpy(newString, value, length);
   newString[length] = 0;
   return newString;
@@ -166,9 +167,10 @@ static inline char* duplicateAndPrefixStringValue(const char* value,
   unsigned actualLength = length + static_cast<unsigned>(sizeof(unsigned)) + 1U;
   char* newString = static_cast<char*>(malloc(actualLength));
   if (newString == nullptr) {
-    throwRuntimeError("in Json::Value::duplicateAndPrefixStringValue(): "
-                      "Failed to allocate string value buffer");
+    THROW_RUNTIME_ERROR("in Json::Value::duplicateAndPrefixStringValue(): "
+                        "Failed to allocate string value buffer");
   }
+
   *reinterpret_cast<unsigned*>(newString) = length;
   memcpy(newString + sizeof(unsigned), value, length);
   newString[actualLength - 1U] =
@@ -232,15 +234,6 @@ Exception::~Exception() JSONCPP_NOEXCEPT {}
 char const* Exception::what() const JSONCPP_NOEXCEPT { return msg_.c_str(); }
 RuntimeError::RuntimeError(String const& msg) : Exception(msg) {}
 LogicError::LogicError(String const& msg) : Exception(msg) {}
-JSONCPP_NORETURN void throwRuntimeError(String const& msg) {
-  throw RuntimeError(msg);
-}
-JSONCPP_NORETURN void throwLogicError(String const& msg) {
-  throw LogicError(msg);
-}
-#else // !JSON_USE_EXCEPTION
-JSONCPP_NORETURN void throwRuntimeError(String const& msg) { abort(); }
-JSONCPP_NORETURN void throwLogicError(String const& msg) { abort(); }
 #endif
 
 // //////////////////////////////////////////////////////////////////

--- a/src/lib_json/json_valueiterator.inl
+++ b/src/lib_json/json_valueiterator.inl
@@ -146,7 +146,7 @@ ValueIterator::ValueIterator(const Value::ObjectValues::iterator& current)
 
 ValueIterator::ValueIterator(const ValueConstIterator& other)
     : ValueIteratorBase(other) {
-  throwRuntimeError("ConstIterator to Iterator should never be allowed.");
+  THROW_RUNTIME_ERROR("ConstIterator to Iterator should never be allowed.");
 }
 
 ValueIterator::ValueIterator(const ValueIterator& other) = default;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -1166,16 +1166,18 @@ StreamWriter* StreamWriterBuilder::newStreamWriter() const {
   } else if (cs_str == "None") {
     cs = CommentStyle::None;
   } else {
-    throwRuntimeError("commentStyle must be 'All' or 'None'");
+    THROW_RUNTIME_ERROR("commentStyle must be 'All' or 'None'");
   }
+
   PrecisionType precisionType(significantDigits);
   if (pt_str == "significant") {
     precisionType = PrecisionType::significantDigits;
   } else if (pt_str == "decimal") {
     precisionType = PrecisionType::decimalPlaces;
   } else {
-    throwRuntimeError("precisionType must be 'significant' or 'decimal'");
+    THROW_RUNTIME_ERROR("precisionType must be 'significant' or 'decimal'");
   }
+
   String colonSymbol = " : ";
   if (eyc) {
     colonSymbol = ": ";


### PR DESCRIPTION
Currently, if exceptions are disabled we throw instead, even though that
probably isn't desirable. This PR switches to using an early return,
which will typically cause methods to return false. Callers are
responsible for any cleanup.