### PR TITLE
fix: GCC 16 / C++20 build failure with u8 string literals

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        cxx_standard: [11, 17]
+        cxx_standard: [11, 17, 20]
         
     steps:
       - name: checkout project

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1993,7 +1993,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni = u8"\u5f0f\uff0c\u8fdb"; // "式，进"
+  const std::string uni = reinterpret_cast<const char*>(u8"\u5f0f\uff0c\u8fdb"); // "式，进"
   std::string styled;
   {
     Json::Value v;
@@ -3109,9 +3109,9 @@ JSONTEST_FIXTURE_LOCAL(ReaderTest, strictModeParseNumber) {
 }
 
 JSONTEST_FIXTURE_LOCAL(ReaderTest, parseChineseWithOneError) {
-  checkParse(R"({ "pr)"
+  checkParse(reinterpret_cast<const char*>(R"({ "pr)"
              u8"\u4f50\u85e4" // 佐藤
-             R"(erty" :: "value" })",
+             R"(erty" :: "value" })"),
              {{18, 19, "Syntax error: value, object or array expected."}},
              "* Line 1, Column 19\n  Syntax error: value, object or array "
              "expected.\n");
@@ -3223,7 +3223,7 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL(u8"\u8A2a", root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL(reinterpret_cast<const char*>(u8"\u8A2a"), root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -1993,7 +1993,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni = reinterpret_cast<const char*>(u8"\u5f0f\uff0c\u8fdb"); // "式，进"
+  const std::string uni =
+      reinterpret_cast<const char*>(u8"\u5f0f\uff0c\u8fdb"); // "式，进"
   std::string styled;
   {
     Json::Value v;
@@ -3110,8 +3111,8 @@ JSONTEST_FIXTURE_LOCAL(ReaderTest, strictModeParseNumber) {
 
 JSONTEST_FIXTURE_LOCAL(ReaderTest, parseChineseWithOneError) {
   checkParse(reinterpret_cast<const char*>(R"({ "pr)"
-             u8"\u4f50\u85e4" // 佐藤
-             R"(erty" :: "value" })"),
+                                           u8"\u4f50\u85e4" // 佐藤
+                                           R"(erty" :: "value" })"),
              {{18, 19, "Syntax error: value, object or array expected."}},
              "* Line 1, Column 19\n  Syntax error: value, object or array "
              "expected.\n");
@@ -3223,7 +3224,8 @@ JSONTEST_FIXTURE_LOCAL(CharReaderTest, parseString) {
     bool ok = reader->parse(doc, doc + std::strlen(doc), &root, &errs);
     JSONTEST_ASSERT(ok);
     JSONTEST_ASSERT(errs.empty());
-    JSONTEST_ASSERT_EQUAL(reinterpret_cast<const char*>(u8"\u8A2a"), root[0].asString()); // "訪"
+    JSONTEST_ASSERT_EQUAL(reinterpret_cast<const char*>(u8"\u8A2a"),
+                          root[0].asString()); // "訪"
   }
   {
     char const doc[] = R"([ "\uD801" ])";


### PR DESCRIPTION
In C++20, the `u8""` string literal prefix was changed to evaluate to `const char8_t[]` instead of `const char[]`. This caused compilation errors when these literals were implicitly converted to `std::string` or passed to functions expecting `const char*`.

This commit adds `reinterpret_cast<const char*>` around the `u8` string literals in the test suite to resolve the build errors while maintaining the intended UTF-8 semantics.

Additionally, this adds C++20 to the GitHub Actions CMake test matrix to ensure we don't regress on newer standards.

Fixes #1684