### PR TITLE
Remove '=delete' from template methods for Xcode 8

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -21,6 +21,24 @@
 #endif
 #endif
 
+// Support for '= delete' with template declarations was a late addition
+// to the c++11 standard and is rejected by clang 3.8 and Apple clang 8.2
+// even though these declare themselves to be c++11 compilers.
+#if !defined(JSONCPP_TEMPLATE_DELETE)
+#if defined(__clang__) && defined(__apple_build_version__)
+#if __apple_build_version__ <= 8000042
+#define JSONCPP_TEMPLATE_DELETE
+#endif
+#elif defined(__clang__)
+#if __clang_major__ == 3 && __clang_minor__ <= 8
+#define JSONCPP_TEMPLATE_DELETE
+#endif
+#endif
+#if !defined(JSONCPP_TEMPLATE_DELETE)
+#define JSONCPP_TEMPLATE_DELETE = delete
+#endif
+#endif
+
 #include <array>
 #include <exception>
 #include <map>
@@ -390,8 +408,8 @@ public:
   bool isObject() const;
 
   /// The `as<T>` and `is<T>` member function templates and specializations.
-  template <typename T> T as() const = delete;
-  template <typename T> bool is() const = delete;
+  template <typename T> T as() const JSONCPP_TEMPLATE_DELETE;
+  template <typename T> bool is() const JSONCPP_TEMPLATE_DELETE;
 
   bool isConvertibleTo(ValueType other) const;
 


### PR DESCRIPTION
For Apple clang-800.0.42.1, which was released with Xcode 8 in September 2016, the '=delete' on the 'is' and 'as' methods introduced in 53c8e2cb causes the following errors for value.h:

    inline declaration of 'as<bool>' follows non-inline definition
    inline declaration of 'is<bool>' follows non-inline definition

etcetera for the other specializations of 'is' and 'as'.

I understand, of course, that this use of '=delete' serves a purpose: it allows the C++ compiler to detect when a program uses specializations of `is()` and `as()` that aren't implemented.  However, this patch will be useful (necessary, in fact) for people who build their projects with Xcode 8.