### PR TITLE
fix: make array operator[] dense when assigning past the end (#1611)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ project(jsoncpp
         # 3. ./CMakeLists.txt
         # 4. ./MODULE.bazel
         # IMPORTANT: also update the PROJECT_SOVERSION!!
-        VERSION 1.9.9 # <major>[.<minor>[.<patch>[.<tweak>]]]
+        VERSION 1.10.0 # <major>[.<minor>[.<patch>[.<tweak>]]]
         LANGUAGES CXX)
 
 message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,7 +9,7 @@ module(
     # 3. /CMakeLists.txt
     # 4. /MODULE.bazel
     # IMPORTANT: also update the SOVERSION!!
-    version = "1.9.9",
+    version = "1.10.0",
     compatibility_level = 1,
 )
 

--- a/include/json/version.h
+++ b/include/json/version.h
@@ -10,10 +10,10 @@
 // 4. /MODULE.bazel
 // IMPORTANT: also update the SOVERSION!!
 
-#define JSONCPP_VERSION_STRING "1.9.9"
+#define JSONCPP_VERSION_STRING "1.10.0"
 #define JSONCPP_VERSION_MAJOR 1
-#define JSONCPP_VERSION_MINOR 9
-#define JSONCPP_VERSION_PATCH 9
+#define JSONCPP_VERSION_MINOR 10
+#define JSONCPP_VERSION_PATCH 0
 #define JSONCPP_VERSION_HEXA                                                   \
   ((JSONCPP_VERSION_MAJOR << 24) | (JSONCPP_VERSION_MINOR << 16) |             \
    (JSONCPP_VERSION_PATCH << 8))

--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ project(
   # 3. /CMakeLists.txt
   # 4. /MODULE.bazel
   # IMPORTANT: also update the SOVERSION!!
-  version : '1.9.9',
+  version : '1.10.0',
   default_options : [
     'buildtype=release',
     'cpp_std=c++11',

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -985,6 +985,15 @@ Value& Value::operator[](ArrayIndex index) {
   if (it != value_.map_->end() && (*it).first == key)
     return (*it).second;
 
+  // JSON arrays are dense: materialize any gap between the current size and
+  // `index` with null so that size(), iteration, and serialization stay
+  // consistent. Without this, `arr[5] = x` on an empty array would store a
+  // single element while size() reported 6 and serialization emitted six
+  // (see issue #1611). resize() already grows arrays this same way.
+  for (ArrayIndex i = size(); i < index; ++i)
+    value_.map_->insert(value_.map_->end(),
+                        ObjectValues::value_type(CZString(i), nullSingleton()));
+
   ObjectValues::value_type defaultValue(key, nullSingleton());
   it = value_.map_->insert(it, defaultValue);
   return (*it).second;

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -524,6 +524,35 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, resizePopulatesAllMissingElements) {
     JSONTEST_ASSERT_EQUAL(e, Json::Value{});
 }
 
+JSONTEST_FIXTURE_LOCAL(ValueTest, assignBeyondEndPopulatesGapsWithNull) {
+  // Regression test for #1611: assigning past the end of an array via
+  // operator[] must fill the intervening indices with null, so that size(),
+  // iteration, and serialization all agree (JSON arrays are dense). Before the
+  // fix, `arr[5] = x` stored a single element while size() reported 6 and
+  // serialization emitted six, and range-for visited only the one element.
+  Json::Value arr(Json::arrayValue);
+  arr[5] = "Hello, World!";
+
+  JSONTEST_ASSERT_EQUAL(6u, arr.size());
+  JSONTEST_ASSERT_EQUAL(6, std::distance(arr.begin(), arr.end()));
+  for (Json::ArrayIndex i = 0; i < 5; ++i)
+    JSONTEST_ASSERT_EQUAL(Json::Value{}, arr[i]);
+  JSONTEST_ASSERT_EQUAL("Hello, World!", arr[5].asString());
+
+  // Iteration count matches size() and the dense serialization.
+  Json::ArrayIndex iterated = 0;
+  for (const Json::Value& e : arr) {
+    (void)e;
+    ++iterated;
+  }
+  JSONTEST_ASSERT_EQUAL(6u, iterated);
+
+  Json::StreamWriterBuilder b;
+  b.settings_["indentation"] = "";
+  JSONTEST_ASSERT_EQUAL("[null,null,null,null,null,\"Hello, World!\"]",
+                        Json::writeString(b, arr));
+}
+
 JSONTEST_FIXTURE_LOCAL(ValueTest, getArrayValue) {
   Json::Value array;
   for (Json::ArrayIndex i = 0; i < 5; i++)


### PR DESCRIPTION
Fixes #1611.

## Problem

`Value::operator[](ArrayIndex)` only inserted the requested index, leaving the array internally **sparse** while the rest of the type treats arrays as **dense**:

| Operation | `arr[5] = "Hello, World!"` on an empty array |
|---|---|
| `size()` | `6` (highest index + 1) |
| serialization | `[null,null,null,null,null,"Hello, World!"]` (6 elements) |
| range-for | **1** element (walked the sparse internal map) |

So iteration disagreed with both `size()` and the serialized output. (`operator==` was affected too — two arrays that serialize identically could compare unequal due to differing internal sparseness.)

## Fix

JSON arrays are dense, so `operator[]` now materializes the intervening indices as `null` when assigning beyond the current end — exactly what `resize()` already does when growing. Iteration, `size()`, equality, and serialization now all agree.

The gap entries serialize as `null`, which is the only valid JSON representation (JSON has no `undefined`); this matches JavaScript's `JSON.stringify` behavior for sparse arrays. Verified the output round-trips back to a 6-element array.

## Release / compatibility

This is a **runtime behavior change** for existing valid code (arrays are now dense in memory after a sparse-looking assignment; iteration yields `size()` elements). It is **ABI-compatible** — no signature or layout change — so `SOVERSION` stays at `27`. Because behavior changes, this targets the **1.10.0** minor release rather than a 1.9.x patch; the version is bumped in this PR.

## Tests

- New `ValueTest/assignBeyondEndPopulatesGapsWithNull` asserts `size()`, iteration count, per-element nulls, and the exact dense serialization.
- All 128 unit tests pass; changed files are clang-format clean.