### PR TITLE
Create aliases with name space for static and shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,6 @@ if(JSONCPP_WITH_CMAKE_PACKAGE)
         COMPATIBILITY SameMajorVersion)
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfig.cmake
-        ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp-namespaced-targets.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp)
 endif()
 

--- a/jsoncpp-namespaced-targets.cmake
+++ b/jsoncpp-namespaced-targets.cmake
@@ -1,7 +1,0 @@
-if (TARGET jsoncpp_static)
-    add_library(JsonCpp::JsonCpp INTERFACE IMPORTED)
-    set_target_properties(JsonCpp::JsonCpp PROPERTIES INTERFACE_LINK_LIBRARIES "jsoncpp_static")
-elseif (TARGET jsoncpp_lib)
-    add_library(JsonCpp::JsonCpp INTERFACE IMPORTED)
-    set_target_properties(JsonCpp::JsonCpp PROPERTIES INTERFACE_LINK_LIBRARIES "jsoncpp_lib")
-endif ()

--- a/jsoncppConfig.cmake.in
+++ b/jsoncppConfig.cmake.in
@@ -4,7 +4,6 @@ cmake_policy(VERSION 3.0)
 @PACKAGE_INIT@
 
 include ( "${CMAKE_CURRENT_LIST_DIR}/jsoncpp-targets.cmake" )
-include ( "${CMAKE_CURRENT_LIST_DIR}/jsoncpp-namespaced-targets.cmake" )
 
 check_required_components(JsonCpp)
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -115,6 +115,7 @@ if(BUILD_SHARED_LIBS)
 
     set(SHARED_LIB ${PROJECT_NAME}_lib)
     add_library(${SHARED_LIB} SHARED ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+    add_library(JsonCpp::JsonCpp ALIAS ${SHARED_LIB})
     set_target_properties(${SHARED_LIB} PROPERTIES
         OUTPUT_NAME jsoncpp
         VERSION ${PROJECT_VERSION}
@@ -141,6 +142,7 @@ endif()
 if(BUILD_STATIC_LIBS)
     set(STATIC_LIB ${PROJECT_NAME}_static)
     add_library(${STATIC_LIB} STATIC ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+    add_library(JsonCpp::JsonCpp ALIAS ${STATIC_LIB})
 
     # avoid name clashes on windows as the shared import lib is alse named jsoncpp.lib
     if(NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)


### PR DESCRIPTION
The previously, used add_library in the removed cmake file is something similar but it causes trouble when having jsoncpp included with cmake fetch_content.

Furthermore, alias is the simple way to go.
