### PR TITLE
Fix parsing `[]` in JSONPath

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1538,7 +1538,7 @@ void Path::makePath(const String& path, const InArgs& in) {
           index = index * 10 + ArrayIndex(*current - '0');
         args_.push_back(index);
       }
-      if (current == end || *++current != ']')
+      if (current == end || *current != ']')
         invalidPath(path, int(current - path.c_str()));
     } else if (*current == '%') {
       addPathInArg(path, in, itInArg, PathArgument::kindKey);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1535,6 +1535,8 @@ void Path::makePath(const String& path, const InArgs& in) {
         ++current;
       } else {
         ArrayIndex index = 0;
+        if (current == end || *current < '0' || *current > '9')
+          invalidPath(path, int(current - path.c_str()));
         for (; current != end && *current >= '0' && *current <= '9'; ++current)
           index = index * 10 + ArrayIndex(*current - '0');
         args_.push_back(index);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1530,7 +1530,7 @@ void Path::makePath(const String& path, const InArgs& in) {
   while (current != end) {
     if (*current == '[') {
       ++current;
-      if (*current == '%') {
+      if (current != end && *current == '%') {
         addPathInArg(path, in, itInArg, PathArgument::kindIndex);
         ++current;
       } else {

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1530,9 +1530,10 @@ void Path::makePath(const String& path, const InArgs& in) {
   while (current != end) {
     if (*current == '[') {
       ++current;
-      if (*current == '%')
+      if (*current == '%') {
         addPathInArg(path, in, itInArg, PathArgument::kindIndex);
-      else {
+        ++current;
+      } else {
         ArrayIndex index = 0;
         for (; current != end && *current >= '0' && *current <= '9'; ++current)
           index = index * 10 + ArrayIndex(*current - '0');

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2138,23 +2138,21 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, searchValueByPath) {
   }
   {
     const Json::String expected("{"
-                                "\"property1\":[0,1,null],"
-                                "\"property2\":{"
-                                "\"hello\":null,"
-                                "\"object\":\"object\"},"
-                                "\"property3\":[[0,1,null],[2,3]]"
+                                "\"property1\":[0,1],"
+                                "\"property2\":{\"object\":\"object\"},"
+                                "\"property3\":[[0,1],[2,3]]"
                                 "}\n");
-    Json::Path path1(".property1.[%]", 2);
-    Json::Value& value1 = path1.make(root);
-    JSONTEST_ASSERT_EQUAL(Json::nullValue, value1);
-
-    Json::Path path2(".property2.%", "hello");
-    Json::Value& value2 = path2.make(root);
-    JSONTEST_ASSERT_EQUAL(Json::nullValue, value2);
-
-    Json::Path path3(".property3[0][%]", 2);
-    Json::Value& value3 = path3.make(root);
-    JSONTEST_ASSERT_EQUAL(Json::nullValue, value3);
+    Json::Path cases[] = {
+        Json::Path(".property1.[%]", 2),
+        Json::Path(".property2.%", "hello"),
+        Json::Path(".property3.[0][%]", 2),
+    };
+    for (const auto& path : cases) {
+        Json::Value rootCopy(root);
+        Json::Value v(12345);
+        path.make(rootCopy) = v;
+        JSONTEST_ASSERT_EQUAL(path.resolve(rootCopy), v);
+    };
 
     // make will change the value
     const Json::String outcome = writer.write(root);

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2140,8 +2140,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, searchValueByPath) {
     const Json::String expected("{"
                                 "\"property1\":[0,1,null],"
                                 "\"property2\":{"
-                                  "\"hello\":null,"
-                                  "\"object\":\"object\"},"
+                                "\"hello\":null,"
+                                "\"object\":\"object\"},"
                                 "\"property3\":[[0,1,null],[2,3]]"
                                 "}\n");
     Json::Path path1(".property1.[%]", 2);


### PR DESCRIPTION
There is no need `++` since we already `++current` on parsing number