### PR TITLE
Fix flag -DJSONCPP_USE_SECURE_MEMORY:BOOL=TRUE

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -127,7 +127,7 @@ using LargestUInt = UInt64;
 
 template <typename T>
 using Allocator =
-    typename std::conditional<JSONCPP_USING_SECURE_MEMORY, SecureAllocator<T>,
+    typename std::conditional<JSONCPP_USE_SECURE_MEMORY, SecureAllocator<T>,
                               std::allocator<T>>::type;
 using String = std::basic_string<char, std::char_traits<char>, Allocator<char>>;
 using IStringStream =

--- a/include/json/value.h
+++ b/include/json/value.h
@@ -375,7 +375,7 @@ public:
   int compare(const Value& other) const;
 
   const char* asCString() const; ///< Embedded zeroes could cause you trouble!
-#if JSONCPP_USING_SECURE_MEMORY
+#if JSONCPP_USE_SECURE_MEMORY
   unsigned getCStringLength() const; // Allows you to understand the length of
                                      // the CString
 #endif

--- a/include/json/version.h
+++ b/include/json/version.h
@@ -19,7 +19,7 @@
    (JSONCPP_VERSION_PATCH << 8))
 
 #if !defined(JSONCPP_USE_SECURE_MEMORY)
-#define JSONCPP_USING_SECURE_MEMORY 0
+#define JSONCPP_USE_SECURE_MEMORY 0
 #endif
 // If non-zero, the library zeroes any memory that it has allocated before
 // it frees its memory.

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -165,7 +165,7 @@ inline static void decodePrefixedString(bool isPrefixed, char const* prefixed,
 /** Free the string duplicated by
  * duplicateStringValue()/duplicateAndPrefixStringValue().
  */
-#if JSONCPP_USING_SECURE_MEMORY
+#if JSONCPP_USE_SECURE_MEMORY
 static inline void releasePrefixedStringValue(char* value) {
   unsigned length = 0;
   char const* valueDecoded;
@@ -180,10 +180,10 @@ static inline void releaseStringValue(char* value, unsigned length) {
   memset(value, 0, size);
   free(value);
 }
-#else  // !JSONCPP_USING_SECURE_MEMORY
+#else  // !JSONCPP_USE_SECURE_MEMORY
 static inline void releasePrefixedStringValue(char* value) { free(value); }
 static inline void releaseStringValue(char* value, unsigned) { free(value); }
-#endif // JSONCPP_USING_SECURE_MEMORY
+#endif // JSONCPP_USE_SECURE_MEMORY
 
 } // namespace Json
 
@@ -601,7 +601,7 @@ const char* Value::asCString() const {
   return this_str;
 }
 
-#if JSONCPP_USING_SECURE_MEMORY
+#if JSONCPP_USE_SECURE_MEMORY
 unsigned Value::getCStringLength() const {
   JSON_ASSERT_MESSAGE(type() == stringValue,
                       "in Json::Value::asCString(): requires stringValue");

--- a/src/test_lib_json/jsontest.cpp
+++ b/src/test_lib_json/jsontest.cpp
@@ -410,7 +410,7 @@ Json::String ToJsonString(const char* toConvert) {
 
 Json::String ToJsonString(Json::String in) { return in; }
 
-#if JSONCPP_USING_SECURE_MEMORY
+#if JSONCPP_USE_SECURE_MEMORY
 Json::String ToJsonString(std::string in) {
   return Json::String(in.data(), in.data() + in.length());
 }

--- a/src/test_lib_json/jsontest.h
+++ b/src/test_lib_json/jsontest.h
@@ -185,7 +185,7 @@ TestResult& checkEqual(TestResult& result, T expected, U actual,
 
 Json::String ToJsonString(const char* toConvert);
 Json::String ToJsonString(Json::String in);
-#if JSONCPP_USING_SECURE_MEMORY
+#if JSONCPP_USE_SECURE_MEMORY
 Json::String ToJsonString(std::string in);
 #endif
 


### PR DESCRIPTION
The Cmake description uses `JSONCPP_USE_SECURE_MEMORY` and the source uses `JSONCPP_USING_SECURE_MEMORY`.

Is it known that the tests don't compile with this setting being enabled?