### PR TITLE
fix: make the JSONCPP_USE_SECURE_MEMORY build compile and pass

### DIFF
--- a/include/json/allocator.h
+++ b/include/json/allocator.h
@@ -43,10 +43,9 @@ public:
     // unlike memset.
 #if defined(HAVE_MEMSET_S)
     memset_s(p, n * sizeof(T), 0, n * sizeof(T));
-#elif defined(_WIN32)
-    RtlSecureZeroMemory(p, n * sizeof(T));
 #else
-    std::fill_n(reinterpret_cast<volatile unsigned char*>(p), n, 0);
+    std::fill_n(reinterpret_cast<volatile unsigned char*>(p), n * sizeof(T),
+                static_cast<unsigned char>(0));
 #endif
 
     // free using "global operator delete"

--- a/src/jsontestrunner/main.cpp
+++ b/src/jsontestrunner/main.cpp
@@ -328,7 +328,7 @@ int main(int argc, const char* argv[]) {
       return modern_return_code;
     }
 
-    const std::string filename =
+    const Json::String filename =
         opts.path.substr(opts.path.find_last_of("\\/") + 1);
     const bool should_run_legacy = (filename.rfind("legacy_", 0) == 0);
     if (should_run_legacy) {

--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -324,7 +324,9 @@ Value::CZString& Value::CZString::operator=(const CZString& other) {
 
 Value::CZString& Value::CZString::operator=(CZString&& other) noexcept {
   if (cstr_ && storage_.policy_ == duplicate) {
-    releasePrefixedStringValue(const_cast<char*>(cstr_));
+    // CZString keys come from duplicateStringValue (no length prefix), so
+    // release with the matching non-prefixed variant, as the destructor does.
+    releaseStringValue(const_cast<char*>(cstr_), storage_.length_ + 1U);
   }
   cstr_ = other.cstr_;
   if (other.cstr_) {

--- a/src/test_lib_json/main.cpp
+++ b/src/test_lib_json/main.cpp
@@ -214,8 +214,8 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, CZStringCoverage) { runCZStringTests(); }
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, checkNormalizeFloatingPointStr) {
   struct TestData {
-    std::string in;
-    std::string out;
+    Json::String in;
+    Json::String out;
   } const testData[] = {
       {"0.0", "0.0"},
       {"0e0", "0e0"},
@@ -295,7 +295,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, objects) {
   JSONTEST_ASSERT(foundId != nullptr);
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), *foundId);
 
-  const std::string stringIdKey = "id";
+  const Json::String stringIdKey = "id";
   const Json::Value* stringFoundId = object1_.find(stringIdKey);
   JSONTEST_ASSERT(stringFoundId != nullptr);
   JSONTEST_ASSERT_EQUAL(Json::Value(1234), *stringFoundId);
@@ -305,7 +305,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, objects) {
       object1_.find(unknownIdKey, unknownIdKey + strlen(unknownIdKey));
   JSONTEST_ASSERT_EQUAL(nullptr, foundUnknownId);
 
-  const std::string stringUnknownIdKey = "unknown id";
+  const Json::String stringUnknownIdKey = "unknown id";
   const Json::Value* stringFoundUnknownId = object1_.find(stringUnknownIdKey);
   JSONTEST_ASSERT_EQUAL(nullptr, stringFoundUnknownId);
 
@@ -357,7 +357,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, objects) {
 
   const Json::Value* stringFound = object2_.findString("string");
   JSONTEST_ASSERT(stringFound != nullptr);
-  JSONTEST_ASSERT_EQUAL(std::string{"string"}, *stringFound);
+  JSONTEST_ASSERT_EQUAL(Json::String{"string"}, *stringFound);
   JSONTEST_ASSERT(object3_.findString("string") == nullptr);
 
   const Json::Value* arrayFound = object2_.findArray("array");
@@ -2027,9 +2027,9 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, StaticString) {
 
 JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   // https://github.com/open-source-parsers/jsoncpp/issues/756
-  const std::string uni =
+  const Json::String uni =
       reinterpret_cast<const char*>(u8"\u5f0f\uff0c\u8fdb"); // "式，进"
-  std::string styled;
+  Json::String styled;
   {
     Json::Value v;
     v["abc"] = uni;
@@ -2038,7 +2038,7 @@ JSONTEST_FIXTURE_LOCAL(ValueTest, WideString) {
   Json::Value root;
   {
     JSONCPP_STRING errs;
-    std::istringstream iss(styled);
+    Json::IStringStream iss(styled);
     bool ok = parseFromStream(Json::CharReaderBuilder(), iss, &root, &errs);
     JSONTEST_ASSERT(ok);
     if (!ok) {
@@ -2893,7 +2893,7 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, unicode) {
 JSONTEST_FIXTURE_LOCAL(StreamWriterTest, escapeControlCharacters) {
   auto uEscape = [](unsigned ch) {
     static const char h[] = "0123456789abcdef";
-    std::string r = "\\u";
+    Json::String r = "\\u";
     r += h[(ch >> (3 * 4)) & 0xf];
     r += h[(ch >> (2 * 4)) & 0xf];
     r += h[(ch >> (1 * 4)) & 0xf];
@@ -2930,8 +2930,8 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, escapeControlCharacters) {
       if (!emitUTF8 && i >= 0x80)
         break; // The algorithm would try to parse UTF-8, so stop here.
 
-      std::string raw({static_cast<char>(i)});
-      std::string esc = raw;
+      Json::String raw({static_cast<char>(i)});
+      Json::String esc = raw;
       if (i < 0x20)
         esc = uEscape(i);
       if (const char* shEsc = shortEscape(i))
@@ -2943,7 +2943,7 @@ JSONTEST_FIXTURE_LOCAL(StreamWriterTest, escapeControlCharacters) {
       Json::Value root;
       root["test"] = raw;
       JSONTEST_ASSERT_STRING_EQUAL(
-          std::string("{\n\t\"test\" : \"").append(esc).append("\"\n}"),
+          Json::String("{\n\t\"test\" : \"").append(esc).append("\"\n}"),
           Json::writeString(b, root))
           << ", emit=" << emitUTF8 << ", i=" << i << ", raw=\"" << raw << "\""
           << ", esc=\"" << esc << "\"";
@@ -3017,7 +3017,7 @@ struct ReaderTest : JsonTest::TestCase {
   template <typename Input>
   void checkParse(Input&& input,
                   const std::vector<Json::Reader::StructuredError>& structured,
-                  const std::string& formatted) {
+                  const Json::String& formatted) {
     checkParse(input, structured);
     JSONTEST_ASSERT_EQUAL(formatted, reader->getFormattedErrorMessages());
   }
@@ -3763,7 +3763,7 @@ struct CharReaderAllowDropNullTest : JsonTest::TestCase {
     return [=](const Value& root) { JSONTEST_ASSERT_EQUAL(root, v); };
   }
 
-  static ValueCheck objGetAnd(std::string idx, ValueCheck f) {
+  static ValueCheck objGetAnd(Json::String idx, ValueCheck f) {
     return [=](const Value& root) { f(root.get(idx, true)); };
   }
 
@@ -4087,16 +4087,16 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, members) {
   j["k1"] = "a";
   j["k2"] = "b";
 
-  std::vector<std::string> keys;
-  std::vector<std::string> values;
+  std::vector<Json::String> keys;
+  std::vector<Json::String> values;
 
   for (const auto& member : j.members()) {
     keys.push_back(member.name);
     values.push_back(member.value.asString());
   }
 
-  JSONTEST_ASSERT((keys == std::vector<std::string>{"k1", "k2"}));
-  JSONTEST_ASSERT((values == std::vector<std::string>{"a", "b"}));
+  JSONTEST_ASSERT((keys == std::vector<Json::String>{"k1", "k2"}));
+  JSONTEST_ASSERT((values == std::vector<Json::String>{"a", "b"}));
 
   // Test modification through value reference
   for (const auto& member : j.members()) {
@@ -4115,8 +4115,8 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, members) {
     values.push_back(member.value.asString());
   }
 
-  JSONTEST_ASSERT((keys == std::vector<std::string>{"k1", "k2"}));
-  JSONTEST_ASSERT((values == std::vector<std::string>{"c", "c"}));
+  JSONTEST_ASSERT((keys == std::vector<Json::String>{"k1", "k2"}));
+  JSONTEST_ASSERT((values == std::vector<Json::String>{"c", "c"}));
 
 #if __cplusplus >= 201703L
   keys.clear();
@@ -4125,8 +4125,8 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, members) {
     keys.push_back(k);
     values.push_back(v.asString());
   }
-  JSONTEST_ASSERT((keys == std::vector<std::string>{"k1", "k2"}));
-  JSONTEST_ASSERT((values == std::vector<std::string>{"c", "c"}));
+  JSONTEST_ASSERT((keys == std::vector<Json::String>{"k1", "k2"}));
+  JSONTEST_ASSERT((values == std::vector<Json::String>{"c", "c"}));
 #endif
 }
 
@@ -4143,25 +4143,25 @@ JSONTEST_FIXTURE_LOCAL(IteratorTest, decrement) {
   Json::Value json;
   json["k1"] = "a";
   json["k2"] = "b";
-  std::vector<std::string> values;
+  std::vector<Json::String> values;
   for (auto it = json.end(); it != json.begin();) {
     --it;
     values.push_back(it->asString());
   }
-  JSONTEST_ASSERT((values == std::vector<std::string>{"b", "a"}));
+  JSONTEST_ASSERT((values == std::vector<Json::String>{"b", "a"}));
 }
 
 JSONTEST_FIXTURE_LOCAL(IteratorTest, reverseIterator) {
   Json::Value json;
   json["k1"] = "a";
   json["k2"] = "b";
-  std::vector<std::string> values;
+  std::vector<Json::String> values;
   using Iter = decltype(json.begin());
   auto re = std::reverse_iterator<Iter>(json.begin());
   for (auto it = std::reverse_iterator<Iter>(json.end()); it != re; ++it) {
     values.push_back(it->asString());
   }
-  JSONTEST_ASSERT((values == std::vector<std::string>{"b", "a"}));
+  JSONTEST_ASSERT((values == std::vector<Json::String>{"b", "a"}));
 }
 
 JSONTEST_FIXTURE_LOCAL(IteratorTest, distance) {


### PR DESCRIPTION
`JSONCPP_USE_SECURE_MEMORY=1` does not build. It fails in three separate ways, each hidden behind the previous one, so fixing only the first gets you to the second. No CI job builds this configuration, which is how they accumulated.

**Reproduce on master (`60de77f`), MSVC 19.44 x64:**

```
cmake -S . -B sb -A x64 -DCMAKE_CXX_FLAGS="/DJSONCPP_USE_SECURE_MEMORY=1 /std:c++17"
cmake --build sb --config Debug
```

```
include\json\allocator.h(47,5): error C3861: 'RtlSecureZeroMemory': identifier not found
```

**1. The `_WIN32` branch calls `RtlSecureZeroMemory` without including `<windows.h>`.** Removing that branch lets the portable `volatile std::fill_n` path handle Windows too. The same fill was zeroing `n` bytes rather than `n * sizeof(T)`; `Json::String` is `SecureAllocator<char>` so it is unaffected, but any wider `T` through the public `Json::Allocator<T>` alias was leaving most of the allocation un-wiped.

**2. `jsontestrunner` declares a `std::string` where the surrounding code uses `Json::String`.** Identical types in default builds, different under secure memory, so the runner does not compile. One line.

**3. `CZString`'s move-assignment releases a key with `releasePrefixedStringValue`, but `CZString` keys come from `duplicateStringValue` and carry no length prefix.** The destructor already uses the matching `releaseStringValue`. Under the default allocator the mismatch is survivable; under `SecureAllocator` the suite segfaults. This is the one that only appears after the first two are fixed.

**Verification.** Before: `error C3861`. With only 1 and 2 fixed: builds, then `jsoncpp_test (SEGFAULT)`. With all three: secure build compiles and 3/3 ctest suites pass. The default build is unaffected and also 3/3.

Fixes #1399, which reported both the portability problem and that "the unit tests won't build".
