### PR TITLE
fix: bump SOVERSION to 28 for removed std::string_view symbols (#1694)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ project(jsoncpp
         LANGUAGES CXX)
 
 message(STATUS "JsonCpp Version: ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}")
-set(PROJECT_SOVERSION 27)
+set(PROJECT_SOVERSION 28)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/include/PreventInSourceBuilds.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/include/PreventInBuildInstalls.cmake)

--- a/meson.build
+++ b/meson.build
@@ -51,7 +51,7 @@ jsoncpp_lib = library(
     'src/lib_json/json_value.cpp',
     'src/lib_json/json_writer.cpp',
   ]),
-  soversion : 27,
+  soversion : 28,
   install : true,
   include_directories : jsoncpp_include_directories,
   cpp_args: dll_export_flag)


### PR DESCRIPTION
Fixes #1694.

## Problem

The `std::string_view` convenience methods — `Value(std::string_view)`, `getString`, `operator[]`, `get`, `removeMember`, `isMember` — were **exported symbols** in 1.9.7 (declared in `value.h`, defined out-of-line in `value.cpp`). After 1.9.7 the #1661/#1675 ABI-mismatch fixes made them header-only **`inline`**, which removed those symbols from the shared library while **SOVERSION stayed at 27**.

Verified on master (shared lib, C++17): `Value::removeMember(std::string_view)` is no longer exported, while the `const char*` / `const String&` overloads still are.

Removing exported symbols is an incompatible ABI change. Because the SONAME stayed `libjsoncpp.so.27`, a binary linked against 1.9.7's `.so.27` (e.g. the reporter's system `cmake` / NFS Ganesha) fails at load with `undefined symbol: _ZN4Json5Value12removeMemberESt17basic_string_view...` against a later build of `.so.27`.

## Fix

Bump `PROJECT_SOVERSION` / meson `soversion` **27 → 28**. The changed ABI now gets a distinct SONAME (`.so.28`), so affected consumers get a clean "can't find `.so.27`" (rebuild required) instead of a symbol-lookup crash. Rebuilt against 1.10.0 they use the inline methods — no symbol dependency.

The removed symbols are **intentionally not restored**: an exported `std::string_view` symbol's *presence* depends on whether the library was compiled as C++17, which is exactly the mismatch #1661 fixed.

SOVERSION had been bumped every release through 1.9.7 (24→25→26→27) and then stopped; this realigns it with the ABI that actually shipped.