### PR TITLE
docs: update amalgamation instructions and add github action

### DIFF
--- a/.github/workflows/amalgamate.yml
+++ b/.github/workflows/amalgamate.yml
@@ -1,0 +1,39 @@
+name: Amalgamation
+
+on: [check_run, push, pull_request]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  amalgamation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: run amalgamate script
+        run: |
+          python amalgamate.py
+
+      - name: test compile amalgamated source
+        run: |
+          cat << 'EOF' > test_amalgamation.cpp
+          #include "json/json.h"
+          #include <iostream>
+
+          int main() {
+              Json::Value root;
+              root["hello"] = "world";
+              std::cout << root.toStyledString() << std::endl;
+              return 0;
+          }
+          EOF
+          c++ -std=c++11 -I dist dist/jsoncpp.cpp test_amalgamation.cpp -o test_amalgamation
+          ./test_amalgamation

--- a/README.md
+++ b/README.md
@@ -88,10 +88,15 @@ meson wrap install jsoncpp
 
 ### Amalgamated source
 
-> [!NOTE]
-> This approach may be outdated.
+For projects requiring a single-header approach, JsonCpp provides a script to generate an amalgamated source and header file.
 
-For projects requiring a single-header approach, see the [Wiki entry](https://github.com/open-source-parsers/jsoncpp/wiki/Amalgamated-(Possibly-outdated)).
+You can generate the amalgamated files by running the following Python script from the top-level directory:
+
+```sh
+python3 amalgamate.py
+```
+
+This will generate a `dist` directory containing `jsoncpp.cpp`, `json/json.h`, and `json/json-forwards.h`. You can then drop these files directly into your project's source tree and compile `jsoncpp.cpp` alongside your other source files.
 
 ## Documentation
 


### PR DESCRIPTION
The amalgamation approach is not outdated and works out-of-the-box. This updates the README to remove the 'possibly-outdated' warning and replaces it with direct, simple instructions for generating the amalgamated source files.

A new GitHub Action workflow (`.github/workflows/amalgamate.yml`) has also been added to ensure the `amalgamate.py` script is run on every commit and that the resulting amalgamated C++ source files successfully compile, preventing any future regressions in the single-header distribution method.