### PR TITLE
jsoncpp: Define JSON_USE_INT64_DOUBLE_CONVERSION for clang as well.

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -104,7 +104,9 @@ msvc_pre1900_c99_snprintf(char* outBuf, size_t size, const char* format, ...);
 #define JSONCPP_OP_EXPLICIT
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ >= 6)
+#if defined(__clang__)
+#define JSON_USE_INT64_DOUBLE_CONVERSION 1
+#elif defined(__GNUC__) && (__GNUC__ >= 6)
 #define JSON_USE_INT64_DOUBLE_CONVERSION 1
 #endif
 


### PR DESCRIPTION
The current check to define JSON_USE_INT64_DOUBLE_CONVERSION
works for GCC but not clang.

Clang does define __GNUC__ but with a value 4 which misses
the check for >= 6.

This avoids the -Wimplicit-int-float-conversion warning
when jsoncpp is built with a recent version of clang.

Signed-off-by: Manoj Gupta <manojgupta@google.com>