### PR TITLE
Set up for Bazel module builds.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ compile_commands.json
 
 # Bazel output paths
 /bazel-*
+/MODULE.bazel.lock

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ compile_commands.json
 
 # temps
 /version
+
+# Bazel output paths
+/bazel-*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,12 +55,13 @@ endif()
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 project(jsoncpp
-        # Note: version must be updated in three places when doing a release. This
+        # Note: version must be updated in four places when doing a release. This
         # annoying process ensures that amalgamate, CMake, and meson all report the
         # correct version.
         # 1. ./meson.build
         # 2. ./include/json/version.h
         # 3. ./CMakeLists.txt
+        # 4. ./MODULE.bazel
         # IMPORTANT: also update the PROJECT_SOVERSION!!
         VERSION 1.9.7 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,14 @@
+module(
+    name = "jsoncpp",
+
+    # Note: version must be updated in four places when doing a release. This
+    # annoying process ensures that amalgamate, CMake, and meson all report the
+    # correct version.
+    # 1. /meson.build
+    # 2. /include/json/version.h
+    # 3. /CMakeLists.txt
+    # 4. /MODULE.bazel
+    # IMPORTANT: also update the SOVERSION!!
+    version = "1.9.7",
+    compatibility_level = 1,
+)

--- a/include/json/version.h
+++ b/include/json/version.h
@@ -1,12 +1,13 @@
 #ifndef JSON_VERSION_H_INCLUDED
 #define JSON_VERSION_H_INCLUDED
 
-// Note: version must be updated in three places when doing a release. This
+// Note: version must be updated in four places when doing a release. This
 // annoying process ensures that amalgamate, CMake, and meson all report the
 // correct version.
 // 1. /meson.build
 // 2. /include/json/version.h
 // 3. /CMakeLists.txt
+// 4. /MODULE.bazel
 // IMPORTANT: also update the SOVERSION!!
 
 #define JSONCPP_VERSION_STRING "1.9.7"

--- a/meson.build
+++ b/meson.build
@@ -2,12 +2,13 @@ project(
   'jsoncpp',
   'cpp',
 
-  # Note: version must be updated in three places when doing a release. This
+  # Note: version must be updated in four places when doing a release. This
   # annoying process ensures that amalgamate, CMake, and meson all report the
   # correct version.
   # 1. /meson.build
   # 2. /include/json/version.h
   # 3. /CMakeLists.txt
+  # 4. /MODULE.bazel
   # IMPORTANT: also update the SOVERSION!!
   version : '1.9.7',
   default_options : [


### PR DESCRIPTION
Notes:
---

1) This likely doesn't require a release note as it _shouldn't_ have any effect on any released product.
1) The `MODULE.bazel` is forked from the "[bazel-central-registry](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/jsoncpp/1.9.6/MODULE.bazel)" and this allows the BCR to quit having to uses patches.
1) With these changes JsonCpp can be built by Bazel without any changes. Without this, Bazel is unable to locate a correct root to build from and fails.
1) This effectively supersede https://github.com/open-source-parsers/jsoncpp/pull/1534 ;; Addressing comments from there:
    1) The version in `MODULE.bazel` should track the version used everywhere else. This just becomes yet-another-copy of that.
    1) `WORKSPACE` is dead (though one _would_ be needed ... if someone had to JsonCpp, as a root module, with Bazel, and without using modules, which should be nobody ever again).
    1) I'm not including a `.bazelrc` as things should "just work" (unless your `~/.bazelrc` does something annoying).

---

It would be _nice_ if making updates to [BCR](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/jsoncpp) became part of the normal release process. It looks like that could be rather easy  [with the available tool support](https://github.com/bazelbuild/bazel-central-registry/blob/main/docs/README.md) maybe even automated.
