### PR TITLE
fix(build): remove `check_required_components` for meson build

### DIFF
--- a/jsoncppConfig.cmake.meson.in
+++ b/jsoncppConfig.cmake.meson.in
@@ -4,5 +4,3 @@
 @MESON_STATIC_TARGET@
 
 include ( "${CMAKE_CURRENT_LIST_DIR}/jsoncpp-namespaced-targets.cmake" )
-
-check_required_components(JsonCpp)


### PR DESCRIPTION
fixes #1568

relates to https://github.com/Homebrew/homebrew-core/pull/189352