### PR TITLE
ci(meson): switch coverage upload to official coverallsapp action

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -68,5 +68,9 @@ jobs:
       - name: generate code coverage report
         uses: threeal/gcovr-action@v1.0.0
         with:
-          coveralls-send: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          coveralls-out: coveralls.json
+
+      - name: upload code coverage to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coveralls.json

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -71,6 +71,6 @@ jobs:
           coveralls-out: coveralls.json
 
       - name: upload code coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
         with:
           file: coveralls.json


### PR DESCRIPTION
Fixes the meson coverage job failure caused by an HTTP 400 response from Coveralls due to invalid service_name formatting in gcovr-action. Switches the workflow to generate a local coveralls.json file with gcovr-action and submit it using the official coverallsapp/github-action@v2.