### PR TITLE
Put ".exe" and ".dll" together to make test usable in build dir.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ option(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." OFF)
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
 
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Archive output dir.")
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Library output dir.")
+set(CMAKE_PDB_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/bin" CACHE PATH "PDB (MSVC debug symbol)output dir.")
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Executable/dll output dir.")
+
 set(JSONCPP_USE_SECURE_MEMORY "0" CACHE STRING "-D...=1 to use memory-wiping allocator for STL")
 
 configure_file("${PROJECT_SOURCE_DIR}/version.in"

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -21,28 +21,17 @@ target_link_libraries(jsoncpp_test jsoncpp_lib)
 # another way to solve issue #90
 #set_target_properties(jsoncpp_test PROPERTIES COMPILE_FLAGS -ffloat-store)
 
+## Create tests for dashboard submission, allows easy review of CI results https://my.cdash.org/index.php?project=jsoncpp
+add_test(NAME jsoncpp_test
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
+)
+set_target_properties(jsoncpp_test PROPERTIES OUTPUT_NAME jsoncpp_test)
+
 # Run unit tests in post-build
 # (default cmake workflow hides away the test result into a file, resulting in poor dev workflow?!?)
 if(JSONCPP_WITH_POST_BUILD_UNITTEST)
-    if(BUILD_SHARED_LIBS)
-        # First, copy the shared lib, for Microsoft.
-        # Then, run the test executable.
-        add_custom_command(TARGET jsoncpp_test
-            POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:jsoncpp_lib> $<TARGET_FILE_DIR:jsoncpp_test>
-            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
-        )
-    else()
-        # Just run the test executable.
-        add_custom_command(TARGET jsoncpp_test
-            POST_BUILD
-            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
-        )
-    endif()
-    ## Create tests for dashboard submission, allows easy review of CI results https://my.cdash.org/index.php?project=jsoncpp
-    add_test(NAME jsoncpp_test
+    add_custom_command(TARGET jsoncpp_test
+        POST_BUILD
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
     )
 endif()
-
-set_target_properties(jsoncpp_test PROPERTIES OUTPUT_NAME jsoncpp_test)


### PR DESCRIPTION
Fix https://github.com/open-source-parsers/jsoncpp/issues/1163