### PR TITLE
No trailing space for BuiltStyledStreamWriter

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -923,7 +923,9 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
       precision_(precision), precisionType_(precisionType) {
   if (colonSymbol_[colonSymbol_.size() - 1] == ' ') {
     colonSymbolNoTrailingSpace_ =
-        colonSymbol_.substr(0, (colonSymbol_.find_last_not_of(' ') + 1));
+        colonSymbol_.substr(0, colonSymbol_.size() - 1);
+  }else{
+    colonSymbolNoTrailingSpace_ = colonSymbol_;
   }
 }
 int BuiltStyledStreamWriter::write(Value const& root, OStream* sout) {

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -991,7 +991,7 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
         writeWithIndent(valueToQuotedStringN(
             name.data(), static_cast<unsigned>(name.length()), emitUTF8_));
         if ((childValue.type() == objectValue &&
-             !value.getMemberNames().empty()) ||
+             !childValue.getMemberNames().empty()) ||
             (childValue.type() == arrayValue && childValue.size() > 0 &&
              ((cs_ == CommentStyle::All) || isMultilineArray(childValue))))
           *sout_ << colonSymbolNoTrailingSpace_;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -924,7 +924,7 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
   if (colonSymbol_[colonSymbol_.size() - 1] == ' ') {
     colonSymbolNoTrailingSpace_ =
         colonSymbol_.substr(0, colonSymbol_.size() - 1);
-  }else{
+  } else {
     colonSymbolNoTrailingSpace_ = colonSymbol_;
   }
 }

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -987,7 +987,8 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
             (childValue.type() == arrayValue && !childValue.empty() &&
              ((cs_ == CommentStyle::All) || isMultilineArray(childValue)))) {
           // Line-ending colon, so trim any trailing space from it
-          for (; n && colonSymbol_[n - 1] == ' '; --n) ;
+          for (; n && colonSymbol_[n - 1] == ' '; --n)
+            ;
         }
         sout_->write(colonSymbol_.data(), n);
         writeValue(childValue);

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -921,10 +921,11 @@ BuiltStyledStreamWriter::BuiltStyledStreamWriter(
       addChildValues_(false), indented_(false),
       useSpecialFloats_(useSpecialFloats), emitUTF8_(emitUTF8),
       precision_(precision), precisionType_(precisionType) {
-        if(colonSymbol_[colonSymbol_.size()-1]==' '){
-          colonSymbolNoTrailingSpace_ = colonSymbol_.substr(0, (colonSymbol_.find_last_not_of(' ') + 1));
-        }
-      }
+  if (colonSymbol_[colonSymbol_.size() - 1] == ' ') {
+    colonSymbolNoTrailingSpace_ =
+        colonSymbol_.substr(0, (colonSymbol_.find_last_not_of(' ') + 1));
+  }
+}
 int BuiltStyledStreamWriter::write(Value const& root, OStream* sout) {
   sout_ = sout;
   addChildValues_ = false;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -990,7 +990,8 @@ void BuiltStyledStreamWriter::writeValue(Value const& value) {
         writeCommentBeforeValue(childValue);
         writeWithIndent(valueToQuotedStringN(
             name.data(), static_cast<unsigned>(name.length()), emitUTF8_));
-        if ((childValue.type() == objectValue) ||
+        if ((childValue.type() == objectValue &&
+             !value.getMemberNames().empty()) ||
             (childValue.type() == arrayValue && childValue.size() > 0 &&
              ((cs_ == CommentStyle::All) || isMultilineArray(childValue))))
           *sout_ << colonSymbolNoTrailingSpace_;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2469,7 +2469,7 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, writeNumericValue) {
 JSONTEST_FIXTURE_LOCAL(StreamWriterTest, writeArrays) {
   Json::StreamWriterBuilder writer;
   const Json::String expected("{\n"
-                              "\t\"property1\" : \n"
+                              "\t\"property1\" :\n"
                               "\t[\n"
                               "\t\t\"value1\",\n"
                               "\t\t\"value2\"\n"
@@ -2489,7 +2489,7 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, writeArrays) {
 JSONTEST_FIXTURE_LOCAL(StreamWriterTest, writeNestedObjects) {
   Json::StreamWriterBuilder writer;
   const Json::String expected("{\n"
-                              "\t\"object1\" : \n"
+                              "\t\"object1\" :\n"
                               "\t{\n"
                               "\t\t\"bool\" : true,\n"
                               "\t\t\"nested\" : 123\n"


### PR DESCRIPTION
Before pr, the positions with `<-HERE` annotation has a trailing space:
```json
[
  {
    "headshoulders_info" : <-HERE
    [
      {
        "det_score" : 0.73144500000000001,
        "rect" : <-HERE
        {
          "bottom" : 205,
          "left" : 200,
          "right" : 309,
          "top" : 102
        }
      }
    ],
    "image" : <-HERE
    {
      "height" : 368,
      "id" : 0,
      "uuid" : "/workspace/face/data/shot_0001/img_00000.jpg",
      "width" : 640
    },
    "status" : 0
  }
]
```

After:
```json
[
  {
    "headshoulders_info" :
    [
      {
        "det_score" : 0.73144500000000001,
        "rect" :
        {
          "bottom" : 205,
          "left" : 200,
          "right" : 309,
          "top" : 102
        }
      }
    ],
    "image" :
    {
      "height" : 368,
      "id" : 0,
      "uuid" : "/workspace/face/data/shot_0001/img_00000.jpg",
      "width" : 640
    },
    "status" : 0
  }
]
```

code:
```cpp
Json::StreamWriterBuilder builder;
builder["indentation"] = "  ";
string document = Json::writeString(builder, root);
```