### PR TITLE
Fix comparison warnings caused by 54fc4e2

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -684,7 +684,7 @@ Value::UInt Value::asUInt() const {
     JSON_ASSERT_MESSAGE(isUInt(), "LargestUInt out of UInt range");
     return UInt(value_.uint_);
   case realValue:
-    JSON_ASSERT_MESSAGE(InRange(value_.real_, 0, maxUInt),
+    JSON_ASSERT_MESSAGE(InRange(value_.real_, 0u, maxUInt),
                         "double out of UInt range");
     return UInt(value_.real_);
   case nullValue:
@@ -733,7 +733,7 @@ Value::UInt64 Value::asUInt64() const {
   case uintValue:
     return UInt64(value_.uint_);
   case realValue:
-    JSON_ASSERT_MESSAGE(InRange(value_.real_, 0, maxUInt64),
+    JSON_ASSERT_MESSAGE(InRange(value_.real_, 0u, maxUInt64),
                         "double out of UInt64 range");
     return UInt64(value_.real_);
   case nullValue:
@@ -844,7 +844,7 @@ bool Value::isConvertibleTo(ValueType other) const {
            type() == booleanValue || type() == nullValue;
   case uintValue:
     return isUInt() ||
-           (type() == realValue && InRange(value_.real_, 0, maxUInt)) ||
+           (type() == realValue && InRange(value_.real_, 0u, maxUInt)) ||
            type() == booleanValue || type() == nullValue;
   case realValue:
     return isNumeric() || type() == booleanValue || type() == nullValue;


### PR DESCRIPTION
The commit in 54fc4e2 introduces several warnings of "**comparison of integer expressions of different signedness: 'unsigned int' and 'int'**". Example:

```
src/./json/json_value.cpp: In instantiation of 'bool Json::InRange(double, T, U) [with T = int; U = unsigned int]':
src/./json/json_value.cpp:687:5:   required from here
src/./json/json_value.cpp:106:30: warning: comparison of integer expressions of different signedness: 'unsigned int' and 'int' [-Wsign-compare]
  106 |          !(static_cast<U>(d) == min && d != integerToDouble(min));
      |            ~~~~~~~~~~~~~~~~~~^~~~~~
```

This is because `maxUInt` is `unsigned` while the `0` literal is not.
I replaced them with `0u` and it looks fine again.