### PR TITLE
Fix fuzzer off by one error

### DIFF
--- a/example/readFromString/readFromString.cpp
+++ b/example/readFromString/readFromString.cpp
@@ -2,8 +2,8 @@
 #include <iostream>
 /**
  * \brief Parse a raw string into Value object using the CharReaderBuilder
- * class, or the legacy Reader class. 
- * Example Usage: 
+ * class, or the legacy Reader class.
+ * Example Usage:
  * $g++ readFromString.cpp -ljsoncpp -std=c++11 -o readFromString
  * $./readFromString
  * colin

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -210,7 +210,9 @@ LogicError::LogicError(String const& msg) : Exception(msg) {}
 JSONCPP_NORETURN void throwRuntimeError(String const& msg) {
   throw RuntimeError(msg);
 }
-JSONCPP_NORETURN void throwLogicError(String const& msg) { throw LogicError(msg); }
+JSONCPP_NORETURN void throwLogicError(String const& msg) {
+  throw LogicError(msg);
+}
 #else // !JSON_USE_EXCEPTION
 JSONCPP_NORETURN void throwRuntimeError(String const& msg) { abort(); }
 JSONCPP_NORETURN void throwLogicError(String const& msg) { abort(); }

--- a/src/test_lib_json/fuzz.cpp
+++ b/src/test_lib_json/fuzz.cpp
@@ -25,6 +25,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   uint32_t hash_settings = *(const uint32_t*)data;
   data += sizeof(uint32_t);
+  size -= sizeof(uint32_t);
 
   builder.settings_["failIfExtra"] = hash_settings & (1 << 0);
   builder.settings_["allowComments_"] = hash_settings & (1 << 1);


### PR DESCRIPTION
Currently the fuzzer has an off by one error, as it passing a bad length
to the CharReader::parse method, resulting in a heap buffer overflow.