### PR TITLE
Rearrange Comments::set

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1398,7 +1398,7 @@ String Value::Comments::get(CommentPlacement slot) const {
 }
 
 void Value::Comments::set(CommentPlacement slot, String comment) {
-  if (slot < CommentPlacement::numberOfCommentPlacement)
+  if (slot >= CommentPlacement::numberOfCommentPlacement)
     return;
   if (!ptr_)
     ptr_ = std::unique_ptr<Array>(new Array());

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1398,13 +1398,11 @@ String Value::Comments::get(CommentPlacement slot) const {
 }
 
 void Value::Comments::set(CommentPlacement slot, String comment) {
-  if (!ptr_) {
+  if (slot < CommentPlacement::numberOfCommentPlacement)
+    return;
+  if (!ptr_)
     ptr_ = std::unique_ptr<Array>(new Array());
-  }
-  // check comments array boundry.
-  if (slot < CommentPlacement::numberOfCommentPlacement) {
-    (*ptr_)[slot] = std::move(comment);
-  }
+  (*ptr_)[slot] = std::move(comment);
 }
 
 void Value::setComment(String comment, CommentPlacement placement) {


### PR DESCRIPTION
Avoid allocation if the set is going to be rejected anyway.

Prototype suggestion from #1277 review thread