### PR TITLE
Add support for Bazel build system

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,37 @@
+licenses(["unencumbered"])  # Public Domain or MIT
+
+exports_files(["LICENSE"])
+
+cc_library(
+    name = "jsoncpp",
+    srcs = [
+        "src/lib_json/json_reader.cpp",
+        "src/lib_json/json_tool.h",
+        "src/lib_json/json_value.cpp",
+        "src/lib_json/json_writer.cpp",
+    ],
+    hdrs = [
+        "include/json/allocator.h",
+        "include/json/assertions.h",
+        "include/json/config.h",
+        "include/json/json_features.h",
+        "include/json/forwards.h",
+        "include/json/json.h",
+        "include/json/reader.h",
+        "include/json/value.h",
+        "include/json/version.h",
+        "include/json/writer.h",
+    ],
+    copts = [
+        "-DJSON_USE_EXCEPTION=0",
+        "-DJSON_HAS_INT64",
+    ],
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+    deps = [":private"],
+)
+
+cc_library(
+    name = "private",
+    textual_hdrs = ["src/lib_json/json_valueiterator.inl"],
+)


### PR DESCRIPTION
Adds support for using JsonCpp as an external package in [Bazel](https://www.bazel.build/) projects.

Tested in https://github.com/google/verible by replacing:

```
http_archive(
    name = "jsoncpp_git",
    sha256 = "77a402fb577b2e0e5d0bdc1cf9c65278915cdb25171e3452c68b6da8a561f8f0",
    build_file = "//bazel:jsoncpp.BUILD",
    strip_prefix = "jsoncpp-1.9.2",
    urls = [
        "https://github.com/open-source-parsers/jsoncpp/archive/1.9.2.tar.gz",
    ],
)
```

with:

```
git_repository(
    name = "jsoncpp_git",
    branch = "mglb/bazel-support",
    remote = "https://github.com/mglb/jsoncpp.git",
)
```

in `WORKSPACE` file, and then running `bazel clean; bazel test //...`