### PR TITLE
Implemented as<T>() and is<T>() with accompanying tests

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -399,6 +399,40 @@ public:
   double asDouble() const;
   bool asBool() const;
 
+  template <class T>
+  struct asLookupHelper;
+
+  #define defAsLookupHelper(type, lookup) \
+  template<> \
+  struct asLookupHelper< type > { \
+    static type as(const Value& val) { \
+      return val. lookup (); \
+    } \
+  }
+
+  defAsLookupHelper(const char*, asCString);
+  defAsLookupHelper(String, asString);
+  #ifdef JSON_USE_CPPTL
+  defAsLookupHelper(CppTL::ConstString, asConstString);
+  #endif
+  defAsLookupHelper(Int, asInt);
+  defAsLookupHelper(UInt, asUInt);
+  #if defined(JSON_HAS_INT64)
+  defAsLookupHelper(Int64, asInt64);
+  defAsLookupHelper(UInt64, asUInt64);
+  #endif // if defined(JSON_HAS_INT64)
+  // (U)LargestInt is a type alias of int or int64 and thus cannot be defined
+  defAsLookupHelper(float, asFloat);
+  defAsLookupHelper(double, asDouble);
+  defAsLookupHelper(bool, asBool);
+
+  #undef defAsLookupHelper
+
+  template <class T>
+  T as() const {
+    return asLookupHelper<T>::as(*this);
+  }
+
   bool isNull() const;
   bool isBool() const;
   bool isInt() const;
@@ -411,6 +445,33 @@ public:
   bool isString() const;
   bool isArray() const;
   bool isObject() const;
+
+  template <class T>
+  struct isLookupHelper;
+
+  #define defIsLookupHelper(type, lookup) \
+  template<> \
+  struct isLookupHelper< type > { \
+    static bool is(const Value& val) { \
+      return val. lookup (); \
+    } \
+  }
+
+  defIsLookupHelper(bool, isBool);
+  defIsLookupHelper(Int, isInt);
+  defIsLookupHelper(Int64, isInt64);
+  defIsLookupHelper(UInt, isUInt);
+  defIsLookupHelper(UInt64, isUInt64);
+  defIsLookupHelper(double, isDouble);
+  defIsLookupHelper(const char*, isString);
+  defIsLookupHelper(String, isString);
+
+  #undef defIsLookupHelper
+
+  template <class T>
+  bool is() const {
+    return isLookupHelper<T>::is(*this);
+  }
 
   bool isConvertibleTo(ValueType other) const;
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -399,39 +399,32 @@ public:
   double asDouble() const;
   bool asBool() const;
 
-  template <class T>
-  struct asLookupHelper;
+  template <class T> struct asLookupHelper;
 
-  #define defAsLookupHelper(type, lookup) \
-  template<> \
-  struct asLookupHelper< type > { \
-    static type as(const Value& val) { \
-      return val. lookup (); \
-    } \
+#define defAsLookupHelper(type, lookup)                                        \
+  template <> struct asLookupHelper<type> {                                    \
+    static type as(const Value& val) { return val.lookup(); }                  \
   }
 
   defAsLookupHelper(const char*, asCString);
   defAsLookupHelper(String, asString);
-  #ifdef JSON_USE_CPPTL
+#ifdef JSON_USE_CPPTL
   defAsLookupHelper(CppTL::ConstString, asConstString);
-  #endif
+#endif
   defAsLookupHelper(Int, asInt);
   defAsLookupHelper(UInt, asUInt);
-  #if defined(JSON_HAS_INT64)
+#if defined(JSON_HAS_INT64)
   defAsLookupHelper(Int64, asInt64);
   defAsLookupHelper(UInt64, asUInt64);
-  #endif // if defined(JSON_HAS_INT64)
+#endif // if defined(JSON_HAS_INT64)
   // (U)LargestInt is a type alias of int or int64 and thus cannot be defined
   defAsLookupHelper(float, asFloat);
   defAsLookupHelper(double, asDouble);
   defAsLookupHelper(bool, asBool);
 
-  #undef defAsLookupHelper
+#undef defAsLookupHelper
 
-  template <class T>
-  T as() const {
-    return asLookupHelper<T>::as(*this);
-  }
+  template <class T> T as() const { return asLookupHelper<T>::as(*this); }
 
   bool isNull() const;
   bool isBool() const;
@@ -446,15 +439,11 @@ public:
   bool isArray() const;
   bool isObject() const;
 
-  template <class T>
-  struct isLookupHelper;
+  template <class T> struct isLookupHelper;
 
-  #define defIsLookupHelper(type, lookup) \
-  template<> \
-  struct isLookupHelper< type > { \
-    static bool is(const Value& val) { \
-      return val. lookup (); \
-    } \
+#define defIsLookupHelper(type, lookup)                                        \
+  template <> struct isLookupHelper<type> {                                    \
+    static bool is(const Value& val) { return val.lookup(); }                  \
   }
 
   defIsLookupHelper(bool, isBool);
@@ -466,12 +455,9 @@ public:
   defIsLookupHelper(const char*, isString);
   defIsLookupHelper(String, isString);
 
-  #undef defIsLookupHelper
+#undef defIsLookupHelper
 
-  template <class T>
-  bool is() const {
-    return isLookupHelper<T>::is(*this);
-  }
+  template <class T> bool is() const { return isLookupHelper<T>::is(*this); }
 
   bool isConvertibleTo(ValueType other) const;
 

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3361,6 +3361,116 @@ int main(int argc, const char* argv[]) {
   return runner.runCommandLine(argc, argv);
 }
 
+struct TemplatedAs : JsonTest::TestCase {};
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorCString) {
+  Json::Value json = "hello world";
+  JSONTEST_ASSERT_STRING_EQUAL(json.asCString(), json.as<const char*>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorString) {
+  Json::Value json = "hello world";
+  JSONTEST_ASSERT_STRING_EQUAL(json.asString(), json.as<Json::String>());
+}
+
+#ifdef JSON_USE_CPPTL
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorConstString) {
+  Json::Value json = "hello world";
+  JSONTEST_ASSERT_STRING_EQUAL(json.asConstString(), json.as<CppTL::ConstString>());
+}
+#endif
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorInt) {
+  Json::Value json = Json::Int(64);
+  JSONTEST_ASSERT_EQUAL(json.asInt(), json.as<Json::Int>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorUInt) {
+  Json::Value json = Json::UInt(64);
+  JSONTEST_ASSERT_EQUAL(json.asUInt(), json.as<Json::UInt>());
+}
+
+#if defined(JSON_HAS_INT64)
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorInt64) {
+  Json::Value json = Json::Int64(64);
+  JSONTEST_ASSERT_EQUAL(json.asUInt64(), json.as<Json::Int64>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorUInt64) {
+  Json::Value json = Json::UInt64(64);
+  JSONTEST_ASSERT_EQUAL(json.asUInt64(), json.as<Json::UInt64>());
+}
+#endif // if defined(JSON_HAS_INT64)
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorLargestInt) {
+  Json::Value json = Json::LargestInt(64);
+  JSONTEST_ASSERT_EQUAL(json.asLargestInt(), json.as<Json::LargestInt>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorLargestUInt) {
+  Json::Value json = Json::LargestUInt(64);
+  JSONTEST_ASSERT_EQUAL(json.asLargestUInt(), json.as<Json::LargestUInt>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorFloat) {
+  Json::Value json = float(69.69);
+  JSONTEST_ASSERT_EQUAL(json.asFloat(), json.as<float>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorDouble) {
+  Json::Value json = double(69.69);
+  JSONTEST_ASSERT_EQUAL(json.asDouble(), json.as<double>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorBool) {
+  Json::Value jsonTrue = true;
+  Json::Value jsonFalse = false;
+  JSONTEST_ASSERT_EQUAL(jsonTrue.asBool(), jsonTrue.as<bool>());
+  JSONTEST_ASSERT_EQUAL(jsonFalse.asBool(), jsonFalse.as<bool>());
+}
+
+struct TemplatedIs : JsonTest::TestCase {};
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsBool) {
+  Json::Value json = true;
+  JSONTEST_ASSERT_EQUAL(json.isBool(), json.is<bool>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsInt) {
+  Json::Value json = 142;
+  JSONTEST_ASSERT_EQUAL(json.isInt(), json.is<Json::Int>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsInt64) {
+  Json::Value json = 142;
+  JSONTEST_ASSERT_EQUAL(json.isInt64(), json.is<Json::Int64>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsUInt) {
+  Json::Value json = 142;
+  JSONTEST_ASSERT_EQUAL(json.isUInt(), json.is<Json::UInt>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsUInt64) {
+  Json::Value json = 142;
+  JSONTEST_ASSERT_EQUAL(json.isUInt64(), json.is<Json::UInt64>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsDouble) {
+  Json::Value json = 40.63;
+  JSONTEST_ASSERT_EQUAL(json.isDouble(), json.is<double>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsCString) {
+  Json::Value json = "hello world";
+  JSONTEST_ASSERT_EQUAL(json.isString(), json.is<const char*>());
+}
+
+JSONTEST_FIXTURE_LOCAL(TemplatedIs, equalBehaviorIsString) {
+  Json::Value json = "hello world";
+  JSONTEST_ASSERT_EQUAL(json.isString(), json.is<Json::String>());
+}
+
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3376,7 +3376,8 @@ JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorString) {
 #ifdef JSON_USE_CPPTL
 JSONTEST_FIXTURE_LOCAL(TemplatedAs, equalBehaviorConstString) {
   Json::Value json = "hello world";
-  JSONTEST_ASSERT_STRING_EQUAL(json.asConstString(), json.as<CppTL::ConstString>());
+  JSONTEST_ASSERT_STRING_EQUAL(json.asConstString(),
+                               json.as<CppTL::ConstString>());
 }
 #endif
 


### PR DESCRIPTION
Solves issue #1066 