### PR TITLE
Use stream error flags instead of exception

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1973,7 +1973,7 @@ IStream& operator>>(IStream& sin, Value& root) {
   String errs;
   bool ok = parseFromStream(b, sin, &root, &errs);
   if (!ok) {
-    throwRuntimeError(errs);
+    sin.setstate(std::ios::failbit);
   }
   return sin;
 }


### PR DESCRIPTION
The operator>> overload should use stream error flags instead
of throwing an exception for error handling.