### PR TITLE
Document skipBom in CharReaderBuilder

### DIFF
--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -325,7 +325,8 @@ public:
    *   - If true, special float values (NaNs and infinities) are allowed and
    *     their values are lossfree restorable.
    * - `"skipBom": false or true`
-   *   - If true, if the input starts with the Unicode byte order mark (BOM), it is skipped.
+   *   - If true, if the input starts with the Unicode byte order mark (BOM),
+         it is skipped.
    *
    * You can examine 'settings_` yourself to see the defaults. You can also
    * write and read them just like any JSON Value.

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -326,7 +326,7 @@ public:
    *     their values are lossfree restorable.
    * - `"skipBom": false or true`
    *   - If true, if the input starts with the Unicode byte order mark (BOM),
-         it is skipped.
+  *      it is skipped.
    *
    * You can examine 'settings_` yourself to see the defaults. You can also
    * write and read them just like any JSON Value.

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -324,6 +324,8 @@ public:
    * - `"allowSpecialFloats": false or true`
    *   - If true, special float values (NaNs and infinities) are allowed and
    *     their values are lossfree restorable.
+   * - `"skipBom": false or true`
+   *   - If true, if the input starts with the Unicode byte order mark (BOM), it is skipped.
    *
    * You can examine 'settings_` yourself to see the defaults. You can also
    * write and read them just like any JSON Value.

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -326,7 +326,7 @@ public:
    *     their values are lossfree restorable.
    * - `"skipBom": false or true`
    *   - If true, if the input starts with the Unicode byte order mark (BOM),
-  *      it is skipped.
+   *     it is skipped.
    *
    * You can examine 'settings_` yourself to see the defaults. You can also
    * write and read them just like any JSON Value.


### PR DESCRIPTION
This was introduced in #1149 (and renamed in #1162) but as far as I can tell it was never documented.