### PR TITLE
feat: improve type assertion messages with actual ValueType

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -198,14 +198,22 @@ namespace Json {
 
 static const char* valueTypeToString(ValueType type) {
   switch (type) {
-  case nullValue: return "nullValue";
-  case intValue: return "intValue";
-  case uintValue: return "uintValue";
-  case realValue: return "realValue";
-  case stringValue: return "stringValue";
-  case booleanValue: return "booleanValue";
-  case arrayValue: return "arrayValue";
-  case objectValue: return "objectValue";
+  case nullValue:
+    return "nullValue";
+  case intValue:
+    return "intValue";
+  case uintValue:
+    return "uintValue";
+  case realValue:
+    return "realValue";
+  case stringValue:
+    return "stringValue";
+  case booleanValue:
+    return "booleanValue";
+  case arrayValue:
+    return "arrayValue";
+  case objectValue:
+    return "objectValue";
   }
   return "unknown";
 }
@@ -946,8 +954,10 @@ void Value::clear() {
 }
 
 void Value::resize(ArrayIndex newSize) {
-  JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
-                      "in Json::Value::resize(): requires arrayValue, but found " << valueTypeToString(type()));
+  JSON_ASSERT_MESSAGE(
+      type() == nullValue || type() == arrayValue,
+      "in Json::Value::resize(): requires arrayValue, but found "
+          << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(arrayValue);
   ArrayIndex oldSize = size();
@@ -1080,7 +1090,8 @@ void Value::dupMeta(const Value& other) {
 Value& Value::resolveReference(const char* key) {
   JSON_ASSERT_MESSAGE(
       type() == nullValue || type() == objectValue,
-      "in Json::Value::resolveReference(): requires objectValue, but found " << valueTypeToString(type()));
+      "in Json::Value::resolveReference(): requires objectValue, but found "
+          << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(objectValue);
   CZString actualKey(key, static_cast<unsigned>(strlen(key)),
@@ -1097,9 +1108,10 @@ Value& Value::resolveReference(const char* key) {
 
 // @param key is not null-terminated.
 Value& Value::resolveReference(char const* key, char const* end) {
-  JSON_ASSERT_MESSAGE(
-      type() == nullValue || type() == objectValue,
-      "in Json::Value::resolveReference(key, end): requires objectValue, but found " << valueTypeToString(type()));
+  JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
+                      "in Json::Value::resolveReference(key, end): requires "
+                      "objectValue, but found "
+                          << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(objectValue);
   CZString actualKey(key, static_cast<unsigned>(end - key),
@@ -1210,7 +1222,8 @@ Value& Value::append(const Value& value) { return append(Value(value)); }
 
 Value& Value::append(Value&& value) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
-                      "in Json::Value::append: requires arrayValue, but found " << valueTypeToString(type()));
+                      "in Json::Value::append: requires arrayValue, but found "
+                          << valueTypeToString(type()));
   if (type() == nullValue) {
     *this = Value(arrayValue);
   }
@@ -1269,8 +1282,10 @@ bool Value::removeMember(String const& key, Value* removed) {
 }
 
 void Value::removeMember(const char* key) {
-  JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
-                      "in Json::Value::removeMember(): requires objectValue, but found " << valueTypeToString(type()));
+  JSON_ASSERT_MESSAGE(
+      type() == nullValue || type() == objectValue,
+      "in Json::Value::removeMember(): requires objectValue, but found "
+          << valueTypeToString(type()));
   if (type() == nullValue)
     return;
 
@@ -1725,4 +1740,3 @@ Value& Path::make(Value& root) const {
 const char* version() { return JSONCPP_VERSION_STRING; }
 
 } // namespace Json
-

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -193,6 +193,24 @@ static inline void releaseStringValue(char* value, unsigned) { free(value); }
 // ValueInternals...
 // //////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////
+
+namespace Json {
+
+static const char* valueTypeToString(ValueType type) {
+  switch (type) {
+  case nullValue: return "nullValue";
+  case intValue: return "intValue";
+  case uintValue: return "uintValue";
+  case realValue: return "realValue";
+  case stringValue: return "stringValue";
+  case booleanValue: return "booleanValue";
+  case arrayValue: return "arrayValue";
+  case objectValue: return "objectValue";
+  }
+  return "unknown";
+}
+
+} // namespace Json
 // //////////////////////////////////////////////////////////////////
 #if !defined(JSON_IS_AMALGAMATION)
 
@@ -929,7 +947,7 @@ void Value::clear() {
 
 void Value::resize(ArrayIndex newSize) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
-                      "in Json::Value::resize(): requires arrayValue");
+                      "in Json::Value::resize(): requires arrayValue, but found " << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(arrayValue);
   ArrayIndex oldSize = size();
@@ -1062,7 +1080,7 @@ void Value::dupMeta(const Value& other) {
 Value& Value::resolveReference(const char* key) {
   JSON_ASSERT_MESSAGE(
       type() == nullValue || type() == objectValue,
-      "in Json::Value::resolveReference(): requires objectValue");
+      "in Json::Value::resolveReference(): requires objectValue, but found " << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(objectValue);
   CZString actualKey(key, static_cast<unsigned>(strlen(key)),
@@ -1081,7 +1099,7 @@ Value& Value::resolveReference(const char* key) {
 Value& Value::resolveReference(char const* key, char const* end) {
   JSON_ASSERT_MESSAGE(
       type() == nullValue || type() == objectValue,
-      "in Json::Value::resolveReference(key, end): requires objectValue");
+      "in Json::Value::resolveReference(key, end): requires objectValue, but found " << valueTypeToString(type()));
   if (type() == nullValue)
     *this = Value(objectValue);
   CZString actualKey(key, static_cast<unsigned>(end - key),
@@ -1192,7 +1210,7 @@ Value& Value::append(const Value& value) { return append(Value(value)); }
 
 Value& Value::append(Value&& value) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == arrayValue,
-                      "in Json::Value::append: requires arrayValue");
+                      "in Json::Value::append: requires arrayValue, but found " << valueTypeToString(type()));
   if (type() == nullValue) {
     *this = Value(arrayValue);
   }
@@ -1252,7 +1270,7 @@ bool Value::removeMember(String const& key, Value* removed) {
 
 void Value::removeMember(const char* key) {
   JSON_ASSERT_MESSAGE(type() == nullValue || type() == objectValue,
-                      "in Json::Value::removeMember(): requires objectValue");
+                      "in Json::Value::removeMember(): requires objectValue, but found " << valueTypeToString(type()));
   if (type() == nullValue)
     return;
 
@@ -1707,3 +1725,4 @@ Value& Path::make(Value& root) const {
 const char* version() { return JSONCPP_VERSION_STRING; }
 
 } // namespace Json
+


### PR DESCRIPTION
When interacting with a `Json::Value`, numerous assertions correctly check that the value is of an expected type (e.g., an object or array) before accessing it. If there is a mismatch, the error is somewhat confusing as it only says "requires objectValue".

This commit improves the assertion messages by introducing a `valueTypeToString` helper, allowing the assertions to report the actual `ValueType` encountered (e.g., "requires objectValue, but found stringValue"). This will significantly streamline debugging for users experiencing type mismatch errors.

Fixes #1627