### PR TITLE
fix double-free in CZString copy-assignment operator

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -317,8 +317,11 @@ void Value::CZString::swap(CZString& other) {
 }
 
 Value::CZString& Value::CZString::operator=(const CZString& other) {
-  cstr_ = other.cstr_;
-  index_ = other.index_;
+  // Copy-and-swap so a duplicate-policy buffer is deep-copied and the old one
+  // released once. The prior shallow copy aliased other.cstr_, double-freeing
+  // an owned string and leaking the overwritten one.
+  CZString temp(other);
+  swap(temp);
   return *this;
 }
 

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -208,6 +208,19 @@ void ValueTest::runCZStringTests() {
   // This verifies we don't leak "other" (if fixed) and correctly take "param"
   str5 = std::move(str3);
   JSONTEST_ASSERT_STRING_EQUAL(str5.data(), "param");
+
+  // 7. Copy Assignment (String)
+  // Copy-assign one owning string over another. The source must remain valid
+  // (deep copy) and the destination's old buffer must be released once, with no
+  // double free of the shared buffer at scope exit.
+  Json::Value::CZString str6("alpha", 5,
+                             Json::Value::CZString::duplicateOnCopy);
+  Json::Value::CZString str7((str6)); // owning "alpha"
+  Json::Value::CZString str8("beta", 4, Json::Value::CZString::duplicateOnCopy);
+  Json::Value::CZString str9((str8)); // owning "beta"
+  str9 = str7;
+  JSONTEST_ASSERT_STRING_EQUAL(str9.data(), "alpha");
+  JSONTEST_ASSERT_STRING_EQUAL(str7.data(), "alpha");
 }
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, CZStringCoverage) { runCZStringTests(); }


### PR DESCRIPTION
CZString is the key type behind Json::Value's object and array maps, and a key that owns its buffer (the duplicate policy) frees that buffer in its destructor. The copy-assignment operator only shallow-copied cstr_ and the packed index_/policy word, so after `a = b` both keys pointed at b's allocation while a's old buffer was never released. On scope exit both destructors free the same pointer, which AddressSanitizer reports as a double free, and the overwritten buffer leaks. I ran into it while filling out the CZString assignment coverage from #1654, which exercised the copy and move constructors and the move-assignment but not this operator. The move-assignment already releases then transfers correctly, so I made copy-assignment do the safe thing with copy-and-swap: the temporary deep-copies the source and takes our old buffer to be freed exactly once. Added the missing case to runCZStringTests, which double-frees under ASan before the change and passes after.