### PR TITLE
Expose getLocationLineAndColumn() as a public API

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -392,6 +392,12 @@ bool JSON_API parseFromStream(CharReader::Factory const&, IStream&, Value* root,
  */
 JSON_API IStream& operator>>(IStream&, Value&);
 
+/** Get the line and column of a character within a string.
+ */
+void JSON_API getLocationLineAndColumn(char const* beginDoc, char const* endDoc,
+                                       ptrdiff_t location, int& line,
+                                       int& column);
+
 } // namespace Json
 
 #pragma pack(pop)

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -761,24 +761,9 @@ Reader::Char Reader::getNextChar() {
 
 void Reader::getLocationLineAndColumn(Location location, int& line,
                                       int& column) const {
-  Location current = begin_;
-  Location lastLineStart = current;
-  line = 0;
-  while (current < location && current != end_) {
-    Char c = *current++;
-    if (c == '\r') {
-      if (*current == '\n')
-        ++current;
-      lastLineStart = current;
-      ++line;
-    } else if (c == '\n') {
-      lastLineStart = current;
-      ++line;
-    }
-  }
-  // column & line start at 1
-  column = int(location - lastLineStart) + 1;
-  ++line;
+  Json::getLocationLineAndColumn(document_.data(),
+                                 document_.data() + document_.length(),
+                                 location - document_.data(), line, column);
 }
 
 String Reader::getLocationLineAndColumn(Location location) const {
@@ -1988,6 +1973,28 @@ IStream& operator>>(IStream& sin, Value& root) {
     throwRuntimeError(errs);
   }
   return sin;
+}
+
+void getLocationLineAndColumn(char const* beginDoc, char const* endDoc,
+                              ptrdiff_t location, int& line, int& column) {
+  char const* current = beginDoc;
+  char const* lastLineStart = current;
+  line = 0;
+  while (current < beginDoc + location && current < endDoc) {
+    char c = *current++;
+    if (c == '\r') {
+      if (*current == '\n')
+        ++current;
+      lastLineStart = current;
+      ++line;
+    } else if (c == '\n') {
+      lastLineStart = current;
+      ++line;
+    }
+  }
+  // column & line start at 1
+  column = int(beginDoc + location - lastLineStart) + 1;
+  ++line;
 }
 
 } // namespace Json

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -3903,6 +3903,28 @@ JSONTEST_FIXTURE_LOCAL(FuzzTest, fuzzDoesntCrash) {
                              example.size()));
 }
 
+struct GetLocationLineAndColumnTest : JsonTest::TestCase {
+  void testLineAndColumn(const std::string& doc, ptrdiff_t location, int row,
+                         int column) {
+    int actualRow;
+    int actualColumn;
+    Json::getLocationLineAndColumn(doc.data(), doc.data() + doc.length(),
+                                   location, actualRow, actualColumn);
+    JSONTEST_ASSERT_EQUAL(row, actualRow);
+    JSONTEST_ASSERT_EQUAL(column, actualColumn);
+  }
+};
+
+JSONTEST_FIXTURE_LOCAL(GetLocationLineAndColumnTest, test) {
+  const std::string example = "line 1\nline 2\r\nline 3\rline 4";
+  testLineAndColumn(example, 0, 1, 1);
+  testLineAndColumn(example, 6, 1, 7);
+  testLineAndColumn(example, 8, 2, 2);
+  testLineAndColumn(example, 14, 3, 0);
+  testLineAndColumn(example, 15, 3, 1);
+  testLineAndColumn(example, 25, 4, 4);
+}
+
 int main(int argc, const char* argv[]) {
   JsonTest::Runner runner;
 


### PR DESCRIPTION
`getLocationLineAndColumn()` is an internal API used by the error string code, but clients which use `Json::Value::getOffsetStart()` and `Json::Value::getOffsetLimit()` may want to use `getLocationLineAndColumn()` to turn the offset into a line and column. Expose the function as an external API.