### PR TITLE
ci: bump actions off deprecated Node 20

### DIFF
--- a/.github/workflows/abi-compatibility.yml
+++ b/.github/workflows/abi-compatibility.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: build and install JsonCpp (C++${{ matrix.jsoncpp_std }})
         shell: bash

--- a/.github/workflows/amalgamate.yml
+++ b/.github/workflows/amalgamate.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,7 +15,7 @@ jobs:
           - 'example'
           - 'include'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: runs clang-format style check for C/C++/Protobuf programs.
       uses: jidicula/clang-format-action@v4.13.0
       with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
         
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: build project
         uses: threeal/cmake-action@v2.0.0

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:     
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: setup python
         uses: actions/setup-python@v5
@@ -42,7 +42,7 @@ jobs:
     
     steps:
       - name: checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: setup python
         uses: actions/setup-python@v5

--- a/.github/workflows/update-project-version.yml
+++ b/.github/workflows/update-project-version.yml
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: update project files
         run: |
@@ -102,7 +102,7 @@ jobs:
           fi
 
       - name: create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "chore: bump version to ${{ github.event.inputs.target_version }}"


### PR DESCRIPTION
GitHub Actions reports that actions/checkout@v4 and peter-evans/create-pull-request@v7 target Node 20, which is deprecated and currently force-run on Node 24.

Bump them to versions that natively target Node 24:
- actions/checkout v4 -> v5 (the Node 20 -> 24 transition; v6's only notable change is moving credentials to a separate file, unneeded here)
- peter-evans/create-pull-request v7 -> v8 (Node 24 bump only; inputs unchanged)

The other actions in these workflows were not flagged and already run on Node 24.