### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ format to store user input files.
 
 ## Using JsonCpp in your project
 
+### The vcpkg dependency manager
+You can download and install JsonCpp using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install jsoncpp
+
+The JsonCpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ### Amalgamated source
 https://github.com/open-source-parsers/jsoncpp/wiki/Amalgamated
 


### PR DESCRIPTION
JsonCpp is available as a port in vcpkg. Adding installation instructions will help users get started by providing a single command they can use to build JsonCpp and include it into their projects