### PR TITLE
ci(zizmor): run the push scan on master (default branch), not the non-existent main

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: GitHub Actions Security Analysis (zizmor)
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   pull_request:
     branches: ["**"]
 


### PR DESCRIPTION
## What this fixes

`.github/workflows/zizmor.yml` runs the security scanner on `push` to `main`:

```yaml
on:
  push:
    branches: ["main"]
```

But this repo's default branch is **`master`** — there is no `main` branch (`gh api .../branches/main` → 404). So the push half of the scan never fires on the default branch, and the `security-events: write` code-scanning baseline it would populate is never established. Only PRs are covered (via the `pull_request: ["**"]` trigger).

This one-line change points the push trigger at `master` so the scan runs on the default branch as intended.

---

*Disclosure: I used an AI tool to help spot this; I verified the default branch and the missing `main` against the repo myself and take responsibility for it.*
