### PR TITLE
Ignore byte order mark in the head of UTF-8 text.

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <set>
 #include <sstream>
-#include <string.h>
 #include <utility>
 
 #include <cstdio>
@@ -1011,6 +1010,7 @@ bool OurReader::parse(const char* beginDoc, const char* endDoc, Value& root,
   if (!features_.allowComments_) {
     collectComments = false;
   }
+
   begin_ = beginDoc;
   end_ = endDoc;
   collectComments_ = collectComments;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3580,15 +3580,28 @@ JSONTEST_FIXTURE_LOCAL(BuilderTest, settings) {
 
 struct BomTest : JsonTest::TestCase {};
 
-JSONTEST_FIXTURE_LOCAL(BomTest, withBom) {
+JSONTEST_FIXTURE_LOCAL(BomTest, skipBom) {
   const std::string with_bom = "\xEF\xBB\xBF{\"key\" : \"value\"}";
   Json::Value root;
   JSONCPP_STRING errs;
   std::istringstream iss(with_bom);
   bool ok = parseFromStream(Json::CharReaderBuilder(), iss, &root, &errs);
+  // The default behavior is to skip the BOM, so we can parse it normally.
   JSONTEST_ASSERT(ok);
   JSONTEST_ASSERT(errs.empty());
   JSONTEST_ASSERT_STRING_EQUAL(root["key"].asString(), "value");
+}
+JSONTEST_FIXTURE_LOCAL(BomTest, allowBom) {
+  const std::string with_bom = "\xEF\xBB\xBF{\"key\" : \"value\"}";
+  Json::Value root;
+  JSONCPP_STRING errs;
+  std::istringstream iss(with_bom);
+  Json::CharReaderBuilder b;
+  b.settings_["allowBom"] = true;
+  bool ok = parseFromStream(b, iss, &root, &errs);
+  // Detect the BOM, and failed on it.
+  JSONTEST_ASSERT(!ok);
+  JSONTEST_ASSERT(!errs.empty());
 }
 
 struct IteratorTest : JsonTest::TestCase {};

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3581,7 +3581,7 @@ JSONTEST_FIXTURE_LOCAL(BuilderTest, settings) {
 struct BomTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE_LOCAL(BomTest, withBom) {
-  const std::string with_bom = u8"\xEF\xBB\xBF{\"key\" : \"value\"}";
+  const std::string with_bom = "\xEF\xBB\xBF{\"key\" : \"value\"}";
   Json::Value root;
   JSONCPP_STRING errs;
   std::istringstream iss(with_bom);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3578,6 +3578,19 @@ JSONTEST_FIXTURE_LOCAL(BuilderTest, settings) {
   }
 }
 
+struct BomTest : JsonTest::TestCase {};
+
+JSONTEST_FIXTURE_LOCAL(BomTest, withBom) {
+  const std::string with_bom = u8"\xEF\xBB\xBF{\"key\" : \"value\"}";
+  Json::Value root;
+  JSONCPP_STRING errs;
+  std::istringstream iss(with_bom);
+  bool ok = parseFromStream(Json::CharReaderBuilder(), iss, &root, &errs);
+  JSONTEST_ASSERT(ok);
+  JSONTEST_ASSERT(errs.empty());
+  JSONTEST_ASSERT_STRING_EQUAL(root["key"].asString(), "value");
+}
+
 struct IteratorTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE_LOCAL(IteratorTest, convert) {


### PR DESCRIPTION
Fix issue #1141