### PR TITLE
minor fix for code examples

### DIFF
--- a/example/readFromString/readFromString.cpp
+++ b/example/readFromString/readFromString.cpp
@@ -1,5 +1,6 @@
 #include "json/json.h"
 #include <iostream>
+#include <memory>
 /**
  * \brief Parse a raw string into Value object using the CharReaderBuilder
  * class, or the legacy Reader class.

--- a/example/streamWrite/streamWrite.cpp
+++ b/example/streamWrite/streamWrite.cpp
@@ -1,5 +1,6 @@
 #include "json/json.h"
 #include <iostream>
+#include <memory>
 /** \brief Write the Value object to a stream.
  * Example Usage:
  * $g++ streamWrite.cpp -ljsoncpp -std=c++11 -o streamWrite


### PR DESCRIPTION
Noticed these two examples use unique_ptr but forgot to include \<memory\>