### PR TITLE
fix clang-format error for ci

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -85,12 +85,9 @@ bool Reader::containsNewLine(Reader::Location begin, Reader::Location end) {
 // Class Reader
 // //////////////////////////////////////////////////////////////////
 
-Reader::Reader()
-    :  features_(Features::all()) {}
+Reader::Reader() : features_(Features::all()) {}
 
-Reader::Reader(const Features& features)
-    :    features_(features) {
-}
+Reader::Reader(const Features& features) : features_(features) {}
 
 bool Reader::parse(const std::string& document,
                    Value& root,
@@ -110,7 +107,7 @@ bool Reader::parse(std::istream& is, Value& root, bool collectComments) {
   // Since String is reference-counted, this at least does not
   // create an extra copy.
   String doc;
-  std::getline(is, doc, static_cast<char>EOF);
+  std::getline(is, doc, static_cast<char> EOF);
   return parse(doc.data(), doc.data() + doc.size(), root, collectComments);
 }
 
@@ -895,7 +892,7 @@ OurFeatures OurFeatures::all() { return {}; }
 class OurReader {
 public:
   using Char = char;
-  using Location = const Char *;
+  using Location = const Char*;
   struct StructuredError {
     ptrdiff_t offset_start;
     ptrdiff_t offset_limit;
@@ -996,7 +993,7 @@ private:
   static String normalizeEOL(Location begin, Location end);
   static bool containsNewLine(Location begin, Location end);
 
-  using Nodes = std::stack<Value *>;
+  using Nodes = std::stack<Value*>;
   Nodes nodes_;
   Errors errors_;
   String document_;
@@ -1022,9 +1019,8 @@ bool OurReader::containsNewLine(OurReader::Location begin,
 }
 
 OurReader::OurReader(OurFeatures const& features)
-    :  begin_(), end_(), current_(), lastValueEnd_(),
-      lastValue_(),  features_(features), collectComments_() {
-}
+    : begin_(), end_(), current_(), lastValueEnd_(), lastValue_(),
+      features_(features), collectComments_() {}
 
 bool OurReader::parse(const char* beginDoc,
                       const char* endDoc,

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1551,16 +1551,15 @@ Value::iterator Value::end() {
 // class PathArgument
 // //////////////////////////////////////////////////////////////////
 
-PathArgument::PathArgument()  {}
+PathArgument::PathArgument() {}
 
 PathArgument::PathArgument(ArrayIndex index)
-    :  index_(index), kind_(kindIndex) {}
+    : index_(index), kind_(kindIndex) {}
 
-PathArgument::PathArgument(const char* key)
-    : key_(key),  kind_(kindKey) {}
+PathArgument::PathArgument(const char* key) : key_(key), kind_(kindKey) {}
 
 PathArgument::PathArgument(const String& key)
-    : key_(key.c_str()),  kind_(kindKey) {}
+    : key_(key.c_str()), kind_(kindKey) {}
 
 // class Path
 // //////////////////////////////////////////////////////////////////

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -378,8 +378,8 @@ void Runner::preventDialogOnCrash() {
   _CrtSetReportHook(&msvcrtSilentReportHook);
 #endif // if defined(_MSC_VER)
 
-// @todo investigate this handler (for buffer overflow)
-// _set_security_error_handler
+  // @todo investigate this handler (for buffer overflow)
+  // _set_security_error_handler
 
 #if defined(_WIN32)
   // Prevents the system from popping a dialog for debugging if the

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1391,8 +1391,10 @@ void ValueTest::checkIs(const Json::Value& value, const IsCheck& check) {
 
 JSONTEST_FIXTURE(ValueTest, compareNull) {
   JSONTEST_ASSERT_PRED(checkIsEqual(Json::Value(), Json::Value()));
-  JSONTEST_ASSERT_PRED(checkIsEqual(Json::Value::nullSingleton(), Json::Value()));
-  JSONTEST_ASSERT_PRED(checkIsEqual(Json::Value::nullSingleton(), Json::Value::nullSingleton()));
+  JSONTEST_ASSERT_PRED(
+      checkIsEqual(Json::Value::nullSingleton(), Json::Value()));
+  JSONTEST_ASSERT_PRED(
+      checkIsEqual(Json::Value::nullSingleton(), Json::Value::nullSingleton()));
 }
 
 JSONTEST_FIXTURE(ValueTest, compareInt) {
@@ -2643,7 +2645,8 @@ JSONTEST_FIXTURE(IteratorTest, indexes) {
 
 JSONTEST_FIXTURE(IteratorTest, const) {
   Json::Value const v;
-  JSONTEST_ASSERT_THROWS(Json::Value::iterator it(v.begin())); // Compile, but throw.
+  JSONTEST_ASSERT_THROWS(
+      Json::Value::iterator it(v.begin())); // Compile, but throw.
 
   Json::Value value;
 

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2643,9 +2643,7 @@ JSONTEST_FIXTURE(IteratorTest, indexes) {
 
 JSONTEST_FIXTURE(IteratorTest, const) {
   Json::Value const v;
-  JSONTEST_ASSERT_THROWS(
-      Json::Value::iterator it(v.begin()) // Compile, but throw.
-      );
+  JSONTEST_ASSERT_THROWS(Json::Value::iterator it(v.begin())); // Compile, but throw.
 
   Json::Value value;
 


### PR DESCRIPTION
Fix the clang-format errors, which are reported from #1026 's Trivis CI