### PR TITLE
Check the comments array boundry.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1471,7 +1471,6 @@ void Value::Comments::set(CommentPlacement slot, String comment) {
   if (slot < CommentPlacement::numberOfCommentPlacement) {
     (*ptr_)[slot] = std::move(comment);
   }
-
 }
 
 void Value::setComment(String comment, CommentPlacement placement) {

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1467,7 +1467,11 @@ void Value::Comments::set(CommentPlacement slot, String comment) {
   if (!ptr_) {
     ptr_ = std::unique_ptr<Array>(new Array());
   }
-  (*ptr_)[slot] = std::move(comment);
+  // check comments array boundry.
+  if (slot < CommentPlacement::numberOfCommentPlacement) {
+    (*ptr_)[slot] = std::move(comment);
+  }
+
 }
 
 void Value::setComment(String comment, CommentPlacement placement) {


### PR DESCRIPTION
Currently, a Segmentation fault (core dumped) caused by the wrong use of setComment method:
```c++
root.setComment(commentPtr, Json::numberOfCommentPlacement);
```
we should check the comment array boundry before we assign comment value to Array to avoid this seg fault.