### PR TITLE
Fix Visual Studio warning C4275

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -50,7 +50,7 @@
 // be used by...
 #if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 #pragma warning(push)
-#pragma warning(disable : 4251)
+#pragma warning(disable : 4251 4275)
 #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 
 #pragma pack(push, 8)


### PR DESCRIPTION
Disable Visual Studio warning C4275 (std::exception used as base…class in dll-interface class) together with C4251, when building as DLL and JSONCPP_DISABLE_DLL_INTERFACE_WARNING is defined.

This PR relates as well to issue https://github.com/open-source-parsers/jsoncpp/issues/730