### PR TITLE
Vs2013fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Then,
     meson --buildtype ${BUILD_TYPE} --default-library ${LIB_TYPE} . build-${LIB_TYPE}
     ninja -v -C build-${LIB_TYPE}
 
-    ninja -C build-static/ test
+    ninja -C build-shared/ test
 
     # Or
     #cd build-${LIB_TYPE}

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -256,7 +256,15 @@ public:
   // The constant is hard-coded because some compiler have trouble
   // converting Value::maxUInt64 to a double correctly (AIX/xlC).
   // Assumes that UInt64 is a 64 bits integer.
+#if JSONCPP_CXX_STD_11
   static JSONCPP_CONST double maxUInt64AsDouble = 18446744073709551615.0;
+#else
+  // In-class initializer for static data member of type 'const double' is a GNU
+  // extension. JSONCPP_CONST == const, if C++0x.
+  // So initialization has to be done in json_value.cpp to make this project
+  // compileable with e.g. VS2013
+  static JSONCPP_CONST double maxUInt64AsDouble;
+#endif
 // Workaround for bug in the NVIDIAs CUDA 9.1 nvcc compiler
 // when using gcc and clang backend compilers.  CZString
 // cannot be defined as private.  See issue #486

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -335,7 +335,6 @@ bool Value::CZString::isStaticString() const {
 // //////////////////////////////////////////////////////////////////
 
 #if JSONCPP_CXX_STD_11
-
 #else
 // In-class initializer for static data member of type 'const double' is a GNU
 // extension. JSONCPP_CONST == const, if C++0x.

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -334,6 +334,16 @@ bool Value::CZString::isStaticString() const {
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
 
+#if JSONCPP_CXX_STD_11
+
+#else
+// In-class initializer for static data member of type 'const double' is a GNU
+// extension. JSONCPP_CONST == const, if C++0x.
+// So initialization has to be done in json_value.cpp to make this project
+// compileable with e.g. VS2013.
+JSONCPP_CONST double Value::maxUInt64AsDouble = 18446744073709551615.0;
+#endif
+
 /*! \internal Default constructor initialization must be equivalent to:
  * memset( this, 0, sizeof(Value) )
  * This optimization is used in ValueInternalMap fast allocator.


### PR DESCRIPTION
The C++0x part of branch 00.11.z can be build with GNU Compiler but not with Windows VS2013.
In-class initializer for static data member of type 'const double' is a GNU extension which is not provided by Visual Studio.
Initialization is done outside the class definition to make this project compileable with VS2013.
 A small fix was also done in the CONTRIBUTING.md to make code snippets capable for copy-paste usage.