### PR TITLE
Add cxx17 string_view operator[] for Json::Value

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -12,8 +12,12 @@
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <string_view>
 #include <type_traits>
+
+#if __cplusplus >= 201703L
+#include <string_view>
+#define JSON_USE_STRING_VIEW 1
+#endif
 
 /// If defined, indicates that json library is embedded in CppTL library.
 //# define JSON_IN_CPPTL 1
@@ -142,7 +146,9 @@ using Allocator = typename std::conditional<JSONCPP_USING_SECURE_MEMORY,
                                             SecureAllocator<T>,
                                             std::allocator<T>>::type;
 using String = std::basic_string<char, std::char_traits<char>, Allocator<char>>;
+#ifdef JSON_USE_STRING_VIEW
 using StringView = std::basic_string_view<char, std::char_traits<char>>;
+#endif
 using IStringStream = std::basic_istringstream<String::value_type,
                                                String::traits_type,
                                                String::allocator_type>;

--- a/include/json/config.h
+++ b/include/json/config.h
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <type_traits>
 
 /// If defined, indicates that json library is embedded in CppTL library.
@@ -141,6 +142,7 @@ using Allocator = typename std::conditional<JSONCPP_USING_SECURE_MEMORY,
                                             SecureAllocator<T>,
                                             std::allocator<T>>::type;
 using String = std::basic_string<char, std::char_traits<char>, Allocator<char>>;
+using StringView = std::basic_string_view<char, std::char_traits<char>>;
 using IStringStream = std::basic_istringstream<String::value_type,
                                                String::traits_type,
                                                String::allocator_type>;

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -464,6 +464,8 @@ public:
   /// that name.
   /// \param key may contain embedded nulls.
   const Value& operator[](const String& key) const;
+  Value& operator[](const StringView key);
+  const Value& operator[](const StringView key) const;
   /** \brief Access an object value by name, create a null member if it does not
    * exist.
    *

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -325,7 +325,9 @@ public:
    */
   Value(const StaticString& value);
   Value(const String& value);
+#ifdef JSON_USE_STRING_VIEW
   Value(const StringView value);
+#endif
 #ifdef JSON_USE_CPPTL
   Value(const CppTL::ConstString& value);
 #endif
@@ -465,8 +467,12 @@ public:
   /// that name.
   /// \param key may contain embedded nulls.
   const Value& operator[](const String& key) const;
+
+#ifdef JSON_USE_STRING_VIEW
   Value& operator[](const StringView key);
   const Value& operator[](const StringView key) const;
+#endif
+
   /** \brief Access an object value by name, create a null member if it does not
    * exist.
    *

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -325,6 +325,7 @@ public:
    */
   Value(const StaticString& value);
   Value(const String& value);
+  Value(const StringView value);
 #ifdef JSON_USE_CPPTL
   Value(const CppTL::ConstString& value);
 #endif

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -438,11 +438,13 @@ Value::Value(const String& value) {
       value.data(), static_cast<unsigned>(value.length()));
 }
 
+#ifdef JSON_USE_STRING_VIEW
 Value::Value(const StringView value) {
     initBasic(stringValue, true);
     value_.string_ = duplicateAndPrefixStringValue(
             value.data(), static_cast<unsigned>(value.length()));
 }
+#endif
 
 Value::Value(const StaticString& value) {
   initBasic(stringValue);
@@ -1155,12 +1157,14 @@ Value const& Value::operator[](const String& key) const {
     return nullSingleton();
   return *found;
 }
+#ifdef JSON_USE_STRING_VIEW
 Value const& Value::operator[](const StringView key) const {
     Value const* found = find(sv.data(), sv.data() + sv.length());
     if (!found)
         return nullSingleton();
     return *found;
 }
+#endif
 
 Value& Value::operator[](const char* key) {
   return resolveReference(key, key + strlen(key));
@@ -1170,9 +1174,11 @@ Value& Value::operator[](const String& key) {
   return resolveReference(key.data(), key.data() + key.length());
 }
 
+#ifdef JSON_USE_STRING_VIEW
 Value& Value::operator[](const StringView key) {
     return resolveReference(key.data(), key.data() + key.length());
 }
+#endif
 
 Value& Value::operator[](const StaticString& key) {
   return resolveReference(key.c_str());

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -438,6 +438,12 @@ Value::Value(const String& value) {
       value.data(), static_cast<unsigned>(value.length()));
 }
 
+Value::Value(const StringView value) {
+    initBasic(stringValue, true);
+    value_.string_ = duplicateAndPrefixStringValue(
+            value.data(), static_cast<unsigned>(value.length()));
+}
+
 Value::Value(const StaticString& value) {
   initBasic(stringValue);
   value_.string_ = const_cast<char*>(value.c_str());

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1149,6 +1149,12 @@ Value const& Value::operator[](const String& key) const {
     return nullSingleton();
   return *found;
 }
+Value const& Value::operator[](const StringView key) const {
+    Value const* found = find(sv.data(), sv.data() + sv.length());
+    if (!found)
+        return nullSingleton();
+    return *found;
+}
 
 Value& Value::operator[](const char* key) {
   return resolveReference(key, key + strlen(key));
@@ -1156,6 +1162,10 @@ Value& Value::operator[](const char* key) {
 
 Value& Value::operator[](const String& key) {
   return resolveReference(key.data(), key.data() + key.length());
+}
+
+Value& Value::operator[](const StringView key) {
+    return resolveReference(key.data(), key.data() + key.length());
 }
 
 Value& Value::operator[](const StaticString& key) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -300,6 +300,18 @@ JSONTEST_FIXTURE(ValueTest, arrays) {
   JSONTEST_ASSERT_EQUAL(Json::Value(17), got);
   JSONTEST_ASSERT_EQUAL(false, array1_.removeIndex(2, &got)); // gone now
 }
+
+#ifdef JSON_USE_STRING_VIEW
+JSONTEST_FIXTURE(ValueTest, stringView) {
+    Json::Value root;
+    Json::Value item("Test item");
+    std::string_view sv = "array";
+    std::string s = "array";
+    root[s] = item;
+    JSONTEST_ASSERT_EQUAL(item.asString(), root[sv].asString());
+}
+#endif
+
 JSONTEST_FIXTURE(ValueTest, arrayIssue252) {
   int count = 5;
   Json::Value root;


### PR DESCRIPTION
Is it possible to add string_view?
How can we turn it off on older c++ versions?
Can it be another define "JSON_USE_CXX17"? Or compiler defines?

Thank you