### PR TITLE
feat(JSON): Add precision control parameters to toStyledString

### DIFF
--- a/include/json/value.h
+++ b/include/json/value.h
@@ -650,7 +650,8 @@ public:
   /// Include delimiters and embedded newlines.
   String getComment(CommentPlacement placement) const;
 
-  String toStyledString() const;
+  String toStyledString(const StreamWriterBuilder& builder = StreamWriterBuilder()) const;
+  String toStyledString(int precision, PrecisionType precisionType = PrecisionType::decimalPlaces) const;
 
   const_iterator begin() const;
   const_iterator end() const;

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1559,14 +1559,18 @@ ptrdiff_t Value::getOffsetStart() const { return start_; }
 
 ptrdiff_t Value::getOffsetLimit() const { return limit_; }
 
-String Value::toStyledString() const {
-  StreamWriterBuilder builder;
-
+String Value::toStyledString(const StreamWriterBuilder& builder) const {
   String out = this->hasComment(commentBefore) ? "\n" : "";
   out += Json::writeString(builder, *this);
   out += '\n';
-
   return out;
+}
+
+String Value::toStyledString(int precision, PrecisionType precisionType) const {
+  StreamWriterBuilder builder;
+  precisionType == PrecisionType::significantDigits?builder.settings_["precisionType"] = "significant":builder.settings_["precisionType"] = "decimal";
+  builder.settings_["precision"] = std::min(precision, 17);
+  return toStyledString(builder);
 }
 
 Value::const_iterator Value::begin() const {


### PR DESCRIPTION
Add support for controlling the precision of JSON string output through parameters, including two modes: decimal places and significant figures.