### PR TITLE
Issue #990: Remove unsupported C++14 features

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -104,9 +104,26 @@ extern JSON_API int msvc_pre1900_c99_snprintf(char* outBuf, size_t size,
 #define JSONCPP_OP_EXPLICIT
 #endif
 
-#if defined(__clang__)
-#define JSON_USE_INT64_DOUBLE_CONVERSION 1
-#elif defined(__GNUC__) && (__GNUC__ >= 6)
+#ifdef __clang__
+#if __has_extension(attribute_deprecated_with_message)
+#define JSONCPP_DEPRECATED(message) __attribute__((deprecated(message)))
+#endif
+#elif defined(__GNUC__) // not clang (gcc comes later since clang emulates gcc)
+#if (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+#define JSONCPP_DEPRECATED(message) __attribute__((deprecated(message)))
+#elif (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
+#define JSONCPP_DEPRECATED(message) __attribute__((__deprecated__))
+#endif                  // GNUC version
+#elif defined(_MSC_VER) // MSVC (after clang because clang on Windows emulates
+                        // MSVC)
+#define JSONCPP_DEPRECATED(message) __declspec(deprecated(message))
+#endif // __clang__ || __GNUC__ || _MSC_VER
+
+#if !defined(JSONCPP_DEPRECATED)
+#define JSONCPP_DEPRECATED(message)
+#endif // if !defined(JSONCPP_DEPRECATED)
+
+#if defined(__clang__) || (defined(__GNUC__) && (__GNUC__ >= 6))
 #define JSON_USE_INT64_DOUBLE_CONVERSION 1
 #endif
 

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -25,10 +25,6 @@
 
 #pragma pack(push, 8)
 
-#if defined(_MSC_VER)
-#pragma warning(disable : 4996)
-#endif
-
 namespace Json {
 
 /** \brief Unserialize a <a HREF="http://www.json.org">JSON</a> document into a
@@ -36,8 +32,9 @@ namespace Json {
  *
  * \deprecated Use CharReader and CharReaderBuilder.
  */
-class [[deprecated(
-    "deprecated Use CharReader and CharReaderBuilder.")]] JSON_API Reader {
+
+class JSONCPP_DEPRECATED(
+    "Use CharReader and CharReaderBuilder instead.") JSON_API Reader {
 public:
   typedef char Char;
   typedef const Char* Location;
@@ -55,10 +52,12 @@ public:
 
   /** \brief Constructs a Reader allowing all features for parsing.
    */
+  JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead")
   Reader();
 
   /** \brief Constructs a Reader allowing the specified feature set for parsing.
    */
+  JSONCPP_DEPRECATED("Use CharReader and CharReaderBuilder instead")
   Reader(const Features& features);
 
   /** \brief Read a Value from a <a HREF="http://www.json.org">JSON</a>
@@ -99,7 +98,7 @@ public:
 
   /// \brief Parse from input stream.
   /// \see Json::operator>>(std::istream&, Json::Value&).
-  bool parse(IStream & is, Value & root, bool collectComments = true);
+  bool parse(IStream& is, Value& root, bool collectComments = true);
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -109,8 +108,8 @@ public:
    * occurred during parsing.
    * \deprecated Use getFormattedErrorMessages() instead (typo fix).
    */
-  [[deprecated("Use getFormattedErrorMessages() instead.")]] String
-  getFormatedErrorMessages() const;
+  JSONCPP_DEPRECATED("Use getFormattedErrorMessages() instead.")
+  String getFormatedErrorMessages() const;
 
   /** \brief Returns a user friendly string that list errors in the parsed
    * document.
@@ -190,7 +189,7 @@ private:
 
   typedef std::deque<ErrorInfo> Errors;
 
-  bool readToken(Token & token);
+  bool readToken(Token& token);
   void skipSpaces();
   bool match(const Char* pattern, int patternLength);
   bool readComment();
@@ -199,17 +198,17 @@ private:
   bool readString();
   void readNumber();
   bool readValue();
-  bool readObject(Token & token);
-  bool readArray(Token & token);
-  bool decodeNumber(Token & token);
-  bool decodeNumber(Token & token, Value & decoded);
-  bool decodeString(Token & token);
-  bool decodeString(Token & token, String & decoded);
-  bool decodeDouble(Token & token);
-  bool decodeDouble(Token & token, Value & decoded);
-  bool decodeUnicodeCodePoint(Token & token, Location & current, Location end,
+  bool readObject(Token& token);
+  bool readArray(Token& token);
+  bool decodeNumber(Token& token);
+  bool decodeNumber(Token& token, Value& decoded);
+  bool decodeString(Token& token);
+  bool decodeString(Token& token, String& decoded);
+  bool decodeDouble(Token& token);
+  bool decodeDouble(Token& token, Value& decoded);
+  bool decodeUnicodeCodePoint(Token& token, Location& current, Location end,
                               unsigned int& unicode);
-  bool decodeUnicodeEscapeSequence(Token & token, Location & current,
+  bool decodeUnicodeEscapeSequence(Token& token, Location& current,
                                    Location end, unsigned int& unicode);
   bool addError(const String& message, Token& token, Location extra = nullptr);
   bool recoverFromError(TokenType skipUntilToken);
@@ -218,11 +217,11 @@ private:
   void skipUntilSpace();
   Value& currentValue();
   Char getNextChar();
-  void getLocationLineAndColumn(Location location, int& line, int& column)
-      const;
+  void getLocationLineAndColumn(Location location, int& line,
+                                int& column) const;
   String getLocationLineAndColumn(Location location) const;
   void addComment(Location begin, Location end, CommentPlacement placement);
-  void skipCommentTokens(Token & token);
+  void skipCommentTokens(Token& token);
 
   static bool containsNewLine(Location begin, Location end);
   static String normalizeEOL(Location begin, Location end);

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -567,8 +567,8 @@ public:
   //# endif
 
   /// \deprecated Always pass len.
-  [[deprecated("Use setComment(String const&) instead.")]] void
-  setComment(const char* comment, CommentPlacement placement) {
+  JSONCPP_DEPRECATED("Use setComment(String const&) instead.")
+  void setComment(const char* comment, CommentPlacement placement) {
     setComment(String(comment, strlen(comment)), placement);
   }
   /// Comments must be //... or /* ... */
@@ -750,7 +750,8 @@ public:
   /// objectValue.
   /// \deprecated This cannot be used for UTF-8 strings, since there can be
   /// embedded nulls.
-  [[deprecated("Use `key = name();` instead.")]] char const* memberName() const;
+  JSONCPP_DEPRECATED("Use `key = name();` instead.")
+  char const* memberName() const;
   /// Return the member name of the referenced Value, or NULL if it is not an
   /// objectValue.
   /// \note Better version than memberName(). Allows embedded nulls.

--- a/include/json/writer.h
+++ b/include/json/writer.h
@@ -145,7 +145,7 @@ public:
 /** \brief Abstract class for writers.
  * \deprecated Use StreamWriter. (And really, this is an implementation detail.)
  */
-class [[deprecated("Use StreamWriter instead")]] JSON_API Writer {
+class JSONCPP_DEPRECATED("Use StreamWriter instead") JSON_API Writer {
 public:
   virtual ~Writer();
 
@@ -165,7 +165,7 @@ public:
 #pragma warning(push)
 #pragma warning(disable : 4996) // Deriving from deprecated class
 #endif
-class [[deprecated("Use StreamWriterBuilder instead")]] JSON_API FastWriter
+class JSONCPP_DEPRECATED("Use StreamWriterBuilder instead") JSON_API FastWriter
     : public Writer {
 public:
   FastWriter();
@@ -225,8 +225,8 @@ private:
 #pragma warning(push)
 #pragma warning(disable : 4996) // Deriving from deprecated class
 #endif
-class [[deprecated("Use StreamWriterBuilder instead")]] JSON_API StyledWriter
-    : public Writer {
+class JSONCPP_DEPRECATED("Use StreamWriterBuilder instead") JSON_API
+    StyledWriter : public Writer {
 public:
   StyledWriter();
   ~StyledWriter() override = default;
@@ -294,8 +294,8 @@ private:
 #pragma warning(push)
 #pragma warning(disable : 4996) // Deriving from deprecated class
 #endif
-class [[deprecated(
-    "Use StreamWriterBuilder instead")]] JSON_API StyledStreamWriter {
+class JSONCPP_DEPRECATED("Use StreamWriterBuilder instead") JSON_API
+    StyledStreamWriter {
 public:
   /**
    * \param indentation Each level will be indented by this amount extra.
@@ -310,7 +310,7 @@ public:
    * \note There is no point in deriving from Writer, since write() should not
    * return a value.
    */
-  void write(OStream & out, const Value& root);
+  void write(OStream& out, const Value& root);
 
 private:
   void writeValue(const Value& value);


### PR DESCRIPTION
[[deprecated]] is a C++14 extension, and was mistakenly introducted into the code base.

This patch removes it from JsonCpp.