### PR TITLE
Fix POSITION_INDEPENDENT_CODE

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -119,7 +119,7 @@ if(BUILD_SHARED_LIBS)
         OUTPUT_NAME jsoncpp
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ON
+        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
     )
 
     # Set library's runtime search path on OSX
@@ -180,7 +180,7 @@ if(BUILD_OBJECT_LIBS)
         OUTPUT_NAME jsoncpp
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ON
+        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
     )
 
     # Set library's runtime search path on OSX


### PR DESCRIPTION
## Description
This PR just fixed a wrong configuration in the `cmake` files with the `POSITION_INDEPENDENT_CODE`, it should be just enabled when the `BUILD_SHARED_LIBS` config is enabled as well.

The specific details about the issue can be found here:
#1344 

Thanks