### PR TITLE
#1209 add parseFromString to avoid unnecessary stringstream content copy

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ ds283 <D.Seery@sussex.ac.uk>
 Egor Tensin <Egor.Tensin@gmail.com>
 eightnoteight <mr.eightnoteight@gmail.com>
 Evince <baneyue@gmail.com>
+Fedor Moiseev <fedormsv@gmail.com>
 filipjs <filipjs@users.noreply.github.com>
 findblar <ft@finbarr.ca>
 Florian Meier <florian.meier@koalo.de>

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -359,6 +359,20 @@ public:
   static void strictMode(Json::Value* settings);
 };
 
+/** Consume entire string and use its begin/end.
+ * Someday we might have a real StreamReader, but for now this
+ * is convenient.
+ */
+bool JSON_API parseFromString(CharReader::Factory const&, char const* str, size_t len, Value* root,
+                                 String* errs);
+
+/** Consume entire string and use its begin/end.
+ * Someday we might have a real StreamReader, but for now this
+ * is convenient.
+ */
+bool JSON_API parseFromString(CharReader::Factory const&,const String&, Value* root,
+                              String* errs);
+
 /** Consume entire stream and use its begin/end.
  * Someday we might have a real StreamReader, but for now this
  * is convenient.

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1968,16 +1968,27 @@ void CharReaderBuilder::setDefaults(Json::Value* settings) {
 //////////////////////////////////
 // global functions
 
+bool parseFromString(CharReader::Factory const& fact, char const* str, size_t len, Value* root,
+                     String* errs) {
+    char const* begin = str;
+    char const* end = str + len;
+    // Note that we do not actually need a null-terminator.
+    CharReaderPtr const reader(fact.newCharReader());
+    return reader->parse(begin, end, root, errs);
+}
+
+bool parseFromString(CharReader::Factory const& fact, const String& doc, Value* root,
+                     String* errs) {
+  // Note that we do not actually need a null-terminator.
+  return parseFromString(fact, doc.data(), doc.size(), root, errs);
+}
+
 bool parseFromStream(CharReader::Factory const& fact, IStream& sin, Value* root,
                      String* errs) {
   OStringStream ssin;
   ssin << sin.rdbuf();
   String doc = ssin.str();
-  char const* begin = doc.data();
-  char const* end = begin + doc.size();
-  // Note that we do not actually need a null-terminator.
-  CharReaderPtr const reader(fact.newCharReader());
-  return reader->parse(begin, end, root, errs);
+  return parseFromString(fact, doc, root, errs);
 }
 
 IStream& operator>>(IStream& sin, Value& root) {


### PR DESCRIPTION
functions for parsing directly from string, without unnecessary pass through string->stringstream->string pipeline