### PR TITLE
json_writer: fix inverted sense in isAnyCharRequiredQuoting

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -178,8 +178,9 @@ static bool isAnyCharRequiredQuoting(char const* s, size_t n) {
 
   char const* const end = s + n;
   for (char const* cur = s; cur < end; ++cur) {
-    if (*cur == '\\' || *cur == '\"' || *cur < ' ' ||
-        static_cast<unsigned char>(*cur) < 0x80)
+    if (*cur == '\\' || *cur == '\"' ||
+        static_cast<unsigned char>(*cur) < ' ' ||
+        static_cast<unsigned char>(*cur) >= 0x80)
       return true;
   }
   return false;


### PR DESCRIPTION
This bug is only affects platforms where `char` is unsigned.

When char is a signed type, values >= 0x80 are also considered < 0,
and hence require escaping due to the < ' ' condition.

When char is an unsigned type, values >= 0x80 match none of the
conditions and are considered safe to emit without escaping.

This shows up as a test failure:

* Detail of EscapeSequenceTest/writeEscapeSequence test failure:
/build/source/src/test_lib_json/main.cpp(3370): expected == result
  Expected: '["\"","\\","\b","\f","\n","\r","\t","\u0278","\ud852\udf62"]
  '
  Actual  : '["\"","\\","\b","\f","\n","\r","\t","ɸ","𤭢"]
  '