### PR TITLE
Do not allow tokenError tokens after input if failIfExtra is set.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1052,10 +1052,10 @@ bool OurReader::parse(const char* beginDoc,
   Token token;
   skipCommentTokens(token);
   if (features_.failIfExtra_) {
-    if ((features_.strictRoot_ || token.type_ != tokenError) &&
-        token.type_ != tokenEndOfStream) {
-      addError("Extra non-whitespace after JSON value.", token);
-      return false;
+    if (token.type_ != tokenEndOfStream) {
+      if (successful)
+        addError("Extra non-whitespace after JSON value.", token);
+      successful = false;
     }
   }
   if (collectComments_ && !commentsBefore_.empty())


### PR DESCRIPTION
Currently when failIfExtra is set and strictRoot is not set,
OurReader::parse() will accept trailing non-whitespace after the JSON value
as long as the first token is not a valid JSON token. This commit changes
this to disallow any non-whitespace after the JSON value.

The current behaviour was introduced in https://github.com/open-source-parsers/jsoncpp/issues/511 / https://github.com/open-source-parsers/jsoncpp/commit/126bdc2b057d3d91c785b69c30a41e7697d8f80a but I cannot see any reason to allow error tokens if strictMode is not set. (Before this change error tokens were always allowed after the value itself.)

This commit also suppresses the "Extra non-whitespace after JSON value."
error message if parsing was aborted after another error.