### PR TITLE
Enhance cmake script

### DIFF
--- a/.travis_scripts/cmake_builder.sh
+++ b/.travis_scripts/cmake_builder.sh
@@ -66,7 +66,7 @@ cmake --version
 echo ${CXX}
 ${CXX} --version
 _COMPILER_NAME=`basename ${CXX}`
-if [ "${BUILD_TYPE}" == "shared" ]; then
+if [ "${LIB_TYPE}" = "shared" ]; then
   _CMAKE_BUILD_SHARED_LIBS=ON
 else
   _CMAKE_BUILD_SHARED_LIBS=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,19 +59,19 @@ if(CCACHE_EXECUTABLE)
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_EXECUTABLE}" CACHE PATH "ccache" FORCE)
 endif()
 
-project(JSONCPP
+project(jsoncpp
         # Note: version must be updated in three places when doing a release. This
         # annoying process ensures that amalgamate, CMake, and meson all report the
         # correct version.
         # 1. ./meson.build
         # 2. ./include/json/version.h
         # 3. ./CMakeLists.txt
-        # IMPORTANT: also update the JSONCPP_SOVERSION!!
+        # IMPORTANT: also update the PROJECT_SOVERSION!!
         VERSION 1.9.3 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)
 
-message(STATUS "JsonCpp Version: ${JSONCPP_VERSION_MAJOR}.${JSONCPP_VERSION_MINOR}.${JSONCPP_VERSION_PATCH}")
-set(JSONCPP_SOVERSION 24)
+message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
+set(PROJECT_SOVERSION 24)
 
 option(JSONCPP_WITH_TESTS "Compile and (for jsoncpp_check) run JsonCpp test executables" ON)
 option(JSONCPP_WITH_POST_BUILD_UNITTEST "Automatically run unit-tests as a post build step" ON)
@@ -80,7 +80,9 @@ option(JSONCPP_WITH_STRICT_ISO "Issue all the warnings demanded by strict ISO C 
 option(JSONCPP_WITH_PKGCONFIG_SUPPORT "Generate and install .pc files" ON)
 option(JSONCPP_WITH_CMAKE_PACKAGE "Generate and install cmake package files" ON)
 option(JSONCPP_WITH_EXAMPLE "Compile JsonCpp example" OFF)
-option(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." OFF)
+option(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." ON)
+option(BUILD_STATIC_LIBS "Build jsoncpp_lib as a static library." ON)
+option(BUILD_OBJECT_LIBS "Build jsoncpp_lib as a object library." ON)
 
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)

--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -19,8 +19,10 @@ if(BUILD_SHARED_LIBS)
     else()
         add_definitions(-DJSON_DLL)
     endif()
+    target_link_libraries(jsontestrunner_exe jsoncpp_lib)
+else()
+    target_link_libraries(jsontestrunner_exe jsoncpp_static)
 endif()
-target_link_libraries(jsontestrunner_exe jsoncpp_lib)
 
 set_target_properties(jsontestrunner_exe PROPERTIES OUTPUT_NAME jsontestrunner_exe)
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -50,7 +50,7 @@ set(PUBLIC_HEADERS
 
 source_group("Public API" FILES ${PUBLIC_HEADERS})
 
-set(jsoncpp_sources
+set(JSONCPP_SOURCES
     json_tool.h
     json_reader.cpp
     json_valueiterator.inl
@@ -65,32 +65,10 @@ else()
     set(INSTALL_EXPORT)
 endif()
 
-
-if(BUILD_SHARED_LIBS)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
-        add_compile_definitions(JSON_DLL_BUILD)
-    else()
-        add_definitions(-DJSON_DLL_BUILD)
-    endif()
-endif()
-
-add_library(jsoncpp_lib ${PUBLIC_HEADERS} ${jsoncpp_sources})
-set_target_properties( jsoncpp_lib PROPERTIES
-    OUTPUT_NAME jsoncpp
-    VERSION ${JSONCPP_VERSION}
-    SOVERSION ${JSONCPP_SOVERSION}
-    POSITION_INDEPENDENT_CODE ON
-)
-
-# Set library's runtime search path on OSX
-if(APPLE)
-    set_target_properties(jsoncpp_lib PROPERTIES INSTALL_RPATH "@loader_path/.")
-endif()
-
 # Specify compiler features required when compiling a given target.
 # See https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#prop_gbl:CMAKE_CXX_KNOWN_FEATURES
 # for complete list of features available
-target_compile_features(jsoncpp_lib PUBLIC
+list(APPEND REQUIRED_FEATURES
         cxx_std_11 # Compiler mode is aware of C++ 11.
         #MSVC 1900 cxx_alignas # Alignment control alignas, as defined in N2341.
         #MSVC 1900 cxx_alignof # Alignment control alignof, as defined in N2341.
@@ -137,16 +115,106 @@ target_compile_features(jsoncpp_lib PUBLIC
         cxx_variadic_templates # Variadic templates, as defined in N2242.
 )
 
-install(TARGETS jsoncpp_lib ${INSTALL_EXPORT}
+
+if(BUILD_SHARED_LIBS)
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
+        add_compile_definitions(JSON_DLL_BUILD)
+    else()
+        add_definitions(-DJSON_DLL_BUILD)
+    endif()
+
+    set(SHARED_LIB ${PROJECT_NAME}_lib)
+    add_library(${SHARED_LIB} SHARED ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+    set_target_properties(${SHARED_LIB} PROPERTIES
+        OUTPUT_NAME jsoncpp
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_SOVERSION}
+        POSITION_INDEPENDENT_CODE ON
+    )
+
+    # Set library's runtime search path on OSX
+    if(APPLE)
+        set_target_properties(${SHARED_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
+    endif()
+
+    target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
+
+    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
+        target_include_directories(${SHARED_LIB} PUBLIC
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+        )
+    endif()
+
+    list(APPEND CMAKE_TARGETS ${SHARED_LIB})
+endif()
+
+if(BUILD_STATIC_LIBS)
+    set(STATIC_LIB ${PROJECT_NAME}_static)
+    add_library(${STATIC_LIB} STATIC ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+
+    # avoid name clashes on windows as the shared import lib is alse named jsoncpp.lib
+    if(NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)
+        set(STATIC_SUFFIX "_static")
+    endif()
+
+    set_target_properties(${STATIC_LIB} PROPERTIES
+        OUTPUT_NAME jsoncpp${STATIC_SUFFIX}
+        VERSION ${PROJECT_VERSION}
+    )
+
+    # Set library's runtime search path on OSX
+    if(APPLE)
+        set_target_properties(${STATIC_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
+    endif()
+
+    target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
+
+    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
+        target_include_directories(${STATIC_LIB} PUBLIC
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+        )
+    endif()
+
+    list(APPEND CMAKE_TARGETS ${STATIC_LIB})
+endif()
+
+if(BUILD_OBJECT_LIBS)
+    set(OBJECT_LIB ${PROJECT_NAME}_object)
+    add_library(${OBJECT_LIB} OBJECT ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+
+    set_target_properties(${OBJECT_LIB} PROPERTIES
+        OUTPUT_NAME jsoncpp
+        VERSION ${PROJECT_VERSION}
+        SOVERSION ${PROJECT_SOVERSION}
+        POSITION_INDEPENDENT_CODE ON
+    )
+
+    # Set library's runtime search path on OSX
+    if(APPLE)
+        set_target_properties(${OBJECT_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
+    endif()
+
+    target_compile_features(${OBJECT_LIB} PUBLIC ${REQUIRED_FEATURES})
+
+    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
+        target_include_directories(${OBJECT_LIB} PUBLIC
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+        )
+    endif()
+
+    list(APPEND CMAKE_TARGETS ${OBJECT_LIB})
+endif()
+
+install(TARGETS ${CMAKE_TARGETS} ${INSTALL_EXPORT}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    OBJECTS DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
-if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-    target_include_directories(jsoncpp_lib PUBLIC
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-    )
-endif()

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -15,8 +15,10 @@ if(BUILD_SHARED_LIBS)
     else()
         add_definitions( -DJSON_DLL )
     endif()
+    target_link_libraries(jsoncpp_test jsoncpp_lib)
+else()
+    target_link_libraries(jsoncpp_test jsoncpp_static)
 endif()
-target_link_libraries(jsoncpp_test jsoncpp_lib)
 
 # another way to solve issue #90
 #set_target_properties(jsoncpp_test PROPERTIES COMPILE_FLAGS -ffloat-store)


### PR DESCRIPTION
User @AMDmi3 put forward a requirement in issue #1170 , that is to use cmake to compile both static and shared libraries. After some investigation, I found that this is a very practical usage scenario. At the same time, I also know a common software usage scenario: In a large software system, the JSON parsing library(like JsonCpp) is the basic library of the system. Client may only need the `xxx.o` files of these basic libraries, and then link them into a shared library(`yyy.so` file) to use. Therefore, I made this patch.

During this time, I noticed the PR #827, I think the names of static libraries and dynamic libraries should be different. When users call them externally, they should be very clear about what type of libraries they are using, and a different names can guarantee this.
So, basically, the part of this patch is a rollback to that patch.

Cc: @cdunn2001 @hjmjohnson 