### PR TITLE
removing ccache from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,12 +186,6 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     endif()
 endif()
 
-find_program(CCACHE_FOUND ccache)
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
-
 if(JSONCPP_WITH_WARNING_AS_ERROR)
     UseCompilationWarningAsError()
 endif()


### PR DESCRIPTION
seeing issues with ccache when using CMake -- removed it as per https://github.com/open-source-parsers/jsoncpp/issues/737. 