### PR TITLE
Add missing include to json_reader.cpp

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -16,6 +16,7 @@
 #include <cstring>
 #include <iostream>
 #include <istream>
+#include <iterator>
 #include <limits>
 #include <memory>
 #include <set>


### PR DESCRIPTION
This fails to compile with clang module builds.