### PR TITLE
add "allowHexadecimal" reader option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /doc/doxyfile
 /dist/
 /.cache/
+/.vscode/
 
 # MSVC project files:
 *.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ project(jsoncpp
         # 2. ./include/json/version.h
         # 3. ./CMakeLists.txt
         # IMPORTANT: also update the PROJECT_SOVERSION!!
-        VERSION 1.9.5 # <major>[.<minor>[.<patch>[.<tweak>]]]
+        VERSION 1.10.0 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)
 
 message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

--- a/include/json/reader.h
+++ b/include/json/reader.h
@@ -324,6 +324,8 @@ public:
    * - `"allowSpecialFloats": false or true`
    *   - If true, special float values (NaNs and infinities) are allowed and
    *     their values are lossfree restorable.
+   * - `"allowHexadecimal": false or true`
+   *   - If true, allow hexadecimal (eg 0xFFFF) to be used as unsigned integers.
    * - `"skipBom": false or true`
    *   - If true, if the input starts with the Unicode byte order mark (BOM),
    *     it is skipped.

--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -1692,11 +1692,11 @@ bool OurReader::decodeHexadecimal(Token& token, Value& decoded) {
     return addError("Token too long to be unsigned integer.", token, current);
   for (; current < token.end_; ++current) {
     Char c = *current;
-    if (c >= 'a')
+    if (c >= 'a' && c <= 'f')
       c -= 'a' - 10;
-    else if (c >= 'A')
+    else if (c >= 'A' && c <= 'F')
       c -= 'A' - 10;
-    else if (c >= '0')
+    else if (c >= '0' && c <= '9')
       c -= '0';
     else
       return addError("Contains non-hexadecimal digits.", token, current);


### PR DESCRIPTION
Adds optional read-support for hexadecimal numbers matching `0x[0-9a-fA-F]{1,16}` (size depends on LargestUInt). New capability is tied to the **allowHexadecimal** reader-option.

Not sure if there is much interest aside from myself. This would contribute to possible future [JSON5](https://spec.json5.org/) support which does seem to have been considered (https://github.com/open-source-parsers/jsoncpp/issues/209 https://github.com/open-source-parsers/jsoncpp/issues/723). Would need to support leading `(+|-)` for this to be compliant with the JSON5 spec.