### PR TITLE
cmake: Bump min policy version

### DIFF
--- a/jsoncppConfig.cmake.in
+++ b/jsoncppConfig.cmake.in
@@ -1,5 +1,5 @@
 cmake_policy(PUSH)
-cmake_policy(VERSION 3.0...3.26)
+cmake_policy(VERSION 3.5...3.26)
 
 @PACKAGE_INIT@
 


### PR DESCRIPTION
We are getting this error:
```
 CMake Error at external/Release/64/jsoncpp/build/install/lib/cmake/jsoncpp/jsoncppConfig.cmake:2 (cmake_policy):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
Call Stack (most recent call first):
  CMakeLists.txt:32 (find_package)
```

Is bumping minimum to 3.5 ok?