### PR TITLE
Bump CMake policy version to avoid deprecation warning

### DIFF
--- a/jsoncppConfig.cmake.in
+++ b/jsoncppConfig.cmake.in
@@ -1,5 +1,5 @@
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.0)
+cmake_policy(VERSION 3.0...3.26)
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
Starting with CMake 3.27, there will be a warning for compat levels below CMake 3.5.
