### PR TITLE
CMake: Remove ancient version checks

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -11,20 +11,10 @@ include(CheckCXXSymbolExists)
 check_include_file_cxx(clocale HAVE_CLOCALE)
 check_cxx_symbol_exists(localeconv clocale HAVE_LOCALECONV)
 
-if(CMAKE_VERSION VERSION_LESS 3.0.0)
-    # The "LANGUAGE CXX" parameter is not supported in CMake versions below 3,
-    # so the C compiler and header has to be used.
-    check_include_file(locale.h HAVE_LOCALE_H)
-    set(CMAKE_EXTRA_INCLUDE_FILES locale.h)
-    check_type_size("struct lconv" LCONV_SIZE)
-    unset(CMAKE_EXTRA_INCLUDE_FILES)
-    check_struct_has_member("struct lconv" decimal_point locale.h HAVE_DECIMAL_POINT)
-else()
-    set(CMAKE_EXTRA_INCLUDE_FILES clocale)
-    check_type_size(lconv LCONV_SIZE LANGUAGE CXX)
-    unset(CMAKE_EXTRA_INCLUDE_FILES)
-    check_struct_has_member(lconv decimal_point clocale HAVE_DECIMAL_POINT LANGUAGE CXX)
-endif()
+set(CMAKE_EXTRA_INCLUDE_FILES clocale)
+check_type_size(lconv LCONV_SIZE LANGUAGE CXX)
+unset(CMAKE_EXTRA_INCLUDE_FILES)
+check_struct_has_member(lconv decimal_point clocale HAVE_DECIMAL_POINT LANGUAGE CXX)
 
 if(NOT (HAVE_CLOCALE AND HAVE_LCONV_SIZE AND HAVE_DECIMAL_POINT AND HAVE_LOCALECONV))
     message(WARNING "Locale functionality is not supported")
@@ -139,13 +129,11 @@ if(BUILD_SHARED_LIBS)
 
     target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
 
-    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-        target_include_directories(${SHARED_LIB} PUBLIC
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-        )
-    endif()
+    target_include_directories(${SHARED_LIB} PUBLIC
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+    )
 
     list(APPEND CMAKE_TARGETS ${SHARED_LIB})
 endif()
@@ -175,13 +163,11 @@ if(BUILD_STATIC_LIBS)
 
     target_compile_features(${STATIC_LIB} PUBLIC ${REQUIRED_FEATURES})
 
-    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-        target_include_directories(${STATIC_LIB} PUBLIC
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-        )
-    endif()
+    target_include_directories(${STATIC_LIB} PUBLIC
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+    )
 
     list(APPEND CMAKE_TARGETS ${STATIC_LIB})
 endif()
@@ -204,13 +190,11 @@ if(BUILD_OBJECT_LIBS)
 
     target_compile_features(${OBJECT_LIB} PUBLIC ${REQUIRED_FEATURES})
 
-    if(NOT CMAKE_VERSION VERSION_LESS 2.8.11)
-        target_include_directories(${OBJECT_LIB} PUBLIC
-            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-            $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-        )
-    endif()
+    target_include_directories(${OBJECT_LIB} PUBLIC
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
+    )
 
     list(APPEND CMAKE_TARGETS ${OBJECT_LIB})
 endif()


### PR DESCRIPTION
The minimum version for the project is CMake 3.8.0 (as set in `cmake_minimum_required()` at the top of the root `CMakeLists.txt`), so there's no point in keeping legacy code for pre-3.0 or pre-2.8 CMake.