### PR TITLE
Added current dir specifier for PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can download and install JsonCpp using the [vcpkg](https://github.com/Micros
     cd vcpkg
     ./bootstrap-vcpkg.sh
     ./vcpkg integrate install
-    vcpkg install jsoncpp
+    ./vcpkg install jsoncpp
 
 The JsonCpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 


### PR DESCRIPTION
The `./` is needed before `vcpkg install jsoncpp` when installing with PowerShell.