### PR TITLE
meson: Don't specifically look for python3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,7 +73,7 @@ if meson.is_subproject() or not get_option('tests')
   subdir_done()
 endif
 
-python = import('python').find_installation('python3')
+python = import('python').find_installation()
 
 jsoncpp_test = executable(
   'jsoncpp_test', files([


### PR DESCRIPTION
Not all distributions provide Python as python3 and as Meson already depends on 3.5+ just use what Meson uses.
References: https://mesonbuild.com/Getting-meson.html
https://mesonbuild.com/Python-module.html#find_installation

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>