### PR TITLE
Better support for modern CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ compile_commands.json
 *.a
 
 # eclipse project files
+.idea/
 .project
 .cproject
 /.settings/
@@ -55,3 +56,4 @@ compile_commands.json
 
 # temps
 /version
+cmake-build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,12 +40,6 @@ foreach(pold "") # Currently Empty
     endif()
 endforeach()
 
-# Build the library with C++11 standard support, independent from other including
-# software which may use a different CXX_STANDARD or CMAKE_CXX_STANDARD.
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Ensure that CMAKE_BUILD_TYPE has a value specified for single configuration generators.
 if(NOT DEFINED CMAKE_BUILD_TYPE AND NOT DEFINED CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Release CACHE STRING
@@ -116,9 +110,6 @@ macro(use_compilation_warning_as_error)
         endif()
     endif()
 endmacro()
-
-# Include our configuration header
-include_directories(${jsoncpp_SOURCE_DIR}/include)
 
 if(MSVC)
     # Only enabled in debug because some old versions of VS STL generate

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,11 +98,6 @@ option(JSONCPP_BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." OFF)
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Archive output dir.")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Library output dir.")
-set(CMAKE_PDB_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/bin" CACHE PATH "PDB (MSVC debug symbol)output dir.")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Executable/dll output dir.")
-
 set(JSONCPP_USE_SECURE_MEMORY "0" CACHE STRING "-D...=1 to use memory-wiping allocator for STL")
 
 configure_file("${PROJECT_SOURCE_DIR}/version.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,9 @@ project(jsoncpp
 message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
 set(PROJECT_SOVERSION 25)
 
+# Defines the project root to be used throughout all scripts.
+SET(JSONCPP_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 include(${CMAKE_CURRENT_SOURCE_DIR}/include/PreventInSourceBuilds.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/include/PreventInBuildInstalls.cmake)
 
@@ -89,9 +92,8 @@ option(JSONCPP_WITH_PKGCONFIG_SUPPORT "Generate and install .pc files" ON)
 option(JSONCPP_WITH_CMAKE_PACKAGE "Generate and install cmake package files" ON)
 option(JSONCPP_WITH_EXAMPLE "Compile JsonCpp example" OFF)
 option(JSONCPP_STATIC_WINDOWS_RUNTIME "Use static (MT/MTd) Windows runtime" OFF)
-option(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." ON)
-option(BUILD_STATIC_LIBS "Build jsoncpp_lib as a static library." ON)
-option(BUILD_OBJECT_LIBS "Build jsoncpp_lib as a object library." ON)
+
+option(JSONCPP_BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." OFF)
 
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
@@ -179,22 +181,6 @@ if(JSONCPP_WITH_PKGCONFIG_SUPPORT)
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif()
 
-if(JSONCPP_WITH_CMAKE_PACKAGE)
-    include(CMakePackageConfigHelpers)
-    install(EXPORT jsoncpp
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp
-        FILE        jsoncpp-targets.cmake)
-    configure_package_config_file(jsoncppConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfig.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp)
-
-    write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfigVersion.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion)
-    install(FILES
-        ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfigVersion.cmake ${CMAKE_CURRENT_BINARY_DIR}/jsoncppConfig.cmake
-        ${CMAKE_CURRENT_SOURCE_DIR}/jsoncpp-namespaced-targets.cmake
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jsoncpp)
-endif()
 
 if(JSONCPP_WITH_TESTS)
     enable_testing()
@@ -203,9 +189,6 @@ endif()
 
 # Build the different applications
 add_subdirectory(src)
-
-#install the includes
-add_subdirectory(include)
 
 #install the example
 if(JSONCPP_WITH_EXAMPLE)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,27 +1,6 @@
 #vim: et ts =4 sts = 4 sw = 4 tw = 0
-set(EXAMPLES
-    readFromString
-    readFromStream
-    stringWrite
-    streamWrite
-)
-add_definitions(-D_GLIBCXX_USE_CXX11_ABI)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    add_compile_options(-Wall -Wextra)
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    add_definitions(
-        -D_SCL_SECURE_NO_WARNINGS
-        -D_CRT_SECURE_NO_WARNINGS
-        -D_WIN32_WINNT=0x601
-        -D_WINSOCK_DEPRECATED_NO_WARNINGS
-    )
-endif()
-
-foreach(example ${EXAMPLES})
-    add_executable(${example} ${example}/${example}.cpp)
-    target_include_directories(${example} PUBLIC ${CMAKE_SOURCE_DIR}/include)
-    target_link_libraries(${example} jsoncpp_lib)
-endforeach()
-
-add_custom_target(examples ALL DEPENDS ${EXAMPLES})
+ADD_SUBDIRECTORY(readFromStream/)
+ADD_SUBDIRECTORY(readFromString/)
+ADD_SUBDIRECTORY(streamWrite/)
+ADD_SUBDIRECTORY(stringWrite/)

--- a/example/readFromStream/CMakeLists.txt
+++ b/example/readFromStream/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_executable(readFromStream readFromStream.cpp)
-target_include_directories(readFromStream PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(readFromStream jsoncpp_lib)
+ADD_EXECUTABLE(readFromStream readFromStream.cpp)
+TARGET_LINK_LIBRARIES(readFromStream PRIVATE jsoncpp::framework)

--- a/example/readFromStream/CMakeLists.txt
+++ b/example/readFromStream/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(readFromStream readFromStream.cpp)
+target_include_directories(readFromStream PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(readFromStream jsoncpp_lib)

--- a/example/readFromString/CMakeLists.txt
+++ b/example/readFromString/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(readFromString readFromString.cpp)
+target_include_directories(readFromString PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(readFromString jsoncpp_lib)

--- a/example/readFromString/CMakeLists.txt
+++ b/example/readFromString/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_executable(readFromString readFromString.cpp)
-target_include_directories(readFromString PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(readFromString jsoncpp_lib)
+ADD_EXECUTABLE(readFromString readFromString.cpp)
+TARGET_LINK_LIBRARIES(readFromString PRIVATE jsoncpp::framework)

--- a/example/streamWrite/CMakeLists.txt
+++ b/example/streamWrite/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_executable(streamWrite streamWrite.cpp)
-target_include_directories(streamWrite PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(streamWrite jsoncpp_lib)
+ADD_EXECUTABLE(streamWrite streamWrite.cpp)
+TARGET_LINK_LIBRARIES(streamWrite PRIVATE jsoncpp::framework)

--- a/example/streamWrite/CMakeLists.txt
+++ b/example/streamWrite/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(streamWrite streamWrite.cpp)
+target_include_directories(streamWrite PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(streamWrite jsoncpp_lib)

--- a/example/stringWrite/CMakeLists.txt
+++ b/example/stringWrite/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(stringWrite stringWrite.cpp)
+target_include_directories(stringWrite PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(stringWrite jsoncpp_lib)

--- a/example/stringWrite/CMakeLists.txt
+++ b/example/stringWrite/CMakeLists.txt
@@ -1,3 +1,2 @@
-add_executable(stringWrite stringWrite.cpp)
-target_include_directories(stringWrite PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(stringWrite jsoncpp_lib)
+ADD_EXECUTABLE(stringWrite stringWrite.cpp)
+TARGET_LINK_LIBRARIES(stringWrite PRIVATE jsoncpp::framework)

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,5 +1,2 @@
-file(GLOB INCLUDE_FILES "json/*.h")
-install(FILES
-    ${INCLUDE_FILES}
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/json)
+
 

--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -11,24 +11,23 @@ set_target_properties(jsontestrunner_exe PROPERTIES OUTPUT_NAME jsontestrunner_e
 
 if(PYTHONINTERP_FOUND)
     # Run end to end parser/writer tests
-    set(TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../test)
-    set(RUNJSONTESTS_PATH ${TEST_DIR}/runjsontests.py)
+    set(RUNJSONTESTS_PATH ${JSONCPP_ROOT_DIR}/test/runjsontests.py)
 
     # Run unit tests in post-build
     # (default cmake workflow hides away the test result into a file, resulting in poor dev workflow?!?)
     add_custom_target(jsoncpp_readerwriter_tests
-        "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" $<TARGET_FILE:jsontestrunner_exe> "${TEST_DIR}/data"
+        "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" $<TARGET_FILE:jsontestrunner_exe> "${JSONCPP_ROOT_DIR}/test/data"
         DEPENDS jsontestrunner_exe jsoncpp_test
     )
     add_custom_target(jsoncpp_check DEPENDS jsoncpp_readerwriter_tests)
 
     ## Create tests for dashboard submission, allows easy review of CI results https://my.cdash.org/index.php?project=jsoncpp
     add_test(NAME jsoncpp_readerwriter
-        COMMAND "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" $<TARGET_FILE:jsontestrunner_exe> "${TEST_DIR}/data"
-        WORKING_DIRECTORY "${TEST_DIR}/data"
+        COMMAND "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" $<TARGET_FILE:jsontestrunner_exe> "${JSONCPP_ROOT_DIR}/test/data"
+        WORKING_DIRECTORY "${JSONCPP_ROOT_DIR}/test/data"
     )
     add_test(NAME jsoncpp_readerwriter_json_checker
-        COMMAND "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" --with-json-checker  $<TARGET_FILE:jsontestrunner_exe> "${TEST_DIR}/data"
-        WORKING_DIRECTORY "${TEST_DIR}/data"
+        COMMAND "${PYTHON_EXECUTABLE}" -B "${RUNJSONTESTS_PATH}" --with-json-checker  $<TARGET_FILE:jsontestrunner_exe> "${JSONCPP_ROOT_DIR}/test/data"
+        WORKING_DIRECTORY "${JSONCPP_ROOT_DIR}/test/data"
     )
 endif()

--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -1,28 +1,11 @@
-if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
-    # The new Python3 module is much more robust than the previous PythonInterp
-    find_package(Python3 COMPONENTS Interpreter)
-    # Set variables for backwards compatibility with cmake < 3.12.0
-    set(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
-    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-else()
-    set(Python_ADDITIONAL_VERSIONS 3.8)
-    find_package(PythonInterp 3)
-endif()
+# The new Python3 module is much more robust than the previous PythonInterp
+FIND_PACKAGE(Python3 COMPONENTS Interpreter)
+# Set variables for backwards compatibility with cmake < 3.12.0
+SET(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
+SET(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
-add_executable(jsontestrunner_exe
-    main.cpp
-)
-
-if(BUILD_SHARED_LIBS)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
-        add_compile_definitions( JSON_DLL )
-    else()
-        add_definitions(-DJSON_DLL)
-    endif()
-    target_link_libraries(jsontestrunner_exe jsoncpp_lib)
-else()
-    target_link_libraries(jsontestrunner_exe jsoncpp_static)
-endif()
+ADD_EXECUTABLE(jsontestrunner_exe main.cpp)
+TARGET_LINK_LIBRARIES(jsontestrunner_exe PRIVATE jsoncpp::framework)
 
 set_target_properties(jsontestrunner_exe PROPERTIES OUTPUT_NAME jsontestrunner_exe)
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -75,6 +75,14 @@ list(APPEND REQUIRED_FEATURES
         cxx_variadic_templates # Variadic templates, as defined in N2242.
 )
 
+# The OBJECT's can be used to compile the sources in the list given to add_library
+# to object files, but then neither archiving them into a static library nor
+# linking them into a shared object. The use of object libraries is
+# particularly useful if one needs to create both static and shared libraries
+# in one go.
+
+# Property: OBJECT
+
 
 ADD_LIBRARY(jsoncpp.framework.object OBJECT
         json_reader.cpp
@@ -96,7 +104,14 @@ IF (JSONCPP_BUILD_SHARED_LIBS)
     # Ref: https://stackoverflow.com/a/41618677
     SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
+    # The POSITION_INDEPENDENT_CODE property determines whether position independent executables or
+    # shared libraries will be created. This property is True by default for SHARED and MODULE library
+    # targets and False otherwise.
+
+    # Property: SHARED, POSITION_INDEPENDENT_CODE
     ADD_LIBRARY(jsoncpp.framework SHARED $<TARGET_OBJECTS:jsoncpp.framework.object>)
+
+    # Needed for legacy code
     TARGET_COMPILE_DEFINITIONS(jsoncpp.framework PUBLIC JSON_DLL_BUILD)
 
 ELSE ()
@@ -111,4 +126,6 @@ SET_TARGET_PROPERTIES(jsoncpp.framework PROPERTIES VERSION ${PROJECT_VERSION})
 SET_TARGET_PROPERTIES(jsoncpp.framework PROPERTIES SOVERSION ${PROJECT_SOVERSION})
 
 TARGET_COMPILE_FEATURES(jsoncpp.framework PUBLIC ${REQUIRED_FEATURES})
+# It is necessary to repeat these instructions again, in case of not doing it, the executables
+# will be unable to locate the Headers needed to perform the linking
 TARGET_INCLUDE_DIRECTORIES(jsoncpp.framework PUBLIC $<BUILD_INTERFACE:${JSONCPP_ROOT_DIR}/include>)

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -77,9 +77,7 @@ list(APPEND REQUIRED_FEATURES
 
 
 ADD_LIBRARY(jsoncpp.framework.object OBJECT
-        json_tool.h
         json_reader.cpp
-        json_valueiterator.inl
         json_value.cpp
         json_writer.cpp
         )

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -91,11 +91,6 @@ SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES SOVERSION ${PROJECT_SO
 TARGET_COMPILE_FEATURES(jsoncpp.framework.object PUBLIC ${REQUIRED_FEATURES})
 TARGET_INCLUDE_DIRECTORIES(jsoncpp.framework.object PUBLIC $<BUILD_INTERFACE:${JSONCPP_ROOT_DIR}/include>)
 
-# Set library's runtime search path on OSX
-IF (APPLE)
-    SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES INSTALL_RPATH "@loader_path/.")
-ENDIF ()
-
 
 IF (JSONCPP_BUILD_SHARED_LIBS)
 

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -25,41 +25,11 @@ if(NOT (HAVE_CLOCALE AND HAVE_LCONV_SIZE AND HAVE_DECIMAL_POINT AND HAVE_LOCALEC
     endif()
 endif()
 
-set(JSONCPP_INCLUDE_DIR ../../include)
-
-set(PUBLIC_HEADERS
-    ${JSONCPP_INCLUDE_DIR}/json/config.h
-    ${JSONCPP_INCLUDE_DIR}/json/forwards.h
-    ${JSONCPP_INCLUDE_DIR}/json/json_features.h
-    ${JSONCPP_INCLUDE_DIR}/json/value.h
-    ${JSONCPP_INCLUDE_DIR}/json/reader.h
-    ${JSONCPP_INCLUDE_DIR}/json/version.h
-    ${JSONCPP_INCLUDE_DIR}/json/writer.h
-    ${JSONCPP_INCLUDE_DIR}/json/assertions.h
-)
-
-source_group("Public API" FILES ${PUBLIC_HEADERS})
-
-set(JSONCPP_SOURCES
-    json_tool.h
-    json_reader.cpp
-    json_valueiterator.inl
-    json_value.cpp
-    json_writer.cpp
-)
-
-# Install instructions for this target
-if(JSONCPP_WITH_CMAKE_PACKAGE)
-    set(INSTALL_EXPORT EXPORT jsoncpp)
-else()
-    set(INSTALL_EXPORT)
-endif()
 
 # Specify compiler features required when compiling a given target.
 # See https://cmake.org/cmake/help/v3.1/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#prop_gbl:CMAKE_CXX_KNOWN_FEATURES
 # for complete list of features available
 list(APPEND REQUIRED_FEATURES
-        cxx_std_11 # Compiler mode is aware of C++ 11.
         #MSVC 1900 cxx_alignas # Alignment control alignas, as defined in N2341.
         #MSVC 1900 cxx_alignof # Alignment control alignof, as defined in N2341.
         #MSVC 1900 cxx_attributes # Generic attributes, as defined in N2761.
@@ -106,103 +76,46 @@ list(APPEND REQUIRED_FEATURES
 )
 
 
-if(BUILD_SHARED_LIBS)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
-        add_compile_definitions(JSON_DLL_BUILD)
-    else()
-        add_definitions(-DJSON_DLL_BUILD)
-    endif()
+ADD_LIBRARY(jsoncpp.framework.object OBJECT
+        json_tool.h
+        json_reader.cpp
+        json_valueiterator.inl
+        json_value.cpp
+        json_writer.cpp
+        )
 
-    set(SHARED_LIB ${PROJECT_NAME}_lib)
-    add_library(${SHARED_LIB} SHARED ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
-    set_target_properties(${SHARED_LIB} PROPERTIES
-        OUTPUT_NAME jsoncpp
-        VERSION ${PROJECT_VERSION}
-        SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
-    )
+SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES CXX_STANDARD 11)
+SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES VERSION ${PROJECT_VERSION})
+SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES SOVERSION ${PROJECT_SOVERSION})
 
-    # Set library's runtime search path on OSX
-    if(APPLE)
-        set_target_properties(${SHARED_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
-    endif()
+TARGET_COMPILE_FEATURES(jsoncpp.framework.object PUBLIC ${REQUIRED_FEATURES})
+TARGET_INCLUDE_DIRECTORIES(jsoncpp.framework.object PUBLIC $<BUILD_INTERFACE:${JSONCPP_ROOT_DIR}/include>)
 
-    target_compile_features(${SHARED_LIB} PUBLIC ${REQUIRED_FEATURES})
+# Set library's runtime search path on OSX
+IF (APPLE)
+    SET_TARGET_PROPERTIES(jsoncpp.framework.object PROPERTIES INSTALL_RPATH "@loader_path/.")
+ENDIF ()
 
-    target_include_directories(${SHARED_LIB} PUBLIC
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-    )
 
-    list(APPEND CMAKE_TARGETS ${SHARED_LIB})
-endif()
+IF (JSONCPP_BUILD_SHARED_LIBS)
 
-if(BUILD_STATIC_LIBS)
-    set(STATIC_LIB ${PROJECT_NAME}_static)
-    add_library(${STATIC_LIB} STATIC ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
+    # CMake link shared library on Windows
+    # Ref: https://stackoverflow.com/a/41618677
+    SET(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS TRUE)
 
-    # avoid name clashes on windows as the shared import lib is also named jsoncpp.lib
-    if(NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)
-        if (MSVC)
-            set(STATIC_SUFFIX "_static")
-        else()
-            set(STATIC_SUFFIX "")
-        endif()
-    endif()
+    ADD_LIBRARY(jsoncpp.framework SHARED $<TARGET_OBJECTS:jsoncpp.framework.object>)
+    TARGET_COMPILE_DEFINITIONS(jsoncpp.framework PUBLIC JSON_DLL_BUILD)
 
-    set_target_properties(${STATIC_LIB} PROPERTIES
-        OUTPUT_NAME jsoncpp${STATIC_SUFFIX}
-        VERSION ${PROJECT_VERSION}
-    )
+ELSE ()
 
-    # Set library's runtime search path on OSX
-    if(APPLE)
-        set_target_properties(${STATIC_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
-    endif()
+    ADD_LIBRARY(jsoncpp.framework STATIC $<TARGET_OBJECTS:jsoncpp.framework.object>)
 
-    target_compile_features(${STATIC_LIB} PUBLIC ${REQUIRED_FEATURES})
+ENDIF ()
 
-    target_include_directories(${STATIC_LIB} PUBLIC
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-    )
+ADD_LIBRARY(jsoncpp::framework ALIAS jsoncpp.framework)
+SET_TARGET_PROPERTIES(jsoncpp.framework PROPERTIES CXX_STANDARD 11)
+SET_TARGET_PROPERTIES(jsoncpp.framework PROPERTIES VERSION ${PROJECT_VERSION})
+SET_TARGET_PROPERTIES(jsoncpp.framework PROPERTIES SOVERSION ${PROJECT_SOVERSION})
 
-    list(APPEND CMAKE_TARGETS ${STATIC_LIB})
-endif()
-
-if(BUILD_OBJECT_LIBS)
-    set(OBJECT_LIB ${PROJECT_NAME}_object)
-    add_library(${OBJECT_LIB} OBJECT ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
-
-    set_target_properties(${OBJECT_LIB} PROPERTIES
-        OUTPUT_NAME jsoncpp
-        VERSION ${PROJECT_VERSION}
-        SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
-    )
-
-    # Set library's runtime search path on OSX
-    if(APPLE)
-        set_target_properties(${OBJECT_LIB} PROPERTIES INSTALL_RPATH "@loader_path/.")
-    endif()
-
-    target_compile_features(${OBJECT_LIB} PUBLIC ${REQUIRED_FEATURES})
-
-    target_include_directories(${OBJECT_LIB} PUBLIC
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/${JSONCPP_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include/json>
-    )
-
-    list(APPEND CMAKE_TARGETS ${OBJECT_LIB})
-endif()
-
-install(TARGETS ${CMAKE_TARGETS} ${INSTALL_EXPORT}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    OBJECTS DESTINATION ${CMAKE_INSTALL_LIBDIR}
-)
-
+TARGET_COMPILE_FEATURES(jsoncpp.framework PUBLIC ${REQUIRED_FEATURES})
+TARGET_INCLUDE_DIRECTORIES(jsoncpp.framework PUBLIC $<BUILD_INTERFACE:${JSONCPP_ROOT_DIR}/include>)

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -1,39 +1,29 @@
 # vim: et ts=4 sts=4 sw=4 tw=0
 
-add_executable(jsoncpp_test
-    jsontest.cpp
-    jsontest.h
-    fuzz.cpp
-    fuzz.h
-    main.cpp
-)
+ADD_EXECUTABLE(jsoncpp_test
+        jsontest.cpp
+        jsontest.h
+        fuzz.cpp
+        fuzz.h
+        main.cpp
+        )
 
-
-if(BUILD_SHARED_LIBS)
-    if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
-        add_compile_definitions( JSON_DLL )
-    else()
-        add_definitions( -DJSON_DLL )
-    endif()
-    target_link_libraries(jsoncpp_test jsoncpp_lib)
-else()
-    target_link_libraries(jsoncpp_test jsoncpp_static)
-endif()
+TARGET_LINK_LIBRARIES(jsoncpp_test PRIVATE jsoncpp::framework)
 
 # another way to solve issue #90
 #set_target_properties(jsoncpp_test PROPERTIES COMPILE_FLAGS -ffloat-store)
 
 ## Create tests for dashboard submission, allows easy review of CI results https://my.cdash.org/index.php?project=jsoncpp
-add_test(NAME jsoncpp_test
-    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
-)
-set_target_properties(jsoncpp_test PROPERTIES OUTPUT_NAME jsoncpp_test)
+ADD_TEST(NAME jsoncpp_test
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
+        )
+SET_TARGET_PROPERTIES(jsoncpp_test PROPERTIES OUTPUT_NAME jsoncpp_test)
 
 # Run unit tests in post-build
 # (default cmake workflow hides away the test result into a file, resulting in poor dev workflow?!?)
-if(JSONCPP_WITH_POST_BUILD_UNITTEST)
-    add_custom_command(TARGET jsoncpp_test
-        POST_BUILD
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
-    )
-endif()
+IF (JSONCPP_WITH_POST_BUILD_UNITTEST)
+    ADD_CUSTOM_COMMAND(TARGET jsoncpp_test
+            POST_BUILD
+            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:jsoncpp_test>
+            )
+ENDIF ()


### PR DESCRIPTION
Se ha mejorado el soporte con CMake para permitir descargar el proyecto con Fetch, la configuración y el enlace se hace automáticamente para una mejor experiencia de desarrollo, el modo de compilación es dependiente de la opción utilizada y solamente se puede compilar SHARED o STATIC pero no ambas a la vez.