### PR TITLE
Add nullptr Json::Value constructor

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -342,6 +342,7 @@ public:
   Value(const StaticString& value);
   Value(const String& value);
   Value(bool value);
+  Value(std::nullptr_t ptr) = delete;
   Value(const Value& other);
   Value(Value&& other);
   ~Value();


### PR DESCRIPTION
I found some unexpected behavior when using this library when comparing a `Json::Value` to `nullptr`. This was my sample program:
```c++
#include <jsoncpp/json/json.h>
#include <iostream>

int main()
{
    Json::Value test("Hello world!");
    Json::Value test2(Json::nullValue);

    if (test == nullptr)
    {
        std::cout << "test is null" << std::endl;
    }

    if (test2 == nullptr)
    {
        std::cout << "test2 is null" << std::endl;
    }

    return 0;
}
```

Since before this change, `Json::Value` objects can be compared with other `Json::Value` objects, a implicit `Json::Value` object will be constructed with `nullptr` as it's parameters. Given the only valid constructor for `nullptr` was the `const char *`, the program aborts with the following output:
```
terminate called after throwing an instance of 'Json::LogicError'
  what():  Null Value Passed to Value Constructor
Aborted
```

To improve this experience, I've explicitly deleted the `nullptr_t` constructor, so that the above code will result in a compile time error.