### PR TITLE
Fix cpp20 compatibility

### DIFF
--- a/include/json/allocator.h
+++ b/include/json/allocator.h
@@ -38,7 +38,7 @@ public:
    * The pointer argument is tagged as "volatile" to prevent the
    * compiler optimizing out this critical step.
    */
-  void deallocate(volatile pointer p, size_type n) {
+  void deallocate(pointer p, size_type n) {
     std::memset(p, 0, n * sizeof(T));
     // free using "global operator delete"
     ::operator delete(p);

--- a/include/json/allocator.h
+++ b/include/json/allocator.h
@@ -38,7 +38,7 @@ public:
    * The pointer argument is tagged as "volatile" to prevent the
    * compiler optimizing out this critical step.
    */
-  void deallocate(pointer p, size_type n) {
+  void deallocate(volatile pointer p, size_type n) {
     std::memset(p, 0, n * sizeof(T));
     // free using "global operator delete"
     ::operator delete(p);

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -918,8 +918,8 @@ public:
    *  because the returned references/pointers can be used
    *  to change state of the base class.
    */
-  reference operator*() { return deref(); }
-  pointer operator->() { return &deref(); }
+  reference operator*() const { return const_cast<reference>(deref()); }
+  pointer operator->() const { return const_cast<pointer>(&deref()); }
 };
 
 inline void swap(Value& a, Value& b) { a.swap(b); }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1817,7 +1817,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni = u8"\u5f0f\uff0c\u8fdb"; // "式，进"
+  const std::string uni = "式，进"; //u8"\u5f0f\uff0c\u8fdb"
   std::string styled;
   {
     Json::Value v;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3723,8 +3723,8 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, reverseIterator) {
   std::vector<std::string> values;
   using Iter = decltype(json.begin());
   auto re = std::reverse_iterator<Iter>(json.begin());
-  for (auto it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
-    values.push_back(it->asString());
+  for (std::reverse_iterator<Iter> it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
+    values.push_back((*it).asString());
   }
   JSONTEST_ASSERT((values == std::vector<std::string>{"b", "a"}));
 }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3373,7 +3373,7 @@ struct CharReaderAllowDropNullTest : JsonTest::TestCase {
   Value emptyArray = Value{Json::arrayValue};
 
   ValueCheck checkEq(const Value& v) {
-    return [=](const Value& root) { JSONTEST_ASSERT_EQUAL(root, v); };
+    return [=, this](const Value& root) { JSONTEST_ASSERT_EQUAL(root, v); };
   }
 
   static ValueCheck objGetAnd(std::string idx, ValueCheck f) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1817,7 +1817,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni = "式，进"; //u8"\u5f0f\uff0c\u8fdb"
+  const std::string uni = u8"\u5f0f\uff0c\u8fdb"; // "式，进"
   std::string styled;
   {
     Json::Value v;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3724,7 +3724,7 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, reverseIterator) {
   using Iter = decltype(json.begin());
   auto re = std::reverse_iterator<Iter>(json.begin());
   for (auto it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
-    values.push_back((*it).asString());
+    values.push_back(it->asString());
   }
   JSONTEST_ASSERT((values == std::vector<std::string>{"b", "a"}));
 }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2906,7 +2906,7 @@ JSONTEST_FIXTURE_LOCAL(ReaderTest, strictModeParseNumber) {
 
 JSONTEST_FIXTURE_LOCAL(ReaderTest, parseChineseWithOneError) {
   checkParse(R"({ "pr)"
-             "佐藤" // 佐藤
+             u8"\u4f50\u85e4" // 佐藤
              R"(erty" :: "value" })",
              {{18, 19, "Syntax error: value, object or array expected."}},
              "* Line 1, Column 19\n  Syntax error: value, object or array "
@@ -3008,7 +3008,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL("訪", root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL(u8"\u8A2a", root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3723,7 +3723,7 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, reverseIterator) {
   std::vector<std::string> values;
   using Iter = decltype(json.begin());
   auto re = std::reverse_iterator<Iter>(json.begin());
-  for (std::reverse_iterator<Iter> it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
+  for (auto it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
     values.push_back((*it).asString());
   }
   JSONTEST_ASSERT((values == std::vector<std::string>{"b", "a"}));

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2906,7 +2906,7 @@ JSONTEST_FIXTURE_LOCAL(ReaderTest, strictModeParseNumber) {
 
 JSONTEST_FIXTURE_LOCAL(ReaderTest, parseChineseWithOneError) {
   checkParse(R"({ "pr)"
-             u8"\u4f50\u85e4" // 佐藤
+             "佐藤" // 佐藤
              R"(erty" :: "value" })",
              {{18, 19, "Syntax error: value, object or array expected."}},
              "* Line 1, Column 19\n  Syntax error: value, object or array "
@@ -3008,7 +3008,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL(u8"\u8A2a", root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL("訪", root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3008,7 +3008,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL((const char*)u8"\u8A2a", root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL(reinterpret_cast<const char*>(u8"\u8A2a"), root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1817,7 +1817,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni = u8"\u5f0f\uff0c\u8fdb"; // "式，进"
+  const std::string uni = reinterpret_cast<const char*>(u8"\u5f0f\uff0c\u8fdb"); // "式，进"
   std::string styled;
   {
     Json::Value v;
@@ -2905,8 +2905,8 @@ JSONTEST_FIXTURE_LOCAL(ReaderTest, strictModeParseNumber) {
 }
 
 JSONTEST_FIXTURE_LOCAL(ReaderTest, parseChineseWithOneError) {
-  checkParse(R"({ "pr)"
-             u8"\u4f50\u85e4" // 佐藤
+  checkParse(R"({ "pr)" + 
+             std::string(reinterpret_cast<const char*>(u8"\u4f50\u85e4")) + // 佐藤
              R"(erty" :: "value" })",
              {{18, 19, "Syntax error: value, object or array expected."}},
              "* Line 1, Column 19\n  Syntax error: value, object or array "
@@ -3008,7 +3008,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL(u8"\u8A2a", root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL((const char*)u8"\u8A2a", root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";


### PR DESCRIPTION
These are some fixes for when compiling under C++20 with gcc-10

They should all get a double-check, because I can't understand why some of them were errors.

The string ones were because of an introduction of std::u8string. But I didn't dig deeper than that.

The deprecated capture of "this in lambda was straight forward, I only had to add the additional capture.

The removal of the volatile keyword should be okay, but I don't know enough about the codebase to know why it was there in the first place.

For the last commit, I don't know why I had to do what I did.
(*it).asString() should be equal to it->asString.
But I got an error about (it) not being a pointer type
