### PR TITLE
Issue 1182: Fix fuzzing bug

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1175,8 +1175,11 @@ bool OurReader::readToken(Token& token) {
     if (features_.allowSingleQuotes_) {
       token.type_ = tokenString;
       ok = readStringSingleQuote();
-      break;
-    } // else fall through
+    } else {
+      // If we don't allow single quotes, this is a failure case.
+      ok = false;
+    }
+    break;
   case '/':
     token.type_ = tokenComment;
     ok = readComment();

--- a/test/data/fail_invalid_quote.json
+++ b/test/data/fail_invalid_quote.json
@@ -1,0 +1,1 @@
+{'//this is bad JSON.'}


### PR DESCRIPTION
This patch fixes a fuzzing bug by resolving a bad fallthrough in the
setComment logic.

The result is that we get a proper error instead of an assert, making
the library friendlier to use and less likely to cause issue for
consumers.

See related Chromium project bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=989851

Issue: 1182