### PR TITLE
feat: add Json::version() to expose runtime version (#1531)

### DIFF
--- a/include/json/config.h
+++ b/include/json/config.h
@@ -105,6 +105,7 @@ extern JSON_API int msvc_pre1900_c99_snprintf(char* outBuf, size_t size,
 #endif // if !defined(JSON_IS_AMALGAMATION)
 
 namespace Json {
+JSON_API const char* version();
 using Int = int;
 using UInt = unsigned int;
 #if defined(JSON_NO_INT64)

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1708,4 +1708,6 @@ Value& Path::make(Value& root) const {
   return *node;
 }
 
+const char* version() { return JSONCPP_VERSION_STRING; }
+
 } // namespace Json

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -4188,6 +4188,11 @@ JSONTEST_FIXTURE_LOCAL(VersionTest, VersionNumbersMatch) {
   JSONTEST_ASSERT_EQUAL(vstr.str(), std::string(JSONCPP_VERSION_STRING));
 }
 
+JSONTEST_FIXTURE_LOCAL(VersionTest, RuntimeVersionString) {
+  JSONTEST_ASSERT_EQUAL(std::string(JSONCPP_VERSION_STRING),
+                        std::string(Json::version()));
+}
+
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
This adds a runtime function `Json::version()` that returns the `JSONCPP_VERSION_STRING`.

This allows a program using jsoncpp to display the version information of the runtime linked shared library, or check at runtime that the version of the shared library is compatible with what the program expects.

Fixes #1531