### PR TITLE
Fix name of static library when targeting MinGW.

### DIFF
--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -143,7 +143,7 @@ if(BUILD_STATIC_LIBS)
 
     # avoid name clashes on windows as the shared import lib is also named jsoncpp.lib
     if(NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)
-        if (WIN32)
+        if (MSVC OR ("${CMAKE_C_SIMULATE_ID}" STREQUAL "MSVC"))
             set(STATIC_SUFFIX "_static")
         else()
             set(STATIC_SUFFIX "")


### PR DESCRIPTION
The change from #1480 broke the name of the static library when targeting MinGW. That lead to a situation where the values in the pkg-config file didn't match the library name. See https://github.com/msys2/MINGW-packages/issues/22584.

Fix the condition to only use the name suffix for the static library when building with MSVC or when targeting MSVC (potentially with another compiler like LLVM Clang).
