### PR TITLE
ci: suppress Node 20 deprecation and missing python-version warnings

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,6 +1,9 @@
 name: clang-format check
 on: [check_run, pull_request, push]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   formatting-check:
     name: formatting check

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,9 @@
 name: cmake
 on: [check_run, push, pull_request]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   cmake-publish:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -2,6 +2,9 @@ name: meson build and test
 run-name: update pushed to ${{ github.ref }}
 on: [check_run, push, pull_request]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   meson-publish:
     runs-on: ${{ matrix.os }}
@@ -17,6 +20,8 @@ jobs:
         
       - name: setup python
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       
       - name: meson build
         uses: BSFishy/meson-build@v1.0.3
@@ -41,6 +46,8 @@ jobs:
         
       - name: setup python
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
       
       - name: meson build
         uses: BSFishy/meson-build@v1.0.3

--- a/.github/workflows/update-project-version.yml
+++ b/.github/workflows/update-project-version.yml
@@ -11,6 +11,9 @@ on:
         description: 'next soversion (e.g., 28). leave blank to keep current.'
         required: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   bump-and-verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Injects `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` in all workflows to opt-in to Node.js 24 and suppress the deprecation warnings from multiple GitHub Actions.
- Specifies `python-version: '3.x'` for `actions/setup-python@v5` in `meson.yml` to fix the missing input warning.