### PR TITLE
honor length in valueToQuotedString to avoid buffer over-read

### DIFF
--- a/src/lib_json/json_writer.cpp
+++ b/src/lib_json/json_writer.cpp
@@ -216,7 +216,7 @@ static String valueToQuotedStringN(const char* value, size_t length,
     return "";
 
   if (!doesAnyCharRequireEscaping(value, length))
-    return String("\"") + value + "\"";
+    return String("\"") + String(value, length) + "\"";
   // We have to walk value and escape any special characters.
   // Appending to String is not efficient, but this should be rare.
   // (Note: forward slashes are *not* rare, but I am not escaping them.)

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -2850,6 +2850,16 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, writeZeroes) {
   }
 }
 
+// valueToQuotedString(value, length) must quote exactly `length` bytes and not
+// walk off the end of a buffer that is not NUL-terminated at that length.
+JSONTEST_FIXTURE_LOCAL(StreamWriterTest, quotedStringHonorsLength) {
+  // Bytes past position 5 must not leak into the output. Without honoring
+  // length the buffer is treated as a C-string and " world" is appended.
+  JSONTEST_ASSERT_STRING_EQUAL("\"hello\"",
+                               Json::valueToQuotedString("hello world", 5));
+  JSONTEST_ASSERT_STRING_EQUAL("\"\"", Json::valueToQuotedString("abc", 0));
+}
+
 JSONTEST_FIXTURE_LOCAL(StreamWriterTest, unicode) {
   // Create a Json value containing UTF-8 string with some chars that need
   // escape (tab,newline).


### PR DESCRIPTION
the fast path in valueToQuotedStringN appended value as a NUL-terminated C-string, ignoring the length argument, so the public valueToQuotedString(value, length) reads past a buffer that is not NUL-terminated at length; build the quoted result from exactly length bytes instead.