### PR TITLE
Fix generation of pkg-config file with absolute includedir/libdir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@
 
 # CMake-generated files:
 CMakeFiles/
-*.cmake
 /pkg-config/jsoncpp.pc
 jsoncpp_lib_static.dir/
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,8 @@ if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT DEFINED CMAKE_CONFIGURATION_TYPES)
         "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel Coverage.")
 endif()
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # ---------------------------------------------------------------------------
 # use ccache if found, has to be done before project()
 # ---------------------------------------------------------------------------
@@ -146,6 +148,11 @@ if(JSONCPP_WITH_WARNING_AS_ERROR)
 endif()
 
 if(JSONCPP_WITH_PKGCONFIG_SUPPORT)
+    include(JoinPaths)
+
+    join_paths(libdir_for_pc_file "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
+    join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
     configure_file(
         "pkg-config/jsoncpp.pc.in"
         "pkg-config/jsoncpp.pc"

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides a function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/pkg-config/jsoncpp.pc.in
+++ b/pkg-config/jsoncpp.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@libdir_for_pc_file@
+includedir=@includedir_for_pc_file@
 
 Name: jsoncpp
 Description: A C++ library for interacting with JSON


### PR DESCRIPTION
The CMake variables `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` are not guaranteed to be relative paths. If they are absolute, an invalid pkg-config file is generated.

See https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files for more information.