### PR TITLE
pkgconfig: Fix for cross compilation

### DIFF
--- a/pkg-config/jsoncpp.pc.in
+++ b/pkg-config/jsoncpp.pc.in
@@ -1,5 +1,7 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: jsoncpp
 Description: A C++ library for interacting with JSON


### PR DESCRIPTION
exec_ and prefix must be overridden  in such a case.

Makes the .pc file more consistent with other projects.