### PR TITLE
Do not allow tokenError tokens after input if failIfExtra is set.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1051,12 +1051,9 @@ bool OurReader::parse(const char* beginDoc,
   nodes_.pop();
   Token token;
   skipCommentTokens(token);
-  if (features_.failIfExtra_) {
-    if ((features_.strictRoot_ || token.type_ != tokenError) &&
-        token.type_ != tokenEndOfStream) {
-      addError("Extra non-whitespace after JSON value.", token);
-      return false;
-    }
+  if (features_.failIfExtra_ && (token.type_ != tokenEndOfStream)) {
+    addError("Extra non-whitespace after JSON value.", token);
+    return false;
   }
   if (collectComments_ && !commentsBefore_.empty())
     root.setComment(commentsBefore_, commentAfter);


### PR DESCRIPTION
(This is basically PR #1001 plus some change suggestion from it's discussion.)

Currently when failIfExtra is set and strictRoot is not set,
OurReader::parse() will accept trailing non-whitespace after the JSON value
as long as the first token is not a valid JSON token. This commit changes
this to disallow any non-whitespace after the JSON value.

This commit also suppresses the "Extra non-whitespace after JSON value."
error message if parsing was aborted after another error.
