### PR TITLE
#979 Fix parseFromStream definition

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -378,7 +378,7 @@ public:
 bool JSON_API parseFromStream(CharReader::Factory const&,
                               IStream&,
                               Value* root,
-                              std::string* errs);
+                              String* errs);
 
 /** \brief Read from 'sin' into 'root'.
 


### PR DESCRIPTION
This patch fixes issue #979, where the parseFromStream definition in
the header is different from the implementation.