### PR TITLE
test: make ValueTest/objects float check robust against x87 excess precision

### DIFF
--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -352,7 +352,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, objects) {
 
   const Json::Value* numericFound = object2_.findNumeric("numeric");
   JSONTEST_ASSERT(numericFound != nullptr);
-  JSONTEST_ASSERT_EQUAL(0.12345f, *numericFound);
+  JSONTEST_ASSERT_EQUAL(0.12345f, numericFound->asFloat());
   JSONTEST_ASSERT(object3_.findNumeric("numeric") == nullptr);
 
   const Json::Value* stringFound = object2_.findString("string");


### PR DESCRIPTION
On 32-bit x86 (i586/i686) where GCC defaults to x87 math (`-mfpmath=387`, 80-bit excess precision) and the baseline has no SSE2, `ValueTest/objects` fails:

```
src/test_lib_json/main.cpp(355): 0.12345f == *numericFound
  Expected: 0.12345000356435776
  Actual  : 0.12345
```

The test stores the float literal `0.12345f` into a `Json::Value` (widened to the stored `double`) and then asserts equality against the original `0.12345f`. On x87 the stored value round-trips to the exact double `0.12345` instead of the float-widened `0.12345000356435776`, so the exact `double` comparison fails — even though the library is correct.

This makes the check precision-robust by comparing the stored value narrowed back to `float` via `asFloat()`: both sides collapse to the same `float` on every architecture, so the numeric round-trip is still verified but the test no longer depends on x87 vs IEEE double representation.

Found while building jsoncpp 1.9.8 for openSUSE on the i586 architecture (no SSE2 in the baseline, so `-mfpmath=sse` is not an option).