### PR TITLE
change the returned value of method [readToken]

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -311,7 +311,7 @@ bool Reader::readToken(Token& token) {
   if (!ok)
     token.type_ = tokenError;
   token.end_ = current_;
-  return true;
+  return ok;
 }
 
 void Reader::skipSpaces() {
@@ -1274,7 +1274,7 @@ bool OurReader::readToken(Token& token) {
   if (!ok)
     token.type_ = tokenError;
   token.end_ = current_;
-  return true;
+  return ok;
 }
 
 void OurReader::skipSpaces() {


### PR DESCRIPTION
When I read the code, I found that the method [readToken] always return the true value.
But in other place, the returned value is used to judge.
For example, in the method [readObject]
```
while(...)
    initialTokenOK = readToken(tokenName);
if (!initialTokenOK)
    ....
```

So, it is a mistake for the returned value, I think.