### PR TITLE
revert trailing comma in old Reader

### DIFF
--- a/include/json/json_features.h
+++ b/include/json/json_features.h
@@ -23,7 +23,6 @@ public:
   /** \brief A configuration that allows all features and assumes all strings
    * are UTF-8.
    * - C & C++ comments are allowed
-   * - Trailing commas in objects and arrays are allowed.
    * - Root object can be any JSON value
    * - Assumes Value strings are encoded in UTF-8
    */
@@ -32,7 +31,6 @@ public:
   /** \brief A configuration that is strictly compatible with the JSON
    * specification.
    * - Comments are forbidden.
-   * - Trailing commas in objects and arrays are forbidden.
    * - Root object must be either an array or an object value.
    * - Assumes Value strings are encoded in UTF-8
    */
@@ -44,10 +42,6 @@ public:
 
   /// \c true if comments are allowed. Default: \c true.
   bool allowComments_{true};
-
-  /// \c true if trailing commas in objects and arrays are allowed. Default \c
-  /// true.
-  bool allowTrailingCommas_{true};
 
   /// \c true if root must be either an array or an object value. Default: \c
   /// false.


### PR DESCRIPTION
According to https://github.com/open-source-parsers/jsoncpp/pull/1062#issuecomment-549530234 and https://github.com/open-source-parsers/jsoncpp/pull/1098#issuecomment-554256725, this PR will revert the changes to the old Reader. 