### PR TITLE
Use universal references in append() method

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -460,10 +460,8 @@ public:
   /// Return true if index < size().
   bool isValidIndex(ArrayIndex index) const;
   /// \brief Append value to array at the end.
-  ///
   /// Equivalent to jsonvalue[jsonvalue.size()] = value;
-  Value& append(const Value& value);
-  Value& append(Value&& value);
+  Value& append(Value value);
   /// \brief Insert value in array at specific index
   bool insert(ArrayIndex index, Value newValue);
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1147,9 +1147,7 @@ Value const& Value::operator[](CppTL::ConstString const& key) const {
 }
 #endif
 
-Value& Value::append(const Value& value) { return append(Value(value)); }
-
-Value& Value::append(Value&& value) {
+Value& Value::append(Value value) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
                       "in Json::Value::append: requires arrayValue");
   if (type() == nullValue) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -329,11 +329,12 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayIssue252) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   Json::Value array;
+  const Json::Value str("index1");
   const Json::Value str0("index2");
   const Json::Value str1("index3");
-  array.append("index0"); // append rvalue
-  array.append("index1");
-  array.append(str0); // append lvalue
+  array.append("index0");
+  array.append(std::move(str));
+  array.append(str0);
 
   std::vector<Json::Value*> vec; // storage value address for checking
   for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
This litte patch fixes issue #1046.