### PR TITLE
Add insert overload method

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -445,8 +445,10 @@ public:
   /// Equivalent to jsonvalue[jsonvalue.size()] = value;
   Value& append(const Value& value);
   Value& append(Value&& value);
+
   /// \brief Insert value in array at specific index
-  bool insert(ArrayIndex index, Value newValue);
+  bool insert(ArrayIndex index, const Value& newValue);
+  bool insert(ArrayIndex index, Value&& newValue);
 
   /// Access an object value by name, create a null member if it does not exist.
   /// \note Because of our implementation, keys are limited to 2^30 -1 chars.

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1126,7 +1126,11 @@ Value& Value::append(Value&& value) {
   return this->value_.map_->emplace(size(), std::move(value)).first->second;
 }
 
-bool Value::insert(ArrayIndex index, Value newValue) {
+bool Value::insert(ArrayIndex index, const Value& newValue) {
+  return insert(index, Value(newValue));
+}
+
+bool Value::insert(ArrayIndex index, Value&& newValue) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
                       "in Json::Value::insert: requires arrayValue");
   ArrayIndex length = size();

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -417,8 +417,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   }
   vec.push_back(&array[4]);
   // insert rvalue at the tail
-  Json::Value index5("index5");
-  JSONTEST_ASSERT(array.insert(5, std::move(index5)));
+  JSONTEST_ASSERT(array.insert(5, "index5"));
   JSONTEST_ASSERT_EQUAL(Json::Value("index3"), array[0]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index0"), array[1]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index4"), array[2]);


### PR DESCRIPTION
According to the conclusion in issue #1046, the `insert` should follow the standard container members like vector::push_back, which will always have a const T& and a T&& overload. 
This patch is to fix this problem.