### PR TITLE
[docs] Consuming JSONCpp via Conan package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ You can download and install JsonCpp using the [vcpkg](https://github.com/Micros
 
 The JsonCpp port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+### Conan package manager
+
+You can download and install JsonCpp using the [Conan](https://conan.io/) package manager:
+
+    conan install -r conancenter --requires="jsoncpp/[*]"
+
+The JsonCpp package in Conan Center is kept up to date by [ConanCenterIndex](https://github.com/conan-io/conan-center-index) contributors. If the version is out of date, please create an issue or pull request on the Conan Center Index repository.
+
 ### Amalgamated source
 https://github.com/open-source-parsers/jsoncpp/wiki/Amalgamated-(Possibly-outdated)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JsonCpp
 
-[![badge](https://img.shields.io/badge/conan.io-jsoncpp%2F1.8.0-green.svg?logo=data:image/png;base64%2CiVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAA1VBMVEUAAABhlctjlstkl8tlmMtlmMxlmcxmmcxnmsxpnMxpnM1qnc1sn85voM91oM11oc1xotB2oc56pNF6pNJ2ptJ8ptJ8ptN9ptN8p9N5qNJ9p9N9p9R8qtOBqdSAqtOAqtR%2BrNSCrNJ/rdWDrNWCsNWCsNaJs9eLs9iRvNuVvdyVv9yXwd2Zwt6axN6dxt%2Bfx%2BChyeGiyuGjyuCjyuGly%2BGlzOKmzOGozuKoz%2BKqz%2BOq0OOv1OWw1OWw1eWx1eWy1uay1%2Baz1%2Baz1%2Bez2Oe02Oe12ee22ujUGwH3AAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfgBQkREyOxFIh/AAAAiklEQVQI12NgAAMbOwY4sLZ2NtQ1coVKWNvoc/Eq8XDr2wB5Ig62ekza9vaOqpK2TpoMzOxaFtwqZua2Bm4makIM7OzMAjoaCqYuxooSUqJALjs7o4yVpbowvzSUy87KqSwmxQfnsrPISyFzWeWAXCkpMaBVIC4bmCsOdgiUKwh3JojLgAQ4ZCE0AMm2D29tZwe6AAAAAElFTkSuQmCC)](https://bintray.com/theirix/conan-repo/jsoncpp%3Atheirix)
+[![Conan Center](https://img.shields.io/conan/v/jsoncpp)](https://conan.io/center/recipes/jsoncpp)
 [![badge](https://img.shields.io/badge/license-MIT-blue)](https://github.com/open-source-parsers/jsoncpp/blob/master/LICENSE)
 [![badge](https://img.shields.io/badge/document-doxygen-brightgreen)](http://open-source-parsers.github.io/jsoncpp-docs/doxygen/index.html)
 [![Coverage Status](https://coveralls.io/repos/github/open-source-parsers/jsoncpp/badge.svg?branch=master)](https://coveralls.io/github/open-source-parsers/jsoncpp?branch=master)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The JsonCpp port in vcpkg is kept up to date by Microsoft team members and commu
 
 You can download and install JsonCpp using the [Conan](https://conan.io/) package manager:
 
-    conan install -r conancenter --requires="jsoncpp/[*]"
+    conan install -r conancenter --requires="jsoncpp/[*]" --build=missing
 
 The JsonCpp package in Conan Center is kept up to date by [ConanCenterIndex](https://github.com/conan-io/conan-center-index) contributors. If the version is out of date, please create an issue or pull request on the Conan Center Index repository.
 


### PR DESCRIPTION
Hello!

In 2017, this project had a large instruction on how to use Conan to install JSONCpp, but now it's no longer listed. 

This PR adds a note on how to use Conan again, but much smaller and simpler.

Plus, I fixed the badge that was pointing to Bintray, which is no longer available. 


Regards! 