### PR TITLE
Add a BUILD.bazel file for //example.

### DIFF
--- a/example/BUILD.bazel
+++ b/example/BUILD.bazel
@@ -1,0 +1,33 @@
+cc_binary(
+    name = "readFromStream_ok",
+    srcs = ["readFromStream/readFromStream.cpp"],
+    deps = ["//:jsoncpp"],
+    args = ["$(location :readFromStream/withComment.json)"],
+    data = ["readFromStream/withComment.json"],
+)
+
+cc_binary(
+    name = "readFromStream_err",
+    srcs = ["readFromStream/readFromStream.cpp"],
+    deps = ["//:jsoncpp"],
+    args = ["$(location :readFromStream/errorFormat.json)"],
+    data = ["readFromStream/errorFormat.json"],
+)
+
+cc_binary(
+    name = "readFromString",
+    srcs = ["readFromString/readFromString.cpp"],
+    deps = ["//:jsoncpp"],
+)
+
+cc_binary(
+    name = "streamWrite",
+    srcs = ["streamWrite/streamWrite.cpp"],
+    deps = ["//:jsoncpp"],
+)
+
+cc_binary(
+    name = "stringWrite",
+    srcs = ["stringWrite/stringWrite.cpp"],
+    deps = ["//:jsoncpp"],
+)


### PR DESCRIPTION
This is more OCD than anything, but there is a `CMakeList` so might as well do this as well. 

#### Testing

All 5 rules work under `bazel run` (and also do so under all configs enabled via https://github.com/open-source-parsers/jsoncpp/pull/1600 ).