### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives us time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+Please submit the report by filling out
+[this form](https://github.com/open-source-parsers/jsoncpp/security/advisories/new).
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by volunteers on a reasonable-effort basis. As such,
+we ask that you give us 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #1483.

This PR adds a security policy for JsonCpp.

After reading the conversation in https://github.com/open-source-parsers/jsoncpp/issues/838, I wrote the policy to suggest the use of GitHub's private reporting feature (must be enabled in the [project settings](https://github.com/open-source-parsers/jsoncpp/settings/security_analysis)). Let me know if you'd rather use an email or external website (or both!).

The policy also suggests a 90-day remediation schedule, simply because it's pretty standard practice. If you'd rather change that (or anything else!), let me know.