### PR TITLE
feat: adds front and back methods to Value type

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -585,20 +585,20 @@ public:
   iterator begin();
   iterator end();
 
-  /// @brief Returns a reference to the first element in the container.
-  /// Calling front on an empty container is undefined behavior.
-  Value const& front() const;
+  /// \brief Returns a reference to the first element in the `Value`.
+  /// Requires that this value holds an array or json object, with at least one element.
+  const Value& front() const;
 
-  /// @brief Returns a reference to the last element in the container.
-  /// Calling back on an empty container is undefined behavior.
-  Value const& back() const;
-
-  /// @brief Returns a reference to the first element in the container.
-  /// Calling front on an empty container is undefined behavior.
+  /// \brief Returns a reference to the first element in the `Value`.
+  /// Requires that this value holds an array or json object, with at least one element.
   Value& front();
 
-  /// @brief Returns a reference to the last element in the container.
-  /// Calling back on an empty container is undefined behavior.
+  /// \brief Returns a reference to the last element in the `Value`.
+  /// Requires that value holds an array or json object, with at least one element.
+  const Value& back() const;
+
+  /// \brief Returns a reference to the last element in the `Value`.
+  /// Requires that this value holds an array or json object, with at least one element.
   Value& back();
 
   // Accessors for the [start, limit) range of bytes within the JSON text from
@@ -940,6 +940,14 @@ public:
 };
 
 inline void swap(Value& a, Value& b) { a.swap(b); }
+
+inline const Value& Value::front() const { return *begin(); }
+
+inline Value& Value::front() { return *begin(); }
+
+inline const Value& Value::back() const { return *(--end()); }
+
+inline Value& Value::back() { return *(--end()); }
 
 } // namespace Json
 

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -585,6 +585,22 @@ public:
   iterator begin();
   iterator end();
 
+  /// @brief Returns a reference to the first element in the container.
+  /// Calling front on an empty container is undefined behavior.
+  Value const& front() const;
+
+  /// @brief Returns a reference to the last element in the container.
+  /// Calling back on an empty container is undefined behavior.
+  Value const& back() const;
+
+  /// @brief Returns a reference to the first element in the container.
+  /// Calling front on an empty container is undefined behavior.
+  Value& front();
+
+  /// @brief Returns a reference to the last element in the container.
+  /// Calling back on an empty container is undefined behavior.
+  Value& back();
+
   // Accessors for the [start, limit) range of bytes within the JSON text from
   // which this value was parsed, if any.
   void setOffsetStart(ptrdiff_t start);

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1495,6 +1495,14 @@ Value::iterator Value::end() {
   return iterator();
 }
 
+Value const& Value::front() const { return *begin(); }
+
+Value& Value::front() { return *begin(); }
+
+Value const& Value::back() const { return *(--end()); }
+
+Value& Value::back() { return *(--end()); }
+
 // class PathArgument
 // //////////////////////////////////////////////////////////////////
 

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1495,14 +1495,6 @@ Value::iterator Value::end() {
   return iterator();
 }
 
-Value const& Value::front() const { return *begin(); }
-
-Value& Value::front() { return *begin(); }
-
-Value const& Value::back() const { return *(--end()); }
-
-Value& Value::back() { return *(--end()); }
-
 // class PathArgument
 // //////////////////////////////////////////////////////////////////
 

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -310,10 +310,14 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrays) {
   const Json::Value& constArray = array1_;
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), constArray[index0]);
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), constArray[0]);
+  JSONTEST_ASSERT_EQUAL(Json::Value(1234), constArray.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value(1234), constArray.back());
 
   // Access through non-const reference
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), array1_[index0]);
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), array1_[0]);
+  JSONTEST_ASSERT_EQUAL(Json::Value(1234), array1_.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value(1234), array1_.back());
 
   array1_[2] = Json::Value(17);
   JSONTEST_ASSERT_EQUAL(Json::Value(), array1_[1]);
@@ -356,6 +360,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, resizePopulatesAllMissingElements) {
   v.resize(n);
   JSONTEST_ASSERT_EQUAL(n, v.size());
   JSONTEST_ASSERT_EQUAL(n, std::distance(v.begin(), v.end()));
+  JSONTEST_ASSERT_EQUAL(v.front(), Json::Value{});
+  JSONTEST_ASSERT_EQUAL(v.back(), Json::Value{});
   for (const Json::Value& e : v)
     JSONTEST_ASSERT_EQUAL(e, Json::Value{});
 }
@@ -406,6 +412,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   JSONTEST_ASSERT_EQUAL(Json::Value("index0"), array[0]); // check append
   JSONTEST_ASSERT_EQUAL(Json::Value("index1"), array[1]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array[2]);
+  JSONTEST_ASSERT_EQUAL(Json::Value("index0"), array.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array.back());
 
   // insert lvalue at the head
   JSONTEST_ASSERT(array.insert(0, str1));
@@ -413,6 +421,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   JSONTEST_ASSERT_EQUAL(Json::Value("index0"), array[1]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index1"), array[2]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array[3]);
+  JSONTEST_ASSERT_EQUAL(Json::Value("index3"), array.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array.back());
   // checking address
   for (Json::ArrayIndex i = 0; i < 3; i++) {
     JSONTEST_ASSERT_EQUAL(vec[i], &array[i]);
@@ -425,6 +435,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   JSONTEST_ASSERT_EQUAL(Json::Value("index4"), array[2]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index1"), array[3]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array[4]);
+  JSONTEST_ASSERT_EQUAL(Json::Value("index3"), array.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array.back());
   // checking address
   for (Json::ArrayIndex i = 0; i < 4; i++) {
     JSONTEST_ASSERT_EQUAL(vec[i], &array[i]);
@@ -438,6 +450,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, arrayInsertAtRandomIndex) {
   JSONTEST_ASSERT_EQUAL(Json::Value("index1"), array[3]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index2"), array[4]);
   JSONTEST_ASSERT_EQUAL(Json::Value("index5"), array[5]);
+  JSONTEST_ASSERT_EQUAL(Json::Value("index3"), array.front());
+  JSONTEST_ASSERT_EQUAL(Json::Value("index5"), array.back());
   // checking address
   for (Json::ArrayIndex i = 0; i < 5; i++) {
     JSONTEST_ASSERT_EQUAL(vec[i], &array[i]);


### PR DESCRIPTION
This PR adds the `front` and `back` methods to the `Json::Value` class.
These methods can be used to access the first and last elements of a `Json::Value` container.
For a `Json::Value v` they are equal to `*v.begin()` and `*(--v.end())`.