### PR TITLE
Fix SEGV crash caused by Value(s) appended to itself.

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1128,6 +1128,8 @@ Value& Value::append(const Value& value) { return append(Value(value)); }
 Value& Value::append(Value&& value) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
                       "in Json::Value::append: requires arrayValue");
+  JSON_ASSERT_MESSAGE(&value != this,
+                      "in Json::Value::append: appending self using move constructor is forbidden.");
   if (type() == nullValue) {
     *this = Value(arrayValue);
   }

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2136,6 +2136,10 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, searchValueByPath) {
     JSONTEST_ASSERT_STRING_EQUAL(expected, outcome);
   }
 }
+JSONTEST_FIXTURE_LOCAL(ValueTest, valueAppendingSelf) {
+  Json::Value value1{Json::ValueType::nullValue}, value2;
+  JSONTEST_ASSERT_THROWS(value2 = value1.append(std::move(value1)));
+}
 struct FastWriterTest : JsonTest::TestCase {};
 
 JSONTEST_FIXTURE_LOCAL(FastWriterTest, dropNullPlaceholders) {


### PR DESCRIPTION
Hi,
I found that we could get an infinite recursion of `dupPayload` call 
when we copy a `Value` using copy constructor on a `Value` that appended to itself.
We could make such `Value` by using the `append(Value&& value)` API, as shown in the following example:

```c++
Json::ValueType valuetype0 = Json::ValueType::nullValue;
Json::Value value1{valuetype0};
const Json::Value &value2 = value1.append(std::move(value1));
Json::Value value3 = value2; // infinite recursion here
```

Let me know if there is more I can help with this patch.
Thank you.