### PR TITLE
Fix a precision bug of valueToString, prevent to give an error result…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /libs/
 /doc/doxyfile
 /dist/
+/.cache/
 
 # MSVC project files:
 *.sln
@@ -30,6 +31,7 @@
 CMakeFiles/
 /pkg-config/jsoncpp.pc
 jsoncpp_lib_static.dir/
+compile_commands.json
 
 # In case someone runs cmake in the root-dir:
 /CMakeCache.txt

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -124,7 +124,7 @@ Iter fixZerosInTheEnd(Iter begin, Iter end, unsigned int precision) {
     }
     // Don't delete the last zero before the decimal point.
     if (begin != (end - 1) && begin != (end - 2) && *(end - 2) == '.') {
-      if(precision) {
+      if (precision) {
         return end;
       }
       return end - 2;

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -116,14 +116,18 @@ template <typename Iter> void fixNumericLocaleInput(Iter begin, Iter end) {
  * Return iterator that would be the new end of the range [begin,end), if we
  * were to delete zeros in the end of string, but not the last zero before '.'.
  */
-template <typename Iter> Iter fixZerosInTheEnd(Iter begin, Iter end) {
+template <typename Iter> Iter fixZerosInTheEnd(Iter begin, Iter end,unsigned int precision) {
   for (; begin != end; --end) {
     if (*(end - 1) != '0') {
       return end;
     }
     // Don't delete the last zero before the decimal point.
-    if (begin != (end - 1) && *(end - 2) == '.') {
-      return end;
+    if (begin != (end - 1) && begin != (end - 2) && *(end - 2) == '.') {
+      if(precision)
+      {
+        return end;
+      }
+      return end - 2;
     }
   }
   return end;

--- a/src/lib_json/json_tool.h
+++ b/src/lib_json/json_tool.h
@@ -116,15 +116,15 @@ template <typename Iter> void fixNumericLocaleInput(Iter begin, Iter end) {
  * Return iterator that would be the new end of the range [begin,end), if we
  * were to delete zeros in the end of string, but not the last zero before '.'.
  */
-template <typename Iter> Iter fixZerosInTheEnd(Iter begin, Iter end,unsigned int precision) {
+template <typename Iter>
+Iter fixZerosInTheEnd(Iter begin, Iter end, unsigned int precision) {
   for (; begin != end; --end) {
     if (*(end - 1) != '0') {
       return end;
     }
     // Don't delete the last zero before the decimal point.
     if (begin != (end - 1) && begin != (end - 2) && *(end - 2) == '.') {
-      if(precision)
-      {
+      if(precision) {
         return end;
       }
       return end - 2;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -154,16 +154,17 @@ String valueToString(double value, bool useSpecialFloats,
 
   buffer.erase(fixNumericLocale(buffer.begin(), buffer.end()), buffer.end());
 
-  // strip the zero padding from the right
-  if (precisionType == PrecisionType::decimalPlaces) {
-    buffer.erase(fixZerosInTheEnd(buffer.begin(), buffer.end()), buffer.end());
-  }
-
   // try to ensure we preserve the fact that this was given to us as a double on
   // input
   if (buffer.find('.') == buffer.npos && buffer.find('e') == buffer.npos) {
     buffer += ".0";
   }
+
+  // strip the zero padding from the right
+  if (precisionType == PrecisionType::decimalPlaces) {
+    buffer.erase(fixZerosInTheEnd(buffer.begin(), buffer.end(), precision), buffer.end());
+  }
+
   return buffer;
 }
 } // namespace

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -163,7 +163,7 @@ String valueToString(double value, bool useSpecialFloats,
   // strip the zero padding from the right
   if (precisionType == PrecisionType::decimalPlaces) {
     buffer.erase(fixZerosInTheEnd(buffer.begin(), buffer.end(), precision),
-            buffer.end());
+                 buffer.end());
   }
 
   return buffer;

--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -162,7 +162,8 @@ String valueToString(double value, bool useSpecialFloats,
 
   // strip the zero padding from the right
   if (precisionType == PrecisionType::decimalPlaces) {
-    buffer.erase(fixZerosInTheEnd(buffer.begin(), buffer.end(), precision), buffer.end());
+    buffer.erase(fixZerosInTheEnd(buffer.begin(), buffer.end(), precision),
+            buffer.end());
   }
 
   return buffer;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2033,13 +2033,6 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, precision) {
   result = Json::writeString(b, v);
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
-  b.settings_["precision"] = 0;
-  b.settings_["precisionType"] = "decimal";
-  v = 1230.5;
-  expected = "1230";
-  result = Json::writeString(b, v);
-  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
-
   b.settings_["precision"] = 10;
   b.settings_["precisionType"] = "decimal";
   v = 0.23300000;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2005,6 +2005,41 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, precision) {
   result = Json::writeString(b, v);
   JSONTEST_ASSERT_STRING_EQUAL(expected, result);
 
+  b.settings_["precision"] = 0;
+  b.settings_["precisionType"] = "decimal";
+  v = 123.56345694873740545068;
+  expected = "124";
+  result = Json::writeString(b, v);
+  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+  b.settings_["precision"] = 1;
+  b.settings_["precisionType"] = "decimal";
+  v = 1230.001;
+  expected = "1230.0";
+  result = Json::writeString(b, v);
+  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+  b.settings_["precision"] = 0;
+  b.settings_["precisionType"] = "decimal";
+  v = 1230.001;
+  expected = "1230";
+  result = Json::writeString(b, v);
+  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+  b.settings_["precision"] = 0;
+  b.settings_["precisionType"] = "decimal";
+  v = 1231.5;
+  expected = "1232";
+  result = Json::writeString(b, v);
+  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
+  b.settings_["precision"] = 0;
+  b.settings_["precisionType"] = "decimal";
+  v = 1230.5;
+  expected = "1230";
+  result = Json::writeString(b, v);
+  JSONTEST_ASSERT_STRING_EQUAL(expected, result);
+
   b.settings_["precision"] = 10;
   b.settings_["precisionType"] = "decimal";
   v = 0.23300000;


### PR DESCRIPTION
Fix a precision bug of valueToString, prevent to give an error result on input of wanted precision 0 and a double value which end of zero before decimal point ,such as 1230.01,12300.1;
Add test cases for double valueToString with precision 0;